### PR TITLE
Excessive edits email

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -95,7 +95,6 @@ const timeEntrycontroller = function (TimeEntry) {
 
       // Update edit history
       if (initialSeconds !== totalSeconds && timeEntry.isTangible && req.body.requestor.requestorId === timeEntry.personId.toString() && req.body.requestor.role !== 'Administrator') {
-        
         const requestor = await userProfile.findById(req.body.requestor.requestorId);
         requestor.timeEntryEditHistory.push({
           date: moment().tz('America/Los_Angeles').toDate(),
@@ -129,7 +128,7 @@ const timeEntrycontroller = function (TimeEntry) {
           <p>
             This is the ${totalRecentEdits}th edit within the past 365 days.
           </p>
-        `)
+        `);
       }
 
 

--- a/src/utilities/emailSender.js
+++ b/src/utilities/emailSender.js
@@ -3,12 +3,12 @@ const nodemailer = require('nodemailer');
 const logger = require('../startup/logger');
 
 /**
- * 
+ *
  * @param {string} recipient A comma-seperated list of recipients for this email. Examples: 'cow@cow.jp' OR 'cow@cow.jp, cow23@cow.jp'
  * @param {string} subject Email subject
  * @param {string} message HTML formatted email body
- * @param {*} cc 
- * @param {*} bcc 
+ * @param {*} cc
+ * @param {*} bcc
  */
 const emailSender = function (recipient, subject, message, cc = null, bcc = null) {
   nodemailer.createTestAccount(() => {


### PR DESCRIPTION
Related front-end PR: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/242

Fixes issues:

> The popup says 6 or more times gives blue squares (see pic below) and it actually gives them after 5 or more times. See pic below that shows 7 edits and 3 blue squares >> Please update the text to say "5 or more".  >> I also did not get an email notifying me that a blue square was issued for this. I'm guessing they wouldn't have either.
> If they edit the same time repeatedly, it looks like it the warning pops up but it doesn't add the time to their log for me to delete their edits... it DOES still issue them a blue square though for too many edits. And this leaves me with no way to fix this, since I can't see the edits showing up in their editable list for me. 