### PR TITLE
fix: saving updated timezone does not update in database due to user …

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -246,6 +246,7 @@ const userProfileController = function (UserProfile) {
       record.weeklySummaries = req.body.weeklySummaries;
       record.weeklySummariesCount = req.body.weeklySummariesCount;
       record.mediaUrl = req.body.mediaUrl;
+      record.timeZone = req.body.timeZone;
 
       // find userData in cache
       const isUserInCache = cache.hasCache('allusers');
@@ -274,8 +275,7 @@ const userProfileController = function (UserProfile) {
         record.weeklySummaryNotReq = req.body.weeklySummaryNotReq ? req.body.weeklySummaryNotReq : record.weeklySummaryNotReq;
         record.categoryTangibleHrs = req.body.categoryTangibleHrs ? req.body.categoryTangibleHrs : record.categoryTangibleHrs;
         record.totalTangibleHrs = req.body.totalTangibleHrs;
-        record.timeEntryEditHistory = req.body.timeEntryEditHistory;
-        record.timeZone = req.body.timeZone;
+        record.timeEntryEditHistory = req.body.timeEntryEditHistory;        
         record.hoursByCategory = req.body.hoursByCategory;
         record.createdDate = moment(req.body.createdDate).toDate();
         if (yearMonthDayDateValidator(req.body.endDate)) {


### PR DESCRIPTION
Issue: Updating the profile with the new timezone is not reflected in the UI or the database.

Root cause: The method/endpoint "putUserProfile" checks if the role has the permission "putUserProfileImportantInfo" before deciding if he/she is allowed to update the timezone. As for most of the cases, the user role will be "Volunteer", which does not have the permission "putUserProfileImportantInfo". Hence the user won't be able to save the new timeZone.

Resolution: Either give the "Volunteer" role the required permission or shift the timezone update to the generic field update section before this role check section. Option 1  is not feasible as the "putUserProfileImportantInfo" many admin related permissions.

Behaviour After Fix:
![saveTImeZoneFix](https://user-images.githubusercontent.com/13500309/184541882-25d2d372-81d1-415e-908e-bee68bdf91cb.gif)


Note: This is a partial fix for bug 4 in the bug doc.  The other fix is to be taken care of in the front-end as no timezone is passed during the user creation as a result of which the default "America/Los_Angeles" is stored for all the new users.