### PR TITLE
Fixed a bug where the leaderboard displays incorrect values

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -98,8 +98,8 @@ const timeEntrycontroller = function (TimeEntry) {
         const requestor = await userProfile.findById(req.body.requestor.requestorId);
         requestor.timeEntryEditHistory.push({
           date: moment().tz('America/Los_Angeles').toDate(),
-          initialSeconds: initialSeconds,
-          newSeconds: totalSeconds
+          initialSeconds,
+          newSeconds: totalSeconds,
         });
 
         // Issue infraction if edit history contains more than 5 edits in the last year

--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -11,11 +11,10 @@ const dashboardhelper = function () {
   };
 
   const getOrgData = async function () {
-
     const pdtstart = moment().tz('America/Los_Angeles').startOf('week').format('YYYY-MM-DD');
     const pdtend = moment().tz('America/Los_Angeles').endOf('week').format('YYYY-MM-DD');
-    
-    const output =  await userProfile.aggregate([
+
+    const output = await userProfile.aggregate([
       {
         $match: {
           isActive: true,
@@ -108,7 +107,7 @@ const dashboardhelper = function () {
       {
         $project: {
           _id: 0,
-          member_count: '$member_count',
+          memberCount: '$member_count',
           totalWeeklyComittedHours: '$totalWeeklyComittedHours',
           totaltime_hrs: {
             $divide: ['$totalSeconds', 3600],
@@ -130,20 +129,22 @@ const dashboardhelper = function () {
           },
         },
       },
-    ])
-    
+    ]);
+
     // This is a temporary band aid. I can't figure out why, but intangible time entries
     // somehow increment the total weekly committed hours across all users. ???
-    const USERS = await userProfile.find({isActive: true});
+    const USERS = await userProfile.find({ isActive: true });
     let TOTAL_COMMITED_HOURS = 0;
+    let MEMBER_COUNT = 0;
     USERS.forEach((user) => {
       TOTAL_COMMITED_HOURS += user.weeklyComittedHours;
+      MEMBER_COUNT += 1;
     });
 
     output[0].totalWeeklyComittedHours = TOTAL_COMMITED_HOURS;
+    output[0].memberCount = MEMBER_COUNT;
 
     return output;
-
   };
 
   const getLeaderboard = function (userId) {

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -81,8 +81,8 @@ const userProfileSchema = new Schema({
   savedTangibleHrs: [Number],
   timeEntryEditHistory: [{
     date: { type: Date, required: true, default: moment().tz('America/Los_Angeles').toDate() },
-    initialSeconds: { type: Number, required: true},
-    newSeconds: {type: Number, required: true}
+    initialSeconds: { type: Number, required: true },
+    newSeconds: { type: Number, required: true },
   }],
   weeklySummaryNotReq: { type: Boolean, default: false },
 });


### PR DESCRIPTION
Fixes issue: 

> Jae: Dashboard → Leaderboard → Looking at the HGN Totals (see below)
This is not totalling the amount of committed time (1925.8 in the pic below) correctly. This total should be a sum of all active members’ weekly “tangible time” committed. 
Jae 8/20: I found part of the problem here, maybe all of it. Every time I add intangible time it increases the logged time (190.57 in the pic below) by the same amount and the total time (1925.8 in the pic below) by 10x whatever the intangible time added was - intangible time shouldn’t count at all into either of these numbers. 
E.g. I logged 2 hrs intangible time and the numbers on the right went from 254.33 of 2473.2 to 256.33 of 2493.2 (Cameron: PR #224)