### PR TITLE
Email notifications are no longer sent for edits to intangible time entries

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -79,7 +79,7 @@ const timeEntrycontroller = function (TimeEntry) {
 
       const totalSeconds = moment.duration(`${hours}:${minutes}`).asSeconds();
 
-      if (totalSeconds !== timeEntry.totalSeconds) {
+      if (timeEntry.isTangible === true && totalSeconds !== timeEntry.totalSeconds) {
         notifyEditByEmail(timeEntry.personId.toString(), timeEntry, totalSeconds, req.body);
       }
 


### PR DESCRIPTION
Fixes issue: 

> Jae: Editing “intangible time” should not generate an email to the Admin that the intangible time was edited. I should only get emails about time changes to “tangible” time.