### PR TITLE
Send Timezone API key based on user class

### DIFF
--- a/src/controllers/timeZoneAPIController.js
+++ b/src/controllers/timeZoneAPIController.js
@@ -1,0 +1,23 @@
+const timeZoneAPIController = function () {
+    const getTimeZoneAPIKey = (req,res) => {
+        const requestorRole = req.body.requestor.role;
+        const PremiumRoles = ['Manager', 'Administrator', 'Core Team'];
+        const isPremiumRequestor = !!((PremiumRoles.includes(requestorRole)));
+        const premiumKey = process.env.TIMEZONE_PREMIUM_KEY;
+        const commonKey = process.env.TIMEZONE_COMMON_KEY;
+        if(!req.body.requestor.role) {
+            res.status(403).send('Unauthorized Request');
+            return;
+        }
+        if (isPremiumRequestor) {
+            res.status(200).send({userAPIKey: premiumKey});
+        }
+        res.status(200).send({userAPIKey: commonKey});
+    }
+
+    return {
+        getTimeZoneAPIKey,
+    };
+};
+
+module.exports = timeZoneAPIController;

--- a/src/routes/timeZoneAPIRoutes.js
+++ b/src/routes/timeZoneAPIRoutes.js
@@ -1,0 +1,14 @@
+const express = require('express');
+
+
+const routes = function () {
+  const controller = require('../controllers/timeZoneAPIController')();
+  const timeZoneAPIRouter = express.Router();
+
+  timeZoneAPIRouter.route('/timezone')
+    .get(controller.getTimeZoneAPIKey);
+
+  return timeZoneAPIRouter;
+};
+
+module.exports = routes;

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -32,6 +32,7 @@ const popupRouter = require('../routes/popupEditorRouter')(popup);
 const popupBackupRouter = require('../routes/popupEditorBackupRouter')(popupBackup);
 const taskNotificationRouter = require('../routes/taskNotificationRouter')(taskNotification);
 const inventoryRouter = require('../routes/inventoryRouter')(inventoryItem, inventoryItemType);
+const timeZoneAPIRouter = require('../routes/timeZoneAPIRoutes')();
 
 module.exports = function (app) {
   app.use('/api', forgotPwdRouter);
@@ -53,4 +54,5 @@ module.exports = function (app) {
   app.use('/api', taskNotificationRouter);
   app.use('/api', badgeRouter);
   app.use('/api', inventoryRouter);
+  app.use('/api', timeZoneAPIRouter);
 };


### PR DESCRIPTION
This PR creates a new route/controller in the app to integrate OpenCage API to fetch the timezone based on the input location provided by the user. 
A new route and controller is added to send protected (currently free) API key to the frontend application. 
Note - currently we are using a freemium account on OpenCageData and have limited number of requests available to us in one single day (2500 API requests per day) which are quite sufficient since this functionality is currently only used in creation of new users form. 