### PR TITLE
Corrected behavior for editing time entries

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -94,12 +94,12 @@ const timeEntrycontroller = function (TimeEntry) {
       timeEntry.dateOfWork = moment(req.body.dateOfWork).format('YYYY-MM-DD');
 
       // Update edit history
-      if (timeEntry.isTangible && req.body.requestor.requestorId === timeEntry.personId.toString() && req.body.requestor.role !== 'Administrator') {
+      if (initialSeconds !== totalSeconds && timeEntry.isTangible && req.body.requestor.requestorId === timeEntry.personId.toString() && req.body.requestor.role !== 'Administrator') {
         const requestor = await userProfile.findById(req.body.requestor.requestorId);
         requestor.timeEntryEditHistory.push({
           date: moment().tz('America/Los_Angeles').toDate(),
-          initialSeconds: initialSeconds,
-          newSeconds: totalSeconds
+          initialSeconds,
+          newSeconds: totalSeconds,
         });
 
         // Issue infraction if edit history contains more than 5 edits in the last year

--- a/src/helpers/userhelper.js
+++ b/src/helpers/userhelper.js
@@ -99,7 +99,6 @@ const userhelper = function () {
     reporthelper
       .weeklySummaries(weekIndex, weekIndex)
       .then((results) => {
-
         let emailBody = '<h2>Weekly Summaries for all active users:</h2>';
 
         const weeklySummaryNotProvidedMessage = '<div><b>Weekly Summary:</b> <span style="color: red;"> Not provided! </span> </div>';
@@ -120,7 +119,7 @@ const userhelper = function () {
           const totalValidWeeklySummaries = weeklySummariesCount || 'No valid submissions yet!';
 
           let weeklySummaryMessage = weeklySummaryNotProvidedMessage;
-          
+
           // weeklySummaries array should only have one item if any, hence weeklySummaries[0] needs be used to access it.
           if (Array.isArray(weeklySummaries) && weeklySummaries[0]) {
             const { dueDate, summary } = weeklySummaries[0];

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -81,8 +81,8 @@ const userProfileSchema = new Schema({
   savedTangibleHrs: [Number],
   timeEntryEditHistory: [{
     date: { type: Date, required: true, default: moment().tz('America/Los_Angeles').toDate() },
-    initialSeconds: { type: Number, required: true},
-    newSeconds: {type: Number, required: true}
+    initialSeconds: { type: Number, required: true },
+    newSeconds: { type: Number, required: true },
   }],
   weeklySummaryNotReq: { type: Boolean, default: false },
 });


### PR DESCRIPTION
Blue squares can no longer be issued for edits where the time doesn't change