### PR TITLE
Improved weekly summaries reports

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -98,8 +98,8 @@ const timeEntrycontroller = function (TimeEntry) {
         const requestor = await userProfile.findById(req.body.requestor.requestorId);
         requestor.timeEntryEditHistory.push({
           date: moment().tz('America/Los_Angeles').toDate(),
-          initialSeconds: initialSeconds,
-          newSeconds: totalSeconds
+          initialSeconds,
+          newSeconds: totalSeconds,
         });
 
         // Issue infraction if edit history contains more than 5 edits in the last year

--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -42,10 +42,10 @@ const reporthelper = function () {
                 },
                 {
                   $lte: ['$$timeEntry.createdDateTime', toDate],
-                }
-              ]  
+                },
+              ],
             },
-          }
+          },
         },
         firstName: 1,
         lastName: 1,
@@ -73,13 +73,13 @@ const reporthelper = function () {
     {
       $addFields: {
         totalSeconds: {
-          $sum: '$timeEntries.totalSeconds'
-        }
-      }
+          $sum: '$timeEntries.totalSeconds',
+        },
+      },
     },
     {
-      $unset: 'timeEntries'
-    }
+      $unset: 'timeEntries',
+    },
     ]);
   };
 

--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -22,7 +22,31 @@ const reporthelper = function () {
       },
     },
     {
+      $lookup: {
+        from: 'timeEntries',
+        localField: '_id',
+        foreignField: 'personId',
+        as: 'timeEntries',
+      },
+    },
+    {
       $project: {
+        timeEntries: {
+          $filter: {
+            input: '$timeEntries',
+            as: 'timeEntry',
+            cond: {
+              $and: [
+                {
+                  $gte: ['$$timeEntry.createdDateTime', fromDate],
+                },
+                {
+                  $lte: ['$$timeEntry.createdDateTime', toDate],
+                }
+              ]  
+            },
+          }
+        },
         firstName: 1,
         lastName: 1,
         email: 1,
@@ -46,6 +70,16 @@ const reporthelper = function () {
         weeklySummariesCount: 1,
       },
     },
+    {
+      $addFields: {
+        totalSeconds: {
+          $sum: '$timeEntries.totalSeconds'
+        }
+      }
+    },
+    {
+      $unset: 'timeEntries'
+    }
     ]);
   };
 

--- a/src/helpers/userhelper.js
+++ b/src/helpers/userhelper.js
@@ -114,7 +114,7 @@ const userhelper = function () {
             emails.push(email);
           }
 
-          const hoursLogged = (summary.totalSeconds / 3600 || 0);
+          const hoursLogged = (result.totalSeconds / 3600 || 0);
 
           const mediaUrlLink = mediaUrl ? `<a href="${mediaUrl}">${mediaUrl}</a>` : 'Not provided!';
           let weeklySummaryMessage = weeklySummaryNotProvidedMessage;
@@ -132,17 +132,15 @@ const userhelper = function () {
           <b>Name:</b> ${firstName} ${lastName}
           <p><b>Media URL:</b> ${mediaUrlLink || '<span style="color: red;">Not provided!</span>'}</p>
           ${
-            weeklySummariesCount === 8 ?
-            `<p style="color: blue;"><b>Total Valid Weekly Summaries: ${weeklySummariesCount}</b></p>'`
-            :
-            `<p><b>Total Valid Weekly Summaries</b>: ${weeklySummariesCount || 'No valid submissions yet!'}</p>`
-          }
+  weeklySummariesCount === 8
+    ? `<p style="color: blue;"><b>Total Valid Weekly Summaries: ${weeklySummariesCount}</b></p>'`
+    : `<p><b>Total Valid Weekly Summaries</b>: ${weeklySummariesCount || 'No valid submissions yet!'}</p>`
+}
           ${
-            hoursLogged >= weeklyComittedHours ?
-            `<p><b>Hours logged</b>: ${hoursLogged.toFixed(2)} / ${weeklyComittedHours}</p>`
-            :
-            `<p style="color: red;"><b>Hours logged</b>: ${hoursLogged.toFixed(2)} / ${weeklyComittedHours}</p>`
-          }
+  hoursLogged >= weeklyComittedHours
+    ? `<p><b>Hours logged</b>: ${hoursLogged.toFixed(2)} / ${weeklyComittedHours}</p>`
+    : `<p style="color: red;"><b>Hours logged</b>: ${hoursLogged.toFixed(2)} / ${weeklyComittedHours}</p>`
+}
           ${weeklySummaryMessage}
           </div>`;
         });

--- a/src/helpers/userhelper.js
+++ b/src/helpers/userhelper.js
@@ -99,7 +99,6 @@ const userhelper = function () {
     reporthelper
       .weeklySummaries(weekIndex, weekIndex)
       .then((results) => {
-
         let emailBody = '<h2>Weekly Summaries for all active users:</h2>';
 
         const weeklySummaryNotProvidedMessage = '<div><b>Weekly Summary:</b> <span style="color: red;"> Not provided! </span> </div>';
@@ -123,7 +122,7 @@ const userhelper = function () {
           const mediaUrlLink = mediaUrl ? `<a href="${mediaUrl}">${mediaUrl}</a>` : 'Not provided!';
 
           let weeklySummaryMessage = weeklySummaryNotProvidedMessage;
-          
+
           // weeklySummaries array should only have one item if any, hence weeklySummaries[0] needs be used to access it.
           if (Array.isArray(weeklySummaries) && weeklySummaries[0]) {
             const { dueDate, summary } = weeklySummaries[0];

--- a/src/helpers/userhelper.js
+++ b/src/helpers/userhelper.js
@@ -102,6 +102,9 @@ const userhelper = function () {
         let emailBody = '<h2>Weekly Summaries for all active users:</h2>';
         const weeklySummaryNotProvidedMessage = '<div><b>Weekly Summary:</b> Not provided!</div>';
 
+        results.sort((a, b) => (`${a.firstName} ${a.lastName}`).localeCompare(`${b.firstName} ${b.lastname}`));
+
+
         results.forEach((result) => {
           const {
             firstName, lastName, email, weeklySummaries, mediaUrl, weeklySummariesCount, weeklyComittedHours,
@@ -111,8 +114,9 @@ const userhelper = function () {
             emails.push(email);
           }
 
+          const hoursLogged = (summary.totalSeconds / 3600 || 0);
+
           const mediaUrlLink = mediaUrl ? `<a href="${mediaUrl}">${mediaUrl}</a>` : 'Not provided!';
-          const totalValidWeeklySummaries = weeklySummariesCount || 'No valid submissions yet!';
           let weeklySummaryMessage = weeklySummaryNotProvidedMessage;
           // weeklySummaries array should only have one item if any, hence weeklySummaries[0] needs be used to access it.
           if (Array.isArray(weeklySummaries) && weeklySummaries.length && weeklySummaries[0]) {
@@ -127,8 +131,18 @@ const userhelper = function () {
           <div style="padding: 20px 0; margin-top: 5px; border-bottom: 1px solid #828282;">
           <b>Name:</b> ${firstName} ${lastName}
           <p><b>Media URL:</b> ${mediaUrlLink || '<span style="color: red;">Not provided!</span>'}</p>
-          <p><b>Total Valid Weekly Summaries:</b> ${totalValidWeeklySummaries || 'No valid submissions yet!'}</p>
-          <p><b>Committed weekly hours</b>: ${weeklyComittedHours}</p>
+          ${
+            weeklySummariesCount === 8 ?
+            `<p style="color: blue;"><b>Total Valid Weekly Summaries: ${weeklySummariesCount}</b></p>'`
+            :
+            `<p><b>Total Valid Weekly Summaries</b>: ${weeklySummariesCount || 'No valid submissions yet!'}</p>`
+          }
+          ${
+            hoursLogged >= weeklyComittedHours ?
+            `<p><b>Hours logged</b>: ${hoursLogged.toFixed(2)} / ${weeklyComittedHours}</p>`
+            :
+            `<p style="color: red;"><b>Hours logged</b>: ${hoursLogged.toFixed(2)} / ${weeklyComittedHours}</p>`
+          }
           ${weeklySummaryMessage}
           </div>`;
         });

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -81,8 +81,8 @@ const userProfileSchema = new Schema({
   savedTangibleHrs: [Number],
   timeEntryEditHistory: [{
     date: { type: Date, required: true, default: moment().tz('America/Los_Angeles').toDate() },
-    initialSeconds: { type: Number, required: true},
-    newSeconds: {type: Number, required: true}
+    initialSeconds: { type: Number, required: true },
+    newSeconds: { type: Number, required: true },
   }],
   weeklySummaryNotReq: { type: Boolean, default: false },
 });


### PR DESCRIPTION
# Weekly Summary Reports Improvements

Corresponding front-end PR: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/225

Fixes the following issues:

> Jae: Admin functionality: Reports → Weekly Summaries Report
Please make the number blue and bold when the number of “Total Valid Weekly Summaries:” 

> If logged hours were less than committed, please make that show as red so it is obvious. 

> Jae: Admin functionality: Reports → Emailed Weekly Summaries Report
Please make this look like the online version:
Alphabetized
Please make the number blue and bold when the number of “Total Valid Weekly Summaries:” = 8 (8/15: no current example of this, so couldn’t verify)
If logged hours were less than committed, please make that show as red so it is obvious.


## Preview
![https://i.imgur.com/hVK278W.png](https://i.imgur.com/hVK278W.png)