### PR TITLE
Change incorrect report helper filename reference

### DIFF
--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -1,4 +1,4 @@
-const reporthelper = require('../helpers/reportHelper')();
+const reporthelper = require('../helpers/reporthelper')();
 const hasPermission = require('../utilities/permissions');
 
 const reportsController = function () {

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -5,7 +5,7 @@ const timeEntries = require('../models/timeentry');
 const badge = require('../models/badge');
 const myTeam = require('./helperModels/myTeam');
 const dashboardHelper = require('./dashboardhelper')();
-const reportHelper = require('./reportHelper')();
+const reportHelper = require('./reporthelper')();
 
 const emailSender = require('../utilities/emailSender');
 


### PR DESCRIPTION
Reference to "reporthelper.js" file was corrected from "reportHelper" to "reporthelper"