### PR TITLE
Category rename

### DIFF
--- a/src/cronjobs/userProfileJobs.js
+++ b/src/cronjobs/userProfileJobs.js
@@ -3,7 +3,6 @@ import { CronJob } from 'cron';
 const userhelper = require('../helpers/userhelper')();
 
 const userProfileScheduledJobs = function () {
-
   const updateUserStatusToActive = new CronJob(
     '1 0 * * *', // Run this every day, 1 minute after mimdnight (PST).
     userhelper.reActivateUser,

--- a/src/models/badge.js
+++ b/src/models/badge.js
@@ -10,7 +10,9 @@ const Badge = new Schema({
   months: { type: Number },
   totalHrs: { type: Number },
   people: { type: Number },
-  category: { type: String, enum: ['Food', 'Energy', 'Housing', 'Education', 'Society', 'Economics', 'Stewardship', 'Other', 'Unspecified'], default: 'Other' },
+  category: {
+    type: String,
+    enum: ['Food', 'Energy', 'Housing', 'Education', 'Society', 'Economics', 'Stewardship', 'Unassigned', 'Other', 'Unspecified'], default: 'Unassigned' }, //"Other" kept for legacy reasons
   project: { type: Schema.Types.ObjectId, ref: 'project' },
   imageUrl: { type: String },
   ranking: { type: Number },

--- a/src/models/badge.js
+++ b/src/models/badge.js
@@ -12,7 +12,9 @@ const Badge = new Schema({
   people: { type: Number },
   category: {
     type: String,
-    enum: ['Food', 'Energy', 'Housing', 'Education', 'Society', 'Economics', 'Stewardship', 'Unassigned', 'Other', 'Unspecified'], default: 'Unassigned' }, //"Other" kept for legacy reasons
+    enum: ['Food', 'Energy', 'Housing', 'Education', 'Society', 'Economics', 'Stewardship', 'Unassigned', 'Other', 'Unspecified'],
+    default: 'Unassigned',
+  }, // "Other" kept for legacy reasons
   project: { type: Schema.Types.ObjectId, ref: 'project' },
   imageUrl: { type: String },
   ranking: { type: Number },


### PR DESCRIPTION
Changes the name of the "Other" badge category to "Unassigned"

Requires this front-end PR: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/200

> Chris, can we change the “other” in this list to “Unassigned” please