### PR TITLE
Added the ability to edit the number of tangible hours by category

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -222,6 +222,7 @@ const userProfileController = function (UserProfile) {
         record.categoryTangibleHrs = req.body.categoryTangibleHrs ? req.body.categoryTangibleHrs : record.categoryTangibleHrs;
         record.totalTangibleHrs = req.body.totalTangibleHrs;
         record.timeEntryEditHistory = req.body.timeEntryEditHistory;
+        record.hoursByCategory = req.body.hoursByCategory;
       }
 
       if (infringmentAuthorizers.includes(req.body.requestor.role)) {

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -76,6 +76,14 @@ const userProfileSchema = new Schema({
   collaborationPreference: { type: String },
   personalBestMaxHrs: { type: Number, default: 0 },
   totalTangibleHrs: { type: Number, default: 0 },
+  hoursByCategory: {
+    housing: { type: Number, default: 0 },
+    food: { type: Number, default: 0 },
+    education: { type: Number, default: 0 },
+    society: { type: Number, default: 0 },
+    energy: { type: Number, default: 0 },
+    unassigned: { type: Number, default: 0 }
+  },
   lastWeekTangibleHrs: { type: Number, default: 0 },
   categoryTangibleHrs: [{ category: { type: String, enum: ['Food', 'Energy', 'Housing', 'Education', 'Society', 'Economics', 'Stewardship', 'Other'], default: 'Other' }, hrs: { type: Number, default: 0 } }],
   savedTangibleHrs: [Number],


### PR DESCRIPTION
Fixes issue:
> Jae: Profile → Volunteering Times → “Total Hours” field
Some fields (see below) are not editable
What was “Total Other Category Hours” is missing. Should still be included but as “Total Unassigned Category Hours”
Total Hours This Week should say “Total Tangible Hours This Week” and only show tangible time logged

Admin view:
![https://i.imgur.com/fuoDCOk.png](https://i.imgur.com/fuoDCOk.png)

Normal view:
![https://i.imgur.com/ir8uImb.png](https://i.imgur.com/ir8uImb.png)