### PR TITLE
Oauth 2.0 integration for send email

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1314,6 +1314,14 @@
         "@types/node": "*"
       }
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -1423,6 +1431,11 @@
         "es-abstract": "^1.19.0"
       }
     },
+    "arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+    },
     "astral-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -1510,10 +1523,20 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "bcryptjs": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
       "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+    },
+    "bignumber.js": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
+      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -2294,6 +2317,11 @@
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "express": {
       "version": "4.17.3",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.3.tgz",
@@ -2351,6 +2379,11 @@
         }
       }
     },
+    "extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+    },
     "external-editor": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
@@ -2379,6 +2412,11 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fast-text-encoding": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
+      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
     },
     "figures": {
       "version": "2.0.0",
@@ -2524,6 +2562,27 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "gaxios": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "gcp-metadata": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.3.1.tgz",
+      "integrity": "sha512-x850LS5N7V1F3UcV7PoupzGsyD6iVwTVvsh3tbXfkctZnBnjW5yu5z1/3k3SehF7TyoTIe78rJs02GMMy+LF+A==",
+      "requires": {
+        "gaxios": "^4.0.0",
+        "json-bigint": "^1.0.0"
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2574,6 +2633,124 @@
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+    },
+    "google-auth-library": {
+      "version": "7.14.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.14.1.tgz",
+      "integrity": "sha512-5Rk7iLNDFhFeBYc3s8l1CqzbEBcdhwR193RlD4vSNFajIcINKI8W8P0JLmBpwymHqqWbX34pJDQu39cSy/6RsA==",
+      "requires": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
+        "jws": "^4.0.0",
+        "lru-cache": "^6.0.0"
+      },
+      "dependencies": {
+        "jwa": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+          "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+          "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+          "requires": {
+            "jwa": "^2.0.0",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
+    "google-p12-pem": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
+      "integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
+      "requires": {
+        "node-forge": "^1.3.1"
+      }
+    },
+    "googleapis": {
+      "version": "100.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-100.0.0.tgz",
+      "integrity": "sha512-RToFQGY54B756IDbjdyjb1vWFmn03bYpXHB2lIf0eq2UBYsIbYOLZ0kqSomfJnpclEukwEmMF7Jn6Wsev871ew==",
+      "requires": {
+        "google-auth-library": "^7.0.2",
+        "googleapis-common": "^5.0.2"
+      }
+    },
+    "googleapis-common": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-5.1.0.tgz",
+      "integrity": "sha512-RXrif+Gzhq1QAzfjxulbGvAY3FPj8zq/CYcvgjzDbaBNCD6bUl+86I7mUs4DKWHGruuK26ijjR/eDpWIDgNROA==",
+      "requires": {
+        "extend": "^3.0.2",
+        "gaxios": "^4.0.0",
+        "google-auth-library": "^7.14.0",
+        "qs": "^6.7.0",
+        "url-template": "^2.0.8",
+        "uuid": "^8.0.0"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+        }
+      }
+    },
+    "gtoken": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.3.2.tgz",
+      "integrity": "sha512-gkvEKREW7dXWF8NV8pVrKfW7WqReAmjjkMBh6lNCCGOM4ucS0r0YyXXl0r/9Yj8wcW/32ISkfc8h5mPTDbtifQ==",
+      "requires": {
+        "gaxios": "^4.0.0",
+        "google-p12-pem": "^3.1.3",
+        "jws": "^4.0.0"
+      },
+      "dependencies": {
+        "jwa": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+          "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+          "requires": {
+            "buffer-equal-constant-time": "1.0.1",
+            "ecdsa-sig-formatter": "1.0.11",
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "jws": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+          "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+          "requires": {
+            "jwa": "^2.0.0",
+            "safe-buffer": "^5.0.1"
+          }
+        }
+      }
     },
     "has": {
       "version": "1.0.3",
@@ -2844,6 +3021,11 @@
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
       "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
     },
+    "is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+    },
     "is-string": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
@@ -2903,6 +3085,14 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+    },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
     },
     "json-schema-traverse": {
       "version": "0.4.1",
@@ -3279,6 +3469,19 @@
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
+    },
+    "node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      }
+    },
+    "node-forge": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+      "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA=="
     },
     "node-releases": {
       "version": "2.0.2",
@@ -4115,6 +4318,11 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "tsconfig-paths": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.13.0.tgz",
@@ -4216,6 +4424,11 @@
         "punycode": "^2.1.0"
       }
     },
+    "url-template": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
+      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4248,6 +4461,20 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "which": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "cron": "^1.8.2",
     "dotenv": "^5.0.1",
     "express": "^4.17.1",
+    "googleapis": "^100.0.0",
     "jsonwebtoken": "^8.4.0",
     "lodash": "^4.17.21",
     "moment": "^2.29.2",

--- a/src/utilities/emailSender.js
+++ b/src/utilities/emailSender.js
@@ -5,6 +5,31 @@ const logger = require('../startup/logger');
 
 const closure = () => {
   const queue = [];
+
+  const CLIENT_EMAIL = process.env.REACT_APP_EMAIL;
+  const CLIENT_ID = process.env.REACT_APP_EMAIL_CLIENT_ID;
+  const CLIENT_SECRET = process.env.REACT_APP_EMAIL_CLIENT_SECRET;
+  const REDIRECT_URI = process.env.REACT_APP_EMAIL_CLIENT_REDIRECT_URI;
+  const REFRESH_TOKEN = process.env.REACT_APP_EMAIL_REFRESH_TOKEN;
+  // Create the email envelope (transport)
+  const transporter = nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      type: 'OAuth2',
+      user: CLIENT_EMAIL,
+      clientId: CLIENT_ID,
+      clientSecret: CLIENT_SECRET,
+    },
+  });
+
+  const OAuth2Client = new google.auth.OAuth2(
+    CLIENT_ID,
+    CLIENT_SECRET,
+    REDIRECT_URI,
+  );
+  
+  OAuth2Client.setCredentials({ refresh_token: REFRESH_TOKEN });
+
   setInterval(async () => {
     const nextItem = queue.shift();
 
@@ -14,48 +39,26 @@ const closure = () => {
       recipient, subject, message, cc, bcc,
     } = nextItem;
 
-    const CLIENT_EMAIL = process.env.REACT_APP_EMAIL;
-    const CLIENT_ID = process.env.REACT_APP_EMAIL_CLIENT_ID;
-    const CLIENT_SECRET = process.env.REACT_APP_EMAIL_CLIENT_SECRET;
-    const REDIRECT_URI = process.env.REACT_APP_EMAIL_CLIENT_REDIRECT_URI;
-    const REFRESH_TOKEN = process.env.REACT_APP_EMAIL_REFRESH_TOKEN;
-    const OAuth2Client = new google.auth.OAuth2(
-      CLIENT_ID,
-      CLIENT_SECRET,
-      REDIRECT_URI,
-    );
-    logger.logInfo('test refresh token : ', REFRESH_TOKEN);
-    OAuth2Client.setCredentials({ refresh_token: REFRESH_TOKEN });
     try {
       // Generate the accessToken on the fly
-      const ACCESSTOKEN = await OAuth2Client.getAccessToken();
-      logger.logInfo(ACCESSTOKEN);
-
-      // Create the email envelope (transport)
-      const transport = nodemailer.createTransport({
-        service: 'gmail',
-        auth: {
-          type: 'OAuth2',
-          user: CLIENT_EMAIL,
-          clientId: CLIENT_ID,
-          clientSecret: CLIENT_SECRET,
-          refreshToken: REFRESH_TOKEN,
-          accessToken: ACCESSTOKEN,
-        },
-      });
-
-      logger.logInfo(transport);
+      const res = await OAuth2Client.getAccessToken();
+      const ACCESSTOKEN = res.token;
 
       const mailOptions = {
-        from: process.env.SMTPUser,
+        from: CLIENT_EMAIL,
         to: recipient,
         cc,
         bcc,
         subject,
         html: message,
+        auth: {
+          user: CLIENT_EMAIL,
+          refreshToken: REFRESH_TOKEN,
+          accessToken: ACCESSTOKEN,
+        }
       };
 
-      const result = await transport.sendMail(mailOptions);
+      const result = await transporter.sendMail(mailOptions);
       logger.logInfo(result);
     } catch (error) {
       logger.logException(error);

--- a/src/utilities/emailSender.js
+++ b/src/utilities/emailSender.js
@@ -1,71 +1,59 @@
 const nodemailer = require('nodemailer');
+const { google } = require('googleapis');
 const logger = require('../startup/logger');
 
-const closure = () => {
-  const queue = [];
 
-  setInterval(() => {
-    const nextItem = queue.shift();
+const emailSender = async function emailSender(recipient, subject, message, cc = null, bcc = null) {
+  const CLIENT_EMAIL = process.env.REACT_APP_EMAIL;
+  const CLIENT_ID = process.env.REACT_APP_EMAIL_CLIENT_ID;
+  const CLIENT_SECRET = process.env.REACT_APP_EMAIL_CLIENT_SECRET;
+  const REDIRECT_URI = process.env.REACT_APP_EMAIL_CLIENT_REDIRECT_URI;
+  const REFRESH_TOKEN = process.env.REACT_APP_EMAIL_REFRESH_TOKEN;
+  const OAuth2Client = new google.auth.OAuth2(
+    CLIENT_ID,
+    CLIENT_SECRET,
+    REDIRECT_URI,
+  );
 
-    if (!nextItem) return;
+  logger.logInfo('test refresh token : ', REFRESH_TOKEN);
 
-    const {
-      recipient, subject, message, cc, bcc,
-    } = nextItem;
+  OAuth2Client.setCredentials({ refresh_token: REFRESH_TOKEN });
+  try {
+    // Generate the accessToken on the fly
+    const ACCESSTOKEN = await OAuth2Client.getAccessToken();
+    logger.logInfo(ACCESSTOKEN);
 
-    nodemailer.createTestAccount(() => {
-      const transporter = nodemailer.createTransport({
-        host: process.env.SMTPDomain,
-        port: process.env.SMTPPort,
-        secure: true,
-        auth: {
-          user: process.env.SMTPUser,
-          pass: process.env.SMTPPass,
-        },
-        tls: {
-          rejectUnauthorized: false,
-        },
-      });
-
-      logger.logInfo(transporter);
-
-      const mailOptions = {
-        from: process.env.SMTPUser,
-        to: recipient,
-        cc,
-        bcc,
-        subject,
-        html: message,
-      };
-
-      return transporter.sendMail(mailOptions, (error, info) => {
-        if (error) {
-          logger.logException(error);
-          return error;
-        }
-        logger.logInfo(info);
-        return info;
-      });
+    // Create the email envelope (transport)
+    const transport = nodemailer.createTransport({
+      service: 'gmail',
+      auth: {
+        type: 'OAuth2',
+        user: CLIENT_EMAIL,
+        clientId: CLIENT_ID,
+        clientSecret: CLIENT_SECRET,
+        refreshToken: REFRESH_TOKEN,
+        accessToken: ACCESSTOKEN,
+      },
     });
-  }, process.env.MAIL_QUEUE_INTERVAL || 1000);
 
-  /**
-   *
-   * @param {string} recipient A comma-seperated list of recipients for this email. Examples: 'cow@cow.jp' OR 'cow@cow.jp, cow23@cow.jp'
-   * @param {string} subject Email subject
-   * @param {string} message HTML formatted email body
-   * @param {*} cc
-   * @param {*} bcc
-   */
-  const emailSender = function (recipient, subject, message, cc = null, bcc = null) {
-    if (process.env.sendEmail) {
-      queue.push({
-        recipient, subject, message, cc, bcc,
-      });
-    }
-  };
+    logger.logInfo(transport);
 
-  return emailSender;
+    const mailOptions = {
+      from: process.env.SMTPUser,
+      to: recipient,
+      cc,
+      bcc,
+      subject,
+      html: message,
+    };
+
+    const result = await transport.sendMail(mailOptions);
+    logger.logInfo(result);
+    return result;
+  } catch (error) {
+    logger.logException(error);
+    return error;
+  }
 };
 
-module.exports = closure();
+module.exports = emailSender;


### PR DESCRIPTION
initial version for integrate oauth 2.0 prototal into sending email api.

**Changes:**

1. leverage google api for sending email.
2. using await function instead of setting 100 as interval


**Followups:** (several config changes is needed after this cr is merged)

update client secret in GCP(google cloud platform) since refresh token will expire in 7 days in dev stage. We need to update that to prod.

1. setting up environment variable in prod account as follow:
REACT_APP_EMAIL='[highestgoodnetwork@gmail.com](mailto:highestgoodnetwork@gmail.com)'
REACT_APP_EMAIL_CLIENT_ID='805546003177-5smd05lccvrrliras7kljf3crel593go.apps.googleusercontent.com'
REACT_APP_EMAIL_CLIENT_SECRET='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'
REACT_APP_EMAIL_REDIRECT_URI='https://developers.google.com/oauthplayground'
REACT_APP_EMAIL_REFRESH_TOKEN='1//041PDbNZ1xVCoCgYIARAAGAQSNwF-L9Ir61lwpczgn0K-Wv7N8L_44Gi3u8puYA9GhnA8XK7MMOFEo5GFUtG-Zco3LZz9Dlf8luE'
2. testing sending email in prod account.

dev testing:
1. pull this code 
2. set up environment variable as above. (Note: need to add "sendEmail=true" as well)
3. you can simply test forget email block to verify if the email is correctly sent.