### PR TITLE
Create New User: Indicate email/phone already exists and show warning for duplicate name of new user

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -111,6 +111,7 @@ const userProfileController = function (UserProfile) {
     if (userByEmail) {
       res.status(400).send({
         error: 'That email address is already in use. Please choose another email address.',
+        type: 'email',
       });
       return;
     }
@@ -122,9 +123,15 @@ const userProfileController = function (UserProfile) {
     if (userByPhoneNumber) {
       res.status(400).send({
         error: 'That phone number is already in use. Please choose another number.',
+        type: 'phoneNumber',
       });
       return;
     }
+
+    const userDuplicateName = await UserProfile.findOne({
+      firstName: req.body.firstName,
+      lastName: req.body.lastName
+    });
 
     const up = new UserProfile();
     up.password = req.body.password;
@@ -148,9 +155,17 @@ const userProfileController = function (UserProfile) {
     up.timeZone = req.body.timeZone || 'America/Los_Angeles';
 
     up.save()
-      .then(() => res.status(200).send({
-        _id: up._id,
-      }))
+      .then(() => {
+        if(userDuplicateName){
+          res.status(200).send({
+          warning: 'User with same name exists, new user with duplicate name created.',
+          _id: up._id,
+        });
+        }
+        res.status(200).send({
+            _id: up._id,
+          });
+      })
       .catch(error => res.status(501).send(error));
   };
 


### PR DESCRIPTION
Other Links → User Management → Create New User
- Should give warning if the same name exists. Please make the name duplication allowable, but with a warning.
- Would also like some visible indicator around (or under) the field(s) that need to be changed when a number or email are attempted. Right now a warning comes up in the top right but it will only warn for email if number AND email are duplicates. I’d like all fields that need changing to be indicated with the warning and on/under the field needing to be changed.


**Changelog:**
- If email/phone number already exists: add 'type' key to response object with value 'email'/'phoneNumber'
- If new user is created with duplicate name: add 'warning' key to response object