### PR TITLE
add hoursLogged field on task schema

### DIFF
--- a/src/models/task.js
+++ b/src/models/task.js
@@ -20,6 +20,7 @@ const taskschema = new Schema({
   hoursBest: { type: Number, default: 0.0 },
   hoursWorst: { type: Number, default: 0.0 },
   hoursMost: { type: Number, default: 0.0 },
+  hoursLogged: {type: Number, default: 0.0 },
   estimatedHours: { type: Number, default: 0.0 },
   startedDatetime: { type: Date },
   dueDatetime: { type: Date },


### PR DESCRIPTION
This PR is the backend change for "implement the three clock icons on management-dashboard".

**More details:**
The green and red clocks both need the logged hours data of each task, so created `hoursLogged` field in task's schema.