### PR TITLE
Added fix for not showing hours logged in Email Summary Report

### DIFF
--- a/src/helpers/userhelper.js
+++ b/src/helpers/userhelper.js
@@ -114,7 +114,10 @@ const userhelper = function () {
           emails.push(email);
         }
 
-        const hoursLogged = ((result.totalSeconds[weekIndex] / 3600) || 0);
+        // weeklySummaries array will have only one item fetched (if present),
+        // consequently totalSeconds array will also have only one item in the array (if present)
+        // hence totalSeconds[0] should be used
+        const hoursLogged = ((result.totalSeconds[0] / 3600) || 0);
 
         const mediaUrlLink = mediaUrl ? `<a href="${mediaUrl}">${mediaUrl}</a>` : 'Not provided!';
 


### PR DESCRIPTION
BUG: Hours Logged not displaying values in Email Summary Report sent to admin during Cron Jobs execution.

Fix: `emailWeeklySummariesForAllUsers` function will now access `totalSeconds[0]` after fetching a single summary instead of `totalSeconds[weekIndex]` where `weekIndex` was set to 1 for getting the details of previous week. 
Since single summary is fetched for all users by: 
`const results = await reporthelper.weeklySummaries(weekIndex, weekIndex);`
Each result in `results` will have only one value in `totalSeconds` field, hence we will fetch `totalSeconds[0]` to get the correct value.