### PR TITLE
Admins can now edit a user's tangible time

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -195,6 +195,7 @@ const userProfileController = function (UserProfile) {
       record.weeklySummaries = req.body.weeklySummaries;
       record.weeklySummariesCount = req.body.weeklySummariesCount;
       record.mediaUrl = req.body.mediaUrl;
+      record.totalTangibleHrs = req.body.totalTangibleHrs;
 
       if (isRequestorAdmin) {
         record.role = req.body.role;


### PR DESCRIPTION
Backed component of fixing low severity issue 2a and 2b:

> Should show total tangible hours the volunteer has contributed - currently not showing anything
Should be editable by an Admin

Summary: 
- When editing a user profile, changes to totalTangibleHours are now recorded.