### PR TITLE
Fixed weekly summary reports

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -133,10 +133,8 @@ const timeEntrycontroller = function (TimeEntry) {
             description: `You edited your time entries ${totalRecentEdits} times within the last 365 days, exceeding the limit of 4 times per year you can edit them without penalty.`,
           };
 
-          // Baindaid until email queue is implemented
-          setTimeout(() => {
-            emailSender(requestor.email, 'You\'ve been issued a blue square for editing your time entry', getInfringmentEmailBody(requestor.firstName, requestor.lastName, emailInfringement, requestor.infringments.length));
-          }, 5000);
+          emailSender(requestor.email, 'You\'ve been issued a blue square for editing your time entry', getInfringmentEmailBody(requestor.firstName, requestor.lastName, emailInfringement, requestor.infringments.length));
+        
         }
 
         await requestor.save();
@@ -225,8 +223,8 @@ const timeEntrycontroller = function (TimeEntry) {
       return;
     }
 
-    const fromdate = moment(req.params.fromdate).format('YYYY-MM-DD');
-    const todate = moment(req.params.todate).format('YYYY-MM-DD');
+    const fromdate = moment(req.params.fromdate).tz('America/Los_Angeles').format('YYYY-MM-DD');
+    const todate = moment(req.params.todate).tz('America/Los_Angeles').format('YYYY-MM-DD');
     const { userId } = req.params;
 
     TimeEntry.find(

--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -3,15 +3,14 @@ const userProfile = require('../models/userProfile');
 
 /**
  *
- * @param {*} date1
- * @param {*} date2
+ * @param {*} dateOfWork
+ * @param {*} pstEnd
  * @returns The absolute value of the difference in weeks between the two input dates.
  */
-const absoluteDifferenceInWeeks = (date1, date2) => {
-  date1 = moment(date1);
-  date2 = moment(date2);
-  const absoluteDifference = Math.abs(date1.diff(date2, 'days'));
-  return Math.floor(absoluteDifference / 7);
+const absoluteDifferenceInWeeks = (dateOfWork, pstEnd) => {
+  dateOfWork = moment(dateOfWork).endOf('week')
+  pstEnd = moment(pstEnd).tz('America/Los_Angeles').endOf('week')
+  return Math.abs(dateOfWork.diff(pstEnd, 'weeks'));
 };
 
 const reporthelper = function () {
@@ -81,19 +80,28 @@ const reporthelper = function () {
           },
         },
         weeklySummariesCount: 1,
+        isTangible: 1,
       },
     },
     ]);
 
     // Logic too difficult to do using aggregation.
     results.forEach((result) => {
+
       result.totalSeconds = [];
 
       result.timeEntries.forEach((entry) => {
+
         const index = absoluteDifferenceInWeeks(entry.dateOfWork, pstEnd);
 
-        if (result.totalSeconds[index] === undefined || result.totalSeconds[index] === null) result.totalSeconds[index] = 0;
-        result.totalSeconds[index] += entry.totalSeconds;
+        if (result.totalSeconds[index] === undefined || result.totalSeconds[index] === null) {
+          result.totalSeconds[index] = 0;
+        }
+
+        if(entry.isTangible === true) {
+          result.totalSeconds[index] += entry.totalSeconds;
+        }
+
       });
 
       delete result.timeEntries;


### PR DESCRIPTION
Fixes issue: 
> The weekly summaries in the app (Reports → Weekly Summaries Report) are now showing total time instead of just tangible too. Below is my example for last week. It should say 32.38 / 40 since I only did 32.38 hours of tangible time. 