### PR TITLE
Fixed ordering of Cron Jobs

### DIFF
--- a/src/cronjobs/userProfileJobs.js
+++ b/src/cronjobs/userProfileJobs.js
@@ -3,13 +3,6 @@ import { CronJob } from 'cron';
 const userhelper = require('../helpers/userhelper')();
 
 const userProfileScheduledJobs = function () {
-  const updateUserStatusToActive = new CronJob(
-    '1 0 * * *', // Run this every day, 1 minute after mimdnight (PST).
-    userhelper.reActivateUser,
-    null,
-    false,
-    'America/Los_Angeles',
-  );
 
   const assignBlueSquare = new CronJob(
     '2 0 * * 0', // Every Sunday, 2 minutes past midnight (PST).
@@ -43,12 +36,19 @@ const userProfileScheduledJobs = function () {
     'America/Los_Angeles',
   );
 
+  const updateUserStatusToActive = new CronJob(
+    '20 0 * * *', // Run this every day, 20 minutes after midnight (PST).
+    userhelper.reActivateUser,
+    null,
+    false,
+    'America/Los_Angeles',
+  );
 
   assignBlueSquare.start();
   emailWeeklySummaries.start();
   deleteBlueSquareOlderThanYear.start();
-  updateUserStatusToActive.start();
   awardNewBadges.start();
+  updateUserStatusToActive.start();
 };
 
 module.exports = userProfileScheduledJobs;


### PR DESCRIPTION
Blue squares are now issued for failing to meet the number of weekly committed hours BEFORE inactive users are marked as active. 

Solves issue:
> Jae: Person’s Profile → Basic Information → Pause → Choose Date
I paused someone for the first time last week and had them set to restart today (Sunday). They still received a blue square. My guess as to why is because the blue squares go out at 12:05 AM and the pause turned off right at 12 AM. We don’t want to change the blue squares going out at 12:05 though (ask Chris for why), so can we make the “pause” end at 12:15 AM PDT on whatever day a person is paused to? 
