### PR TITLE
Made it obvious on weekly summary reports when someone who didn't sub…

### DIFF
--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -28,6 +28,7 @@ const reporthelper = function () {
         email: 1,
         mediaUrl: 1,
         weeklyComittedHours: 1,
+        weeklySummaryNotReq: 1,
         weeklySummaries: {
           $filter: {
             input: '$weeklySummaries',

--- a/src/helpers/userhelper.js
+++ b/src/helpers/userhelper.js
@@ -99,8 +99,12 @@ const userhelper = function () {
     reporthelper
       .weeklySummaries(weekIndex, weekIndex)
       .then((results) => {
+
         let emailBody = '<h2>Weekly Summaries for all active users:</h2>';
-        const weeklySummaryNotProvidedMessage = '<div><b>Weekly Summary:</b> Not provided!</div>';
+
+        const weeklySummaryNotProvidedMessage = '<div><b>Weekly Summary:</b> <span style="color: red;"> Not provided! </span> </div>';
+
+        const weeklySummaryNotRequiredMessage = '<div><b>Weekly Summary:</b> <span style="color: magenta;"> Not required for this user </span></div>';
 
         results.forEach((result) => {
           const {
@@ -112,14 +116,19 @@ const userhelper = function () {
           }
 
           const mediaUrlLink = mediaUrl ? `<a href="${mediaUrl}">${mediaUrl}</a>` : 'Not provided!';
+
           const totalValidWeeklySummaries = weeklySummariesCount || 'No valid submissions yet!';
+
           let weeklySummaryMessage = weeklySummaryNotProvidedMessage;
+          
           // weeklySummaries array should only have one item if any, hence weeklySummaries[0] needs be used to access it.
-          if (Array.isArray(weeklySummaries) && weeklySummaries.length && weeklySummaries[0]) {
+          if (Array.isArray(weeklySummaries) && weeklySummaries[0]) {
             const { dueDate, summary } = weeklySummaries[0];
             if (summary) {
-              weeklySummaryMessage = `<p><b>Weekly Summary</b> (for the week ending on ${moment(dueDate).tz('America/Los_Angeles').format('YYYY-MM-DD')}):</p>
-                                        <div style="padding: 0 20px;">${summary || '<span style="color: red;">Not provided!</span>'}</div>`;
+              weeklySummaryMessage = `<div><b>Weekly Summary</b> (for the week ending on <b>${moment(dueDate).tz('America/Los_Angeles').format('YYYY-MMM-DD')}</b>):</div>
+                                      <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}">${summary}</div>`;
+            } else if (result.weeklySummaryNotReq === true) {
+              weeklySummaryMessage = weeklySummaryNotRequiredMessage;
             }
           }
 


### PR DESCRIPTION
Corresponding client-side PR: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/221

Solves issue:
 
> Chris added a no-summary-needed function at Profile → Volunteering Times (see below). We need some sort of indicator on the weekly summary reports (emailed, PDFd, and Web-based) that shows when an individual is part of the small group of consultants that don’t need to submit one. Maybe just “Weekly Summary Not Required” in Green, Orange, or Fuschia). This is important so that I’m always remembering each week during my work reviews who the people are that are mentoring and not submitting summaries

## Image Preview

![https://i.imgur.com/LIkpN5g.png](https://i.imgur.com/LIkpN5g.png)

![https://i.imgur.com/QuzDq3v.png](https://i.imgur.com/QuzDq3v.png)