### PR TITLE
update comment

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -234,7 +234,8 @@ const timeEntrycontroller = function (TimeEntry) {
       },
       ' -createdDateTime',
     )
-      .populate('projectId')
+      // allow the task-based timeEntry get its taskId into projectId field when calling this func
+      // .populate('projectId')
       .sort({ lastModifiedDateTime: -1 })
       .then((results) => {
         const data = [];


### PR DESCRIPTION
This PR is the backend changes for showing taskname of each timeEntry on timelog.

This change solves when calling `getTimeEntriesForSpecifiedPeriod()`, the task-based timeEntry data cannot get `taskId`. After change, the `taskId` can also be populated into the `projectId` field, which is same as project-based timeEntry.