### PR TITLE
Email sender/final day

### DIFF
--- a/src/cronjobs/userProfileJobs.js
+++ b/src/cronjobs/userProfileJobs.js
@@ -3,6 +3,7 @@ const moment = require('moment-timezone');
 
 const userhelper = require('../helpers/userhelper')();
 
+
 const userProfileJobs = () => {
   const allUserProfileJobs = new CronJob(
     '1 0 * * *', // Every day, 1 minute past midnight (PST).
@@ -23,17 +24,5 @@ const userProfileJobs = () => {
   );
 
   allUserProfileJobs.start();
-/* For Test
-  const test1 = new CronJob(
-    '42 * * * *', // At minute 42. You can change the minute whenever your want to test 
-    async () => {
-      await userhelper.test();
-    },
-    null,
-    false,
-    'America/Los_Angeles',
-  );
-  test1.start();
-*/
 };
 module.exports = userProfileJobs;

--- a/src/helpers/userhelper.js
+++ b/src/helpers/userhelper.js
@@ -982,7 +982,9 @@ const userhelper = function () {
       const users = await userProfile.find({ isActive: true, endDate: { $exists: true } }, '_id isActive endDate');
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
-        if (moment().isAfter(user.endDate)) {
+        const { endDate } = user;
+        endDate.setHours(endDate.getHours() + 7);
+        if (moment().isAfter(moment(endDate))) {
           await userProfile.findByIdAndUpdate(
             user._id,
             user.set({
@@ -990,23 +992,22 @@ const userhelper = function () {
             }),
             { new: true },
           );
+          const id = user._id;
+          const person = await userProfile.findById(id);
           logger.logInfo(`User with id: ${user._id} was de-acticated at ${moment().format()}.`);
-          const { firstName } = user;
-          const { lastName } = user;
-          const subject = `Deactivate User Report from ${firstName},${lastName}`;
-          const { endDate } = user;
+          const subject = `IMPORTANT:${person.firstName} ${person.lastName} has been deactivated in the Highest Good Network`;
 
           const emailBody = `<p> Hi Admin! </p>
 
-          <p>This email is to let you know that ${firstName}${lastName}  has completed their scheduled last day( ${endDate}) and been deactivated in the Highest Good Network application. 
+          <p>This email is to let you know that ${person.firstName} ${person.lastName} has completed their scheduled last day( ${person.endDate}) and been deactivated in the Highest Good Network application. </p>
           
-          This is their email from the system: <user email> Please email them to let them know their work is complete and thank them for their volunteer time with One Community. </p>
+          <p>This is their email from the system: ${person.email }. Please email them to let them know their work is complete and thank them for their volunteer time with One Community. </p>
           
           <p> Thanks! <br />
           
           One Community </p>`;
           emailSender(
-            'onecommunityglobal@gmail.com.',
+            'onecommunityglobal@gmail.com',
             subject,
             emailBody,
             null,

--- a/src/helpers/userhelper.js
+++ b/src/helpers/userhelper.js
@@ -978,13 +978,11 @@ const userhelper = function () {
   };
 
   const deActivateUser = async () => {
-    const currentFormattedDate = moment().tz('America/Los_Angeles').format();
-    logger.logInfo(`Job for deactivating users based on scheduled end date ${currentFormattedDate}`);
     try {
       const users = await userProfile.find({ isActive: true, endDate: { $exists: true } }, '_id isActive endDate');
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
-        if (moment().isAfter(moment(user.endDate))) {
+        if (moment().isAfter(user.endDate)) {
           await userProfile.findByIdAndUpdate(
             user._id,
             user.set({
@@ -992,7 +990,28 @@ const userhelper = function () {
             }),
             { new: true },
           );
-          logger.logInfo(`User with id: ${user._id} was de-acticated at ${moment().tz('America/Los_Angeles').format()}.`);
+          logger.logInfo(`User with id: ${user._id} was de-acticated at ${moment().format()}.`);
+          const { firstName } = user;
+          const { lastName } = user;
+          const subject = `Deactivate User Report from ${firstName},${lastName}`;
+          const { endDate } = user;
+
+          const emailBody = `<p> Hi Admin! </p>
+
+          <p>This email is to let you know that ${firstName}${lastName}  has completed their scheduled last day( ${endDate}) and been deactivated in the Highest Good Network application. 
+          
+          This is their email from the system: <user email> Please email them to let them know their work is complete and thank them for their volunteer time with One Community. </p>
+          
+          <p> Thanks! <br />
+          
+          One Community </p>`;
+          emailSender(
+            'onecommunityglobal@gmail.com.',
+            subject,
+            emailBody,
+            null,
+            null,
+          );
         }
       }
     } catch (err) {


### PR DESCRIPTION
Aim to add an email sender function to deactivate the user function. 

When the user's last day on one community global as scheduled passes, the admin will receive an email from highestgoodnetwork@gmail.com

subject : IMPORTANT: <First and Last Name> has been deactivated in the Highest Good Network

Email text body:

Hi Admin! 

This email lets you know that <First and Last Name> has completed their scheduled last day (month/Day/year) and been deactivated in the Highest Good Network application. 

This is their email from the system: <user email> Please email them to let them know their work is complete and thank them for their volunteer time with One Community. 

Thanks! 

One Community

Notice: if you want to pull this PR locally and test the effect. it should need some credentials which are not shown on the development branch ( if you need them, please contact admin):
  const CLIENT_EMAIL = process.env.REACT_APP_EMAIL;
  const CLIENT_ID = process.env.REACT_APP_EMAIL_CLIENT_ID;
  const CLIENT_SECRET = process.env.REACT_APP_EMAIL_CLIENT_SECRET;
  const REDIRECT_URI = process.env.REACT_APP_EMAIL_CLIENT_REDIRECT_URI;
  const REFRESH_TOKEN = process.env.REACT_APP_EMAIL_REFRESH_TOKEN; 
