### PR TITLE
Weekly summary report feature parity

### DIFF
--- a/src/cronjobs/userProfileJobs.js
+++ b/src/cronjobs/userProfileJobs.js
@@ -3,7 +3,6 @@ import { CronJob } from 'cron';
 const userhelper = require('../helpers/userhelper')();
 
 const userProfileScheduledJobs = function () {
-
   const updateUserStatusToActive = new CronJob(
     '1 0 * * *', // Run this every day, 1 minute after mimdnight (PST).
     userhelper.reActivateUser,

--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -25,6 +25,7 @@ const reporthelper = function () {
       $project: {
         firstName: 1,
         lastName: 1,
+        email: 1,
         mediaUrl: 1,
         weeklySummaries: {
           $filter: {

--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -27,6 +27,7 @@ const reporthelper = function () {
         lastName: 1,
         email: 1,
         mediaUrl: 1,
+        weeklyComittedHours: 1,
         weeklySummaries: {
           $filter: {
             input: '$weeklySummaries',

--- a/src/helpers/userhelper.js
+++ b/src/helpers/userhelper.js
@@ -104,10 +104,10 @@ const userhelper = function () {
 
         results.forEach((result) => {
           const {
-            firstName, lastName, email, weeklySummaries, mediaUrl, weeklySummariesCount,
+            firstName, lastName, email, weeklySummaries, mediaUrl, weeklySummariesCount, weeklyComittedHours
           } = result;
 
-          if(email !== undefined && email !== null) {
+          if (email !== undefined && email !== null) {
             emails.push(email);
           }
 
@@ -119,24 +119,25 @@ const userhelper = function () {
             const { dueDate, summary } = weeklySummaries[0];
             if (summary) {
               weeklySummaryMessage = `<p><b>Weekly Summary</b> (for the week ending on ${moment(dueDate).tz('America/Los_Angeles').format('YYYY-MM-DD')}):</p>
-                                        <div style="padding: 0 20px;">${summary}</div>`;
+                                        <div style="padding: 0 20px;">${summary || '<span style="color: red;">Not provided!</span>'}</div>`;
             }
           }
 
           emailBody += `\n
           <div style="padding: 20px 0; margin-top: 5px; border-bottom: 1px solid #828282;">
           <b>Name:</b> ${firstName} ${lastName}
-          <p><b>Media URL:</b> ${mediaUrlLink}</p>
-          <p><b>Total Valid Weekly Summaries:</b> ${totalValidWeeklySummaries}</p>
+          <p><b>Media URL:</b> ${mediaUrlLink || '<span style="color: red;">Not provided!</span>'}</p>
+          <p><b>Total Valid Weekly Summaries:</b> ${totalValidWeeklySummaries || 'No valid submissions yet!'}</p>
+          <p><b>Committed weekly hours</b>: ${weeklyComittedHours}</p>
           ${weeklySummaryMessage}
           </div>`;
         });
 
-        //Necessary because our version of node is outdated
-        //and doesn't have String.prototype.replaceAll
+        // Necessary because our version of node is outdated
+        // and doesn't have String.prototype.replaceAll
         let emailString = [...(new Set(emails))].toString();
-        while(emailString.includes(',')) emailString = emailString.replace(',', '\n');
-        while(emailString.includes('\n')) emailString = emailString.replace('\n', ', ');
+        while (emailString.includes(',')) emailString = emailString.replace(',', '\n');
+        while (emailString.includes('\n')) emailString = emailString.replace('\n', ', ');
 
         emailBody += `\n
           <div>
@@ -145,7 +146,7 @@ const userhelper = function () {
               ${emailString}
             </p>
           </div>
-        `
+        `;
 
         if (process.env.sendEmail) {
           emailSender(

--- a/src/helpers/userhelper.js
+++ b/src/helpers/userhelper.js
@@ -104,7 +104,7 @@ const userhelper = function () {
 
         results.forEach((result) => {
           const {
-            firstName, lastName, email, weeklySummaries, mediaUrl, weeklySummariesCount, weeklyComittedHours
+            firstName, lastName, email, weeklySummaries, mediaUrl, weeklySummariesCount, weeklyComittedHours,
           } = result;
 
           if (email !== undefined && email !== null) {

--- a/src/helpers/userhelper.js
+++ b/src/helpers/userhelper.js
@@ -94,6 +94,8 @@ const userhelper = function () {
 
     weekIndex = (weekIndex !== null) ? weekIndex : 1;
 
+    const emails = [];
+
     reporthelper
       .weeklySummaries(weekIndex, weekIndex)
       .then((results) => {
@@ -102,8 +104,12 @@ const userhelper = function () {
 
         results.forEach((result) => {
           const {
-            firstName, lastName, weeklySummaries, mediaUrl, weeklySummariesCount,
+            firstName, lastName, email, weeklySummaries, mediaUrl, weeklySummariesCount,
           } = result;
+
+          if(email !== undefined && email !== null) {
+            emails.push(email);
+          }
 
           const mediaUrlLink = mediaUrl ? `<a href="${mediaUrl}">${mediaUrl}</a>` : 'Not provided!';
           const totalValidWeeklySummaries = weeklySummariesCount || 'No valid submissions yet!';
@@ -125,6 +131,22 @@ const userhelper = function () {
           ${weeklySummaryMessage}
           </div>`;
         });
+
+        //Necessary because our version of node is outdated
+        //and doesn't have String.prototype.replaceAll
+        let emailString = [...(new Set(emails))].toString();
+        while(emailString.includes(',')) emailString = emailString.replace(',', '\n');
+        while(emailString.includes('\n')) emailString = emailString.replace('\n', ', ');
+
+        emailBody += `\n
+          <div>
+            <h3>Emails</h3>
+            <p>
+              ${emailString}
+            </p>
+          </div>
+        `
+
         if (process.env.sendEmail) {
           emailSender(
             'onecommunityglobal@gmail.com',


### PR DESCRIPTION
- The list of active volunteers' emails now appears at the bottom of emailed weekly summary reports as requested

- The information contained in the PDF and in-browser versions of weekly summary reports is now included in the email variant as well 

- Currently, the server doesn't provide the client with access to the emails associated with weekly summaries preventing the report generation feature from working properly. This is now fixed.

- The weekly committed hours associated with each weekly summary is now sent to the client when requesting weekly summary data