### PR TITLE
DeActivateUser function initiation.

### DIFF
--- a/src/cronjobs/userProfileJobs.js
+++ b/src/cronjobs/userProfileJobs.js
@@ -15,6 +15,7 @@ const userProfileJobs = () => {
         await userhelper.awardNewBadges();
       }
       await userhelper.reActivateUser();
+      await userhelper.deActivateUser();
     },
     null,
     false,
@@ -22,6 +23,17 @@ const userProfileJobs = () => {
   );
 
   allUserProfileJobs.start();
+/* For Test
+  const test1 = new CronJob(
+    '42 * * * *', // At minute 42. You can change the minute whenever your want to test 
+    async () => {
+      await userhelper.test();
+    },
+    null,
+    false,
+    'America/Los_Angeles',
+  );
+  test1.start();
+*/
 };
-
 module.exports = userProfileJobs;

--- a/src/helpers/userhelper.js
+++ b/src/helpers/userhelper.js
@@ -977,6 +977,54 @@ const userhelper = function () {
       });
   };
 
+  const deActivateUser = async () => {
+    const currentFormattedDate = moment().tz('America/Los_Angeles').format();
+    logger.logInfo(`Job for deactivating users based on scheduled end date ${currentFormattedDate}`);
+    try {
+      const users = await userProfile.find({ isActive: true, endDate: { $exists: true } }, '_id isActive endDate');
+      for (let i = 0; i < users.length; i += 1) {
+        const user = users[i];
+        if (moment().isSameOrAfter(moment(user.endDate))) {
+          await userProfile.findByIdAndUpdate(
+            user._id,
+            user.set({
+              isActive: false,
+            }),
+            { new: true },
+          );
+          logger.logInfo(`User with id: ${user._id} was de-acticated at ${moment().tz('America/Los_Angeles').format()}.`);
+        }
+      }
+    } catch (err) {
+      logger.logException(err);
+    }
+  };
+  /* Test Function
+  const test = async () => {
+    const currentFormattedDate = moment().tz('America/Los_Angeles').format();
+    try {
+      const users = await userProfile.find({ isActive: true, endDate: { $exists: true } }, '_id isActive endDate');
+      console.log('*Test Data Before findandModify');
+      console.log('User need to be deActivated:', users);
+      for (let i = 0; i < users.length; i += 1) {
+        const user = users[i];
+        if (moment().add(5, 'days').isSameOrAfter(moment(user.endDate))) {
+          await userProfile.findByIdAndUpdate(
+            user._id,
+            user.set({
+              isActive: false,
+            }),
+            { new: true },
+          );
+        }
+      }
+      console.log('*Test Data After findAndModify');
+      console.log('deActivateUser:', users);
+    } catch (err) {
+      logger.logException(err);
+    }
+  };
+  */
   return {
     getUserName,
     getTeamMembers,
@@ -984,11 +1032,13 @@ const userhelper = function () {
     assignBlueSquareforTimeNotMet,
     deleteBlueSquareAfterYear,
     reActivateUser,
+    deActivateUser,
     notifyInfringments,
     getInfringmentEmailBody,
     emailWeeklySummariesForAllUsers,
     awardNewBadges,
     getTangibleHoursReportedThisWeekByUserId,
+    // test,
   };
 };
 

--- a/src/startup/db.js
+++ b/src/startup/db.js
@@ -36,6 +36,7 @@ module.exports = function () {
   mongoose.connect(uri, {
     useNewUrlParser: true,
     useUnifiedTopology: true,
+    useFindAndModify: false,
   })
     .then(afterConnect)
     .catch(err => logger.logException(err));


### PR DESCRIPTION
DeActivateUser function :

Aim of DeActivateUser function: after the date reaching out the final day, the user's status will change from active to inactive. 

How to achieve:

file userhelper

1) Find the user who meets the condition that needs to be deactivated using mongoose - useprofile. find();(three conditions: currently isActive, have already set endDate, the current date is the same or later than the endDate);

2) After finding the user then update the user information and change the user' isActive from true to false; (use findOneAndUpdate())

file userProfileJobs:

3) This function will execute every day one minutes past midnight (use cronjob )

In this PR,  I add a test function in the comment, if you want to test the effect of this function, you can delete the /**/ to test it. The test function is totally the same as the deActiveUser function, except the current date which changes to the current date plus five days, so if you select a final day within five days, it could be a test. 

The test function explanation  as below:

In the real situation, if today is reaching the final day, the function will set the user’s status from active to inactive. But in the test situation, since we want to see the effect immediately, I write a function like this moment().add(5, days), which means if today plus five days is later than the final day, the function will change from active to inactive. Therefore we can test future days. For example, 
End Date : Sep 10
Today: Sep 9,
Test day :  Today(Sep 9) + 5 days =  Sep 14,
In the real situation: if today is later than endDate, the function will be called.
In the test situation: Test day is later than endDate. Therefore function will be called. 

What is more, the deactivated user function should be executed every day one minute past midnight, but in the test situation, since we want to see the effect immediately, I write a function, then it is possible to execute every minute we want. 

