### PR TITLE
Fixed weekly summaries

### DIFF
--- a/src/helpers/userhelper.js
+++ b/src/helpers/userhelper.js
@@ -117,7 +117,7 @@ const userhelper = function () {
             emails.push(email);
           }
 
-          const hoursLogged = (result.totalSeconds / 3600 || 0);
+          const hoursLogged = ((result.totalSeconds[weekIndex] || 0) / 3600 || 0);
 
           const mediaUrlLink = mediaUrl ? `<a href="${mediaUrl}">${mediaUrl}</a>` : 'Not provided!';
 


### PR DESCRIPTION
**Due to the nature of the changes in this PR, the corresponding front-end PR (https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/288) needs to be integrated at the same time.**

Fixes issue:
> Jae: Admin User Class: Dashboard → Reports → Weekly Summaries Report → Tangible Hours for the week are wrong for everyone (WIP: Cameron)
Everyone who completed their hours is at least double their actual logged time.  
I see a person who logged zero hours last week showing as having logged 10 too. He was the guy who was supposed to be paused though (see bug #3 above). But one other who was short shows the correct number and another who was short and got a blue square shows what looks like double his actual hours.  
Below is my example. Screenshot below the first one is my actual time worked. Not sure what the correlation between the two is. 
