### PR TITLE
fix issue where privacy settings wasn't being cached correctly

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -354,7 +354,7 @@ const userProfileController = function (UserProfile) {
   const getUserById = function (req, res) {
     const userid = req.params.userId;
     if (cache.getCache(`user-${userid}`)) {
-      const getData = cache.getCache(`user-${userid}`);
+      const getData = JSON.parse(cache.getCache(`user-${userid}`));
       res.status(200).send(getData);
       return;
     }
@@ -393,7 +393,7 @@ const userProfileController = function (UserProfile) {
           res.status(400).send({ error: 'This is not a valid user' });
           return;
         }
-        cache.setCache(`user-${userid}`, results);
+        cache.setCache(`user-${userid}`, JSON.stringify(results));
         res.status(200).send(results);
       })
       .catch(error => res.status(404).send(error));

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -62,7 +62,7 @@ const userProfileController = function (UserProfile) {
     }
 
     if (cache.getCache('allusers')) {
-      const getData = cache.getCache('allusers');
+      const getData = JSON.parse(cache.getCache('allusers'));
       res.status(200).send(getData);
       return;
     }
@@ -79,7 +79,7 @@ const userProfileController = function (UserProfile) {
           res.status(500).send({ error: 'User result was invalid' });
           return;
         }
-        cache.setCache('allusers', results);
+        cache.setCache('allusers', JSON.stringify(results));
         res.status(200).send(results);
       })
       .catch(error => res.status(404).send(error));


### PR DESCRIPTION
- Noticed privacySettings and hoursByCategory both weren't caching correctly, according to https://github.com/node-cache/node-cache/issues/77, I think it's because node-cache doesn't pick up nested objects correcly, which those two fields are. 