### PR TITLE
Changed some conditions on the formatting of summaries.

### DIFF
--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -1,4 +1,4 @@
-const reporthelper = require('../helpers/reportHelper')();
+const reporthelper = require('../helpers/reporthelper')();
 const hasPermission = require('../utilities/permissions');
 
 const reportsController = function () {

--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -157,7 +157,7 @@ const reporthelper = function () {
       if (Array.isArray(wS) && wS.length && wS.length < 3) {
         // Common cases for the first entry.
         if (getTheWeek(wS[0].dueDate) === 0) wSummaries[0] = { ...wS[0] };
-        if (getTheWeek(wS[0].dueDate) === 1) {
+        else if (getTheWeek(wS[0].dueDate) === 1) {
           wSummaries[0] = null;
           wSummaries[1] = { ...wS[0] };
         }
@@ -169,7 +169,7 @@ const reporthelper = function () {
             wSummaries[1] = null;
             wSummaries[2] = { ...wS[0] };
           }
-        } else { // When two entries.
+        } else if (wS.length === 2) { // When two entries.
           if (getTheWeek(wS[1].dueDate) === 1) wSummaries[1] = { ...wS[1] };
           if (getTheWeek(wS[1].dueDate) === 2) wSummaries[2] = { ...wS[1] };
         }

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -64,5 +64,4 @@ module.exports = function (app) {
   app.use('/api', timeZoneAPIRouter);
   app.use('/api', taskEditSuggestionRouter);
   app.use('/api', roleRouter);
-
 };


### PR DESCRIPTION
Weekly summaries are registering as submitted on the Dashboard (see pic below) even when they haven’t been. This appears to be happening because the submission page is one week off from the correct date. This does not include the additional request. Please test this before merging.