### PR TITLE
fix the bug for infringments not match the number of  blue square

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4202,6 +4202,11 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "ordinal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ordinal/-/ordinal-1.0.3.tgz",
+      "integrity": "sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ=="
+    },
     "os-shim": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "node-cache": "^5.1.2",
     "node-datetime": "^2.0.3",
     "nodemailer": "^6.4.16",
+    "ordinal": "^1.0.3",
     "redis": "^4.2.0",
     "uuid": "^3.4.0",
     "ws": "^8.8.1"

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -1,5 +1,6 @@
 const mongoose = require('mongoose');
 const moment = require('moment-timezone');
+const ordinal = require('ordinal')
 const userProfile = require('../models/userProfile');
 const timeEntries = require('../models/timeentry');
 const badge = require('../models/badge');
@@ -67,7 +68,7 @@ const userHelper = function () {
         <p>Oops, it looks like something happened and you’ve managed to get a blue square.</p>
         <p><b>Date Assigned:</b> ${infringement.date}</p>
         <p><b>Description:</b> ${infringement.description}</p>
-        <p><b>Total Infringements:</b> This is your <b>${totalInfringements}</b> blue square of 5.</p>
+        <p><b>Total Infringements:</b> This is your <b>${ordinal(totalInfringements)}</b> blue square of 5.</p>
         <p>Life happens and we understand that. That’s why we allow 5 of them before taking action. This action usually includes removal from our team though, so please let your direct supervisor know what happened and do your best to avoid future blue squares if you are getting close to 5 and wish to avoid termination. Each blue square drops off after a year.</p>
         <p>Thank you,<br />
         One Community</p>`;

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -67,11 +67,10 @@ const userHelper = function () {
         <p>Oops, it looks like something happened and you’ve managed to get a blue square.</p>
         <p><b>Date Assigned:</b> ${infringement.date}</p>
         <p><b>Description:</b> ${infringement.description}</p>
-        <p><b>Total Infringements:</b> This is your <b>${moment.localeData().ordinal(totalInfringements)}</b> blue square of 5.</p>
+        <p><b>Total Infringements:</b> This is your <b>${totalInfringements}</b> blue square of 5.</p>
         <p>Life happens and we understand that. That’s why we allow 5 of them before taking action. This action usually includes removal from our team though, so please let your direct supervisor know what happened and do your best to avoid future blue squares if you are getting close to 5 and wish to avoid termination. Each blue square drops off after a year.</p>
         <p>Thank you,<br />
         One Community</p>`;
-
     return text;
   };
 


### PR DESCRIPTION
High Priority #6.: Blue square counts stated in emails to team members are not accurate now. Everyone who got an email his week had that email saying it was their 1st blue square, regardless of the number.

<img width="945" alt="image" src="https://user-images.githubusercontent.com/108507783/207997992-47cec8a9-4277-4ef8-ae90-6c5482242abe.png">
<img width="973" alt="image" src="https://user-images.githubusercontent.com/108507783/207998026-192284c5-d6e4-467d-92f6-42521d0716f1.png">

infringement is an array, and each element in this array is named infringement
each infringement has three variables: id, date, description,