### PR TITLE
remove duplicate phone limitation and update backend cache when adding and deleting new user

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -190,8 +190,12 @@ const userProfileController = function (UserProfile) {
         res.status(200).send({
           _id: up._id,
         });
+        //remove backend cache
+        cache.removeCache('allusers');
       })
       .catch(error => res.status(501).send(error));
+      
+      
   };
 
   const putUserProfile = function (req, res) {
@@ -314,6 +318,7 @@ const userProfileController = function (UserProfile) {
       return;
     }
     cache.removeCache(`user-${userId}`);
+    cache.removeCache('allusers');
     const user = await UserProfile.findById(userId);
 
     if (!user) {

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -132,17 +132,25 @@ const userProfileController = function (UserProfile) {
       return;
     }
 
-    const userByPhoneNumber = await UserProfile.findOne({
-      phoneNumber: req.body.phoneNumber,
-    });
+    /***
+     *  Turn on and off the duplicate phone number checker by changing
+     *  the value of duplicatePhoneNumberCheck variable.
+     */
+     const duplicatePhoneNumberCheck = false;
 
-    if (userByPhoneNumber) {
-      res.status(400).send({
-        error: 'That phone number is already in use. Please choose another number.',
-        type: 'phoneNumber',
-      });
-      return;
-    }
+     if(duplicatePhoneNumberCheck){
+       const userByPhoneNumber = await UserProfile.findOne({
+         phoneNumber: req.body.phoneNumber,
+       });
+   
+       if (userByPhoneNumber) {
+         res.status(400).send({
+           error: 'That phone number is already in use. Please choose another number.',
+           type: 'phoneNumber',
+         });
+         return;
+       }
+     }
 
     const userDuplicateName = await UserProfile.findOne({
       firstName: req.body.firstName,

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -193,9 +193,7 @@ const userProfileController = function (UserProfile) {
         //remove backend cache
         cache.removeCache('allusers');
       })
-      .catch(error => res.status(501).send(error));
-      
-      
+      .catch(error => res.status(501).send(error))
   };
 
   const putUserProfile = function (req, res) {


### PR DESCRIPTION
For the ones who review this:
This PR fixes two bugs.
- remove the duplicate number check when creating new user.
Instead of removing the duplicate number check code, I create a new variable `duplicatePhoneNumberCheck` to determine if we need the duplicate phone check. If we need the function in the future, just change the value to true.

- update the backend cache when creating and deleting a user. 
After creating a new user or deleting a user the result will immediately show on the UserManagement table.