### PR TITLE
unspecified added as categoryTangilbleHrs option

### DIFF
--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -85,7 +85,7 @@ const userProfileSchema = new Schema({
     unassigned: { type: Number, default: 0 },
   },
   lastWeekTangibleHrs: { type: Number, default: 0 },
-  categoryTangibleHrs: [{ category: { type: String, enum: ['Food', 'Energy', 'Housing', 'Education', 'Society', 'Economics', 'Stewardship', 'Other'], default: 'Other' }, hrs: { type: Number, default: 0 } }],
+  categoryTangibleHrs: [{ category: { type: String, enum: ['Food', 'Energy', 'Housing', 'Education', 'Society', 'Economics', 'Stewardship', 'Other', 'Unspecified'], default: 'Other' }, hrs: { type: Number, default: 0 } }],
   savedTangibleHrs: [Number],
   timeEntryEditHistory: [{
     date: { type: Date, required: true, default: moment().tz('America/Los_Angeles').toDate() },


### PR DESCRIPTION
This is the error I was getting when trying to save profiles or delete blue squares:
<img width="1028" alt="Screen Shot 2021-10-02 at 7 57 23 PM" src="https://user-images.githubusercontent.com/82235793/135879556-ddf27113-9583-456d-83ce-6ece6af3818e.png">

This is the project model (included the string "unspecified" as a category option):
<img width="666" alt="Screen Shot 2021-10-02 at 7 57 47 PM" src="https://user-images.githubusercontent.com/82235793/135879567-87a18298-4c89-4b6c-add5-95ca68da63cb.png">

This is the userProfile model (did not include string):
<img width="794" alt="Screen Shot 2021-10-02 at 7 58 01 PM" src="https://user-images.githubusercontent.com/82235793/135879622-bb6ba915-db27-4857-85f3-51abed7bd3c2.png">


