### PR TITLE
XhoursForXWeeks changes only

### DIFF
--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -63,18 +63,24 @@ const userHelper = function () {
     };
   };
 
-  const getInfringementEmailBody = function (firstName, lastName, infringement, totalInfringements) {
+  const getInfringementEmailBody = function (
+    firstName,
+    lastName,
+    infringement,
+    totalInfringements,
+  ) {
     const text = `Dear <b>${firstName} ${lastName}</b>,
         <p>Oops, it looks like something happened and you’ve managed to get a blue square.</p>
         <p><b>Date Assigned:</b> ${infringement.date}</p>
         <p><b>Description:</b> ${infringement.description}</p>
-        <p><b>Total Infringements:</b> This is your <b>${moment.localeData().ordinal(totalInfringements)}</b> blue square of 5.</p>
+        <p><b>Total Infringements:</b> This is your <b>${moment
+          .localeData()
+          .ordinal(totalInfringements)}</b> blue square of 5.</p>
         <p>Life happens and we understand that. That’s why we allow 5 of them before taking action. This action usually includes removal from our team though, so please let your direct supervisor know what happened and do your best to avoid future blue squares if you are getting close to 5 and wish to avoid termination. Each blue square drops off after a year.</p>
         <p>Thank you,<br />
         One Community</p>`;
     return text;
   };
-
 
   /**
    * This function will send out an email listing all users that have a summary provided for a specific week.
@@ -89,7 +95,9 @@ const userHelper = function () {
   const emailWeeklySummariesForAllUsers = async (weekIndex = 1) => {
     const currentFormattedDate = moment().tz('America/Los_Angeles').format();
 
-    logger.logInfo(`Job for emailing all users' weekly summaries starting at ${currentFormattedDate}`);
+    logger.logInfo(
+      `Job for emailing all users' weekly summaries starting at ${currentFormattedDate}`,
+    );
 
     const emails = [];
 
@@ -102,13 +110,21 @@ const userHelper = function () {
 
       const weeklySummaryNotRequiredMessage = '<div><b>Weekly Summary:</b> <span style="color: magenta;"> Not required for this user </span></div>';
 
-      results.sort((a, b) => (`${a.firstName} ${a.lastName}`).localeCompare(`${b.firstName} ${b.lastname}`));
+      results.sort((a, b) => `${a.firstName} ${a.lastName}`.localeCompare(
+          `${b.firstName} ${b.lastname}`,
+        ));
 
       for (let i = 0; i < results.length; i += 1) {
         const result = results[i];
 
         const {
-          firstName, lastName, email, weeklySummaries, mediaUrl, weeklySummariesCount, weeklyComittedHours,
+          firstName,
+          lastName,
+          email,
+          weeklySummaries,
+          mediaUrl,
+          weeklySummariesCount,
+          weeklyComittedHours,
         } = result;
 
         if (email !== undefined && email !== null) {
@@ -118,9 +134,11 @@ const userHelper = function () {
         // weeklySummaries array will have only one item fetched (if present),
         // consequently totalSeconds array will also have only one item in the array (if present)
         // hence totalSeconds[0] should be used
-        const hoursLogged = ((result.totalSeconds[0] / 3600) || 0);
+        const hoursLogged = result.totalSeconds[0] / 3600 || 0;
 
-        const mediaUrlLink = mediaUrl ? `<a href="${mediaUrl}">${mediaUrl}</a>` : 'Not provided!';
+        const mediaUrlLink = mediaUrl
+          ? `<a href="${mediaUrl}">${mediaUrl}</a>`
+          : 'Not provided!';
 
         let weeklySummaryMessage = weeklySummaryNotProvidedMessage;
 
@@ -131,7 +149,9 @@ const userHelper = function () {
             weeklySummaryMessage = `
               <div>
                 <b>Weekly Summary</b>
-                (for the week ending on <b>${moment(dueDate).tz('America/Los_Angeles').format('YYYY-MMM-DD')}</b>):
+                (for the week ending on <b>${moment(dueDate)
+                  .tz('America/Los_Angeles')
+                  .format('YYYY-MMM-DD')}</b>):
               </div>
               <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}">
                 ${summary}
@@ -147,24 +167,33 @@ const userHelper = function () {
         <div style="padding: 20px 0; margin-top: 5px; border-bottom: 1px solid #828282;">
           <b>Name:</b> ${firstName} ${lastName}
           <p>
-            <b>Media URL:</b> ${mediaUrlLink || '<span style="color: red;">Not provided!</span>'}
+            <b>Media URL:</b> ${
+              mediaUrlLink || '<span style="color: red;">Not provided!</span>'
+            }
           </p>
-          ${weeklySummariesCount === 8
-    ? `<p style="color: blue;"><b>Total Valid Weekly Summaries: ${weeklySummariesCount}</b></p>`
-    : `<p><b>Total Valid Weekly Summaries</b>: ${weeklySummariesCount || 'No valid submissions yet!'}</p>`
-}
           ${
-  hoursLogged >= weeklyComittedHours
-    ? `<p><b>Hours logged</b>: ${hoursLogged.toFixed(2)} / ${weeklyComittedHours}</p>`
-    : `<p style="color: red;"><b>Hours logged</b>: ${hoursLogged.toFixed(2)} / ${weeklyComittedHours}</p>`
-}
+            weeklySummariesCount === 8
+              ? `<p style="color: blue;"><b>Total Valid Weekly Summaries: ${weeklySummariesCount}</b></p>`
+              : `<p><b>Total Valid Weekly Summaries</b>: ${
+                  weeklySummariesCount || 'No valid submissions yet!'
+                }</p>`
+          }
+          ${
+            hoursLogged >= weeklyComittedHours
+              ? `<p><b>Hours logged</b>: ${hoursLogged.toFixed(
+                  2,
+                )} / ${weeklyComittedHours}</p>`
+              : `<p style="color: red;"><b>Hours logged</b>: ${hoursLogged.toFixed(
+                  2,
+                )} / ${weeklyComittedHours}</p>`
+          }
           ${weeklySummaryMessage}
         </div>`;
       }
 
       // Necessary because our version of node is outdated
       // and doesn't have String.prototype.replaceAll
-      let emailString = [...(new Set(emails))].toString();
+      let emailString = [...new Set(emails)].toString();
       while (emailString.includes(',')) emailString = emailString.replace(',', '\n');
       while (emailString.includes('\n')) emailString = emailString.replace('\n', ', ');
 
@@ -187,7 +216,6 @@ const userHelper = function () {
       logger.logException(err);
     }
   };
-
 
   /**
    * This function will process the weeklySummaries array in the following way:
@@ -218,9 +246,13 @@ const userHelper = function () {
       .then(() => {
         if (hasWeeklySummary) {
           userProfile
-            .findByIdAndUpdate(personId, {
-              $inc: { weeklySummariesCount: 1 },
-            }, { new: true })
+            .findByIdAndUpdate(
+              personId,
+              {
+                $inc: { weeklySummariesCount: 1 },
+              },
+              { new: true },
+            )
             .catch(error => logger.logException(error));
         }
       })
@@ -238,13 +270,24 @@ const userHelper = function () {
     try {
       const currentFormattedDate = moment().tz('America/Los_Angeles').format();
 
-      logger.logInfo(`Job for assigning blue square for commitment not met starting at ${currentFormattedDate}`);
+      logger.logInfo(
+        `Job for assigning blue square for commitment not met starting at ${currentFormattedDate}`,
+      );
 
-      const pdtStartOfLastWeek = moment().tz('America/Los_Angeles').startOf('week').subtract(1, 'week');
+      const pdtStartOfLastWeek = moment()
+        .tz('America/Los_Angeles')
+        .startOf('week')
+        .subtract(1, 'week');
 
-      const pdtEndOfLastWeek = moment().tz('America/Los_Angeles').endOf('week').subtract(1, 'week');
+      const pdtEndOfLastWeek = moment()
+        .tz('America/Los_Angeles')
+        .endOf('week')
+        .subtract(1, 'week');
 
-      const users = await userProfile.find({ isActive: true }, '_id weeklySummaries');
+      const users = await userProfile.find(
+        { isActive: true },
+        '_id weeklySummaries',
+      );
 
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
@@ -253,7 +296,10 @@ const userHelper = function () {
 
         let hasWeeklySummary = false;
 
-        if (Array.isArray(user.weeklySummaries) && user.weeklySummaries.length) {
+        if (
+          Array.isArray(user.weeklySummaries)
+          && user.weeklySummaries.length
+        ) {
           const { summary } = user.weeklySummaries[0];
           if (summary) {
             hasWeeklySummary = true;
@@ -263,11 +309,15 @@ const userHelper = function () {
         //  This needs to run AFTER the check for weekly summary above because the summaries array will be updated/shifted after this function runs.
         await processWeeklySummariesByUserId(personId, hasWeeklySummary);
 
-        const results = await dashboardHelper.laborthisweek(personId, pdtStartOfLastWeek, pdtEndOfLastWeek);
+        const results = await dashboardHelper.laborthisweek(
+          personId,
+          pdtStartOfLastWeek,
+          pdtEndOfLastWeek,
+        );
 
         const { weeklyComittedHours, timeSpent_hrs: timeSpent } = results[0];
 
-        const timeNotMet = (timeSpent < weeklyComittedHours);
+        const timeNotMet = timeSpent < weeklyComittedHours;
         let description;
 
         const updateResult = await userProfile.findByIdAndUpdate(
@@ -293,12 +343,14 @@ const userHelper = function () {
           hasWeeklySummary = true;
         }
 
-        const cutOffDate = moment()
-          .subtract(1, 'year');
+        const cutOffDate = moment().subtract(1, 'year');
 
         const oldInfringements = [];
         for (let k = 0; k < updateResult?.infringements.length; k += 1) {
-          if (updateResult?.infringements && moment(updateResult?.infringements[k].date).diff(cutOffDate) >= 0) {
+          if (
+            updateResult?.infringements
+            && moment(updateResult?.infringements[k].date).diff(cutOffDate) >= 0
+          ) {
             oldInfringements.push(updateResult.infringements[k]);
           } else {
             break;
@@ -306,36 +358,46 @@ const userHelper = function () {
         }
 
         if (oldInfringements.length) {
-          userProfile
-            .findByIdAndUpdate(personId, {
+          userProfile.findByIdAndUpdate(
+            personId,
+            {
               $push: {
                 oldInfringements: { $each: oldInfringements, $slice: -10 },
               },
-            }, { new: true });
+            },
+            { new: true },
+          );
         }
 
-        if (timeNotMet || (!hasWeeklySummary)) {
+        if (timeNotMet || !hasWeeklySummary) {
           if (timeNotMet && !hasWeeklySummary) {
-            description = `System auto-assigned infringement for two reasons: not meeting weekly volunteer time commitment as well as not submitting a weekly summary. For the hours portion, you logged ${timeSpent} hours against committed effort of ${weeklyComittedHours} hours in the week starting ${pdtStartOfLastWeek.format('dddd YYYY-MM-DD')} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
+            description = `System auto-assigned infringement for two reasons: not meeting weekly volunteer time commitment as well as not submitting a weekly summary. For the hours portion, you logged ${timeSpent} hours against committed effort of ${weeklyComittedHours} hours in the week starting ${pdtStartOfLastWeek.format(
+              'dddd YYYY-MM-DD',
+            )} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
           } else if (timeNotMet) {
-            description = `System auto-assigned infringement for not meeting weekly volunteer time commitment. You logged ${timeSpent} hours against committed effort of ${weeklyComittedHours} hours in the week starting ${pdtStartOfLastWeek.format('dddd YYYY-MM-DD')} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
+            description = `System auto-assigned infringement for not meeting weekly volunteer time commitment. You logged ${timeSpent} hours against committed effort of ${weeklyComittedHours} hours in the week starting ${pdtStartOfLastWeek.format(
+              'dddd YYYY-MM-DD',
+            )} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
           } else {
-            description = `System auto-assigned infringement for not submitting a weekly summary for the week starting ${pdtStartOfLastWeek.format('dddd YYYY-MM-DD')} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
+            description = `System auto-assigned infringement for not submitting a weekly summary for the week starting ${pdtStartOfLastWeek.format(
+              'dddd YYYY-MM-DD',
+            )} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
           }
 
           const infringement = {
-            date: moment()
-              .utc()
-              .format('YYYY-MM-DD'),
+            date: moment().utc().format('YYYY-MM-DD'),
             description,
           };
 
-          const status = await userProfile
-            .findByIdAndUpdate(personId, {
+          const status = await userProfile.findByIdAndUpdate(
+            personId,
+            {
               $push: {
                 infringements: infringement,
               },
-            }, { new: true });
+            },
+            { new: true },
+          );
 
           emailSender(
             status.email,
@@ -350,14 +412,17 @@ const userHelper = function () {
             'onecommunityglobal@gmail.com',
           );
 
-          const categories = await dashboardHelper.laborThisWeekByCategory(personId, pdtStartOfLastWeek, pdtEndOfLastWeek);
+          const categories = await dashboardHelper.laborThisWeekByCategory(
+            personId,
+            pdtStartOfLastWeek,
+            pdtEndOfLastWeek,
+          );
 
           if (Array.isArray(categories) && categories.length > 0) {
-            await userProfile
-              .findOneAndUpdate(
-                { _id: personId, categoryTangibleHrs: { $exists: false } },
-                { $set: { categoryTangibleHrs: [] } },
-              );
+            await userProfile.findOneAndUpdate(
+              { _id: personId, categoryTangibleHrs: { $exists: false } },
+              { $set: { categoryTangibleHrs: [] } },
+            );
           } else {
             continue;
           }
@@ -369,28 +434,27 @@ const userHelper = function () {
               elem._id = 'Other';
             }
 
-            const updateResult2 = await userProfile
-              .findOneAndUpdate(
-                { _id: personId, 'categoryTangibleHrs.category': elem._id },
-                { $inc: { 'categoryTangibleHrs.$.hrs': elem.timeSpent_hrs } },
-                { new: true },
-              );
+            const updateResult2 = await userProfile.findOneAndUpdate(
+              { _id: personId, 'categoryTangibleHrs.category': elem._id },
+              { $inc: { 'categoryTangibleHrs.$.hrs': elem.timeSpent_hrs } },
+              { new: true },
+            );
 
             if (!updateResult2) {
-              await userProfile
-                .findOneAndUpdate(
-                  {
-                    _id: personId,
-                    'categoryTangibleHrs.category': { $ne: elem._id },
-                  },
-                  {
-                    $addToSet: {
-                      categoryTangibleHrs: {
-                        category: elem._id, hrs: elem.timeSpent_hrs,
-                      },
+              await userProfile.findOneAndUpdate(
+                {
+                  _id: personId,
+                  'categoryTangibleHrs.category': { $ne: elem._id },
+                },
+                {
+                  $addToSet: {
+                    categoryTangibleHrs: {
+                      category: elem._id,
+                      hrs: elem.timeSpent_hrs,
                     },
                   },
-                );
+                },
+              );
             }
           }
         }
@@ -404,7 +468,10 @@ const userHelper = function () {
       const inactiveUsers = await userProfile.find({ isActive: false }, '_id');
       for (let i = 0; i < inactiveUsers.length; i += 1) {
         const user = inactiveUsers[i];
-        await processWeeklySummariesByUserId(mongoose.Types.ObjectId(user._id), false);
+        await processWeeklySummariesByUserId(
+          mongoose.Types.ObjectId(user._id),
+          false,
+        );
       }
     } catch (err) {
       logger.logException(err);
@@ -414,12 +481,15 @@ const userHelper = function () {
   const deleteBlueSquareAfterYear = async () => {
     const currentFormattedDate = moment().tz('America/Los_Angeles').format();
 
-    logger.logInfo(`Job for deleting blue squares older than 1 year starting at ${currentFormattedDate}`);
+    logger.logInfo(
+      `Job for deleting blue squares older than 1 year starting at ${currentFormattedDate}`,
+    );
 
     const cutOffDate = moment().subtract(1, 'year').format('YYYY-MM-DD');
 
     try {
-      const results = await userProfile.updateMany({},
+      const results = await userProfile.updateMany(
+        {},
         {
           $pull: {
             infringements: {
@@ -428,7 +498,8 @@ const userHelper = function () {
               },
             },
           },
-        });
+        },
+      );
 
       logger.logInfo(results);
     } catch (err) {
@@ -439,11 +510,15 @@ const userHelper = function () {
   const reActivateUser = async () => {
     const currentFormattedDate = moment().tz('America/Los_Angeles').format();
 
-
-    logger.logInfo(`Job for activating users based on scheduled re-activation date starting at ${currentFormattedDate}`);
+    logger.logInfo(
+      `Job for activating users based on scheduled re-activation date starting at ${currentFormattedDate}`,
+    );
 
     try {
-      const users = await userProfile.find({ isActive: false, reactivationDate: { $exists: true } }, '_id isActive reactivationDate');
+      const users = await userProfile.find(
+        { isActive: false, reactivationDate: { $exists: true } },
+        '_id isActive reactivationDate',
+      );
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
         if (moment().isSameOrAfter(moment(user.reactivationDate))) {
@@ -456,13 +531,22 @@ const userHelper = function () {
               $unset: {
                 endDate: user.endDate,
               },
-            }, { new: true },
+            },
+            { new: true },
           );
-          logger.logInfo(`User with id: ${user._id} was re-acticated at ${moment().tz('America/Los_Angeles').format()}.`);
+          logger.logInfo(
+            `User with id: ${user._id} was re-acticated at ${moment()
+              .tz('America/Los_Angeles')
+              .format()}.`,
+          );
           const id = user._id;
           const person = await userProfile.findById(id);
           const endDate = moment(person.endDate).format('YYYY-MM-DD');
-          logger.logInfo(`User with id: ${user._id} was re-acticated at ${moment().format()}.`);
+          logger.logInfo(
+            `User with id: ${
+              user._id
+            } was re-acticated at ${moment().format()}.`,
+          );
           const subject = `IMPORTANT:${person.firstName} ${person.lastName} has been RE-activated in the Highest Good Network`;
 
           const emailBody = `<p> Hi Admin! </p>
@@ -510,7 +594,12 @@ const userHelper = function () {
       emailSender(
         emailAddress,
         'New Infringement Assigned',
-        getInfringementEmailBody(firstName, lastName, element, totalInfringements),
+        getInfringementEmailBody(
+          firstName,
+          lastName,
+          element,
+          totalInfringements,
+        ),
         null,
         'onecommunityglobal@gmail.com',
       );
@@ -519,56 +608,81 @@ const userHelper = function () {
 
   const replaceBadge = async function (personId, oldBadgeId, newBadgeId) {
     console.log('Replacing Badge', personId, oldBadgeId, newBadgeId);
-    userProfile.updateOne({ _id: personId, 'badgeCollection.badge': oldBadgeId },
-      { $set: { 'badgeCollection.$.badge': newBadgeId, 'badgeCollection.$.lastModified': Date.now().toString(), 'badgeCollection.$.count': 1 } },
+    userProfile.updateOne(
+      { _id: personId, 'badgeCollection.badge': oldBadgeId },
+      {
+        $set: {
+          'badgeCollection.$.badge': newBadgeId,
+          'badgeCollection.$.lastModified': Date.now().toString(),
+          'badgeCollection.$.count': 1,
+        },
+      },
       (err) => {
         if (err) {
           console.log(err);
         }
-      });
+      },
+    );
   };
 
   const increaseBadgeCount = async function (personId, badgeId) {
     console.log('Increase Badge Count', personId, badgeId);
-    userProfile.updateOne({ _id: personId, 'badgeCollection.badge': badgeId },
-      { $inc: { 'badgeCollection.$.count': 1 }, $set: { 'badgeCollection.$.lastModified': Date.now().toString() } },
+    userProfile.updateOne(
+      { _id: personId, 'badgeCollection.badge': badgeId },
+      {
+        $inc: { 'badgeCollection.$.count': 1 },
+        $set: { 'badgeCollection.$.lastModified': Date.now().toString() },
+      },
       (err) => {
         if (err) {
           console.log(err);
         }
-      });
+      },
+    );
   };
 
-  const addBadge = async function (personId, badgeId, count = 1, featured = false) {
+  const addBadge = async function (
+    personId,
+    badgeId,
+    count = 1,
+    featured = false,
+  ) {
     console.log('Adding Badge ', personId, badgeId, count);
-    userProfile.findByIdAndUpdate(personId,
+    userProfile.findByIdAndUpdate(
+      personId,
       {
-        $push:
-        {
+        $push: {
           badgeCollection: {
-            badge: badgeId, count, featured, lastModified: Date.now().toString(),
+            badge: badgeId,
+            count,
+            featured,
+            lastModified: Date.now().toString(),
           },
         },
-      }, (err) => {
+      },
+      (err) => {
         if (err) {
           console.log(err);
         }
-      });
+      },
+    );
   };
 
   const removeDupBadge = async function (personId, badgeId) {
     console.log('Removing Badge ', personId, badgeId);
-    userProfile.findByIdAndUpdate(personId,
+    userProfile.findByIdAndUpdate(
+      personId,
       {
-        $pull:
-        {
+        $pull: {
           badgeCollection: { badge: badgeId },
         },
-      }, (err) => {
+      },
+      (err) => {
         if (err) {
           console.log(err);
         }
-      });
+      },
+    );
   };
 
   const changeBadgeCount = async function (personId, badgeId, count) {
@@ -576,35 +690,71 @@ const userHelper = function () {
     if (count === 0) {
       removeDupBadge(personId, badgeId);
     } else {
-      userProfile.updateOne({ _id: personId, 'badgeCollection.badge': badgeId },
-        { $set: { 'badgeCollection.$.count': count, 'badgeCollection.$.lastModified': Date.now().toString() } },
+      userProfile.updateOne(
+        { _id: personId, 'badgeCollection.badge': badgeId },
+        {
+          $set: {
+            'badgeCollection.$.count': count,
+            'badgeCollection.$.lastModified': Date.now().toString(),
+          },
+        },
         (err) => {
           if (err) {
             console.log(err);
           }
-        });
+        },
+      );
     }
   };
 
-
   // remove the last badge you earned on this streak(not including 1)
-  const removePrevHrBadge = async function (personId, user, badgeCollection, hrs, weeks) {
+  const removePrevHrBadge = async function (
+    personId,
+    user,
+    badgeCollection,
+    hrs,
+    weeks,
+  ) {
     // Check each Streak Greater than One to check if it works
     if (weeks < 3) {
       return;
     }
     let removed = false;
-    await badge.aggregate([
-      { $match: { type: 'X Hours for X Week Streak', weeks: { $gt: 1, $lt: weeks }, totalHrs: hrs } },
-      { $sort: { weeks: -1, totalHrs: -1 } },
-      { $group: { _id: '$weeks', badges: { $push: { _id: '$_id', hrs: '$totalHrs', weeks: '$weeks' } } } },
-    ])
+    await badge
+      .aggregate([
+        {
+          $match: {
+            type: 'X Hours for X Week Streak',
+            weeks: { $gt: 1, $lt: weeks },
+            totalHrs: hrs,
+          },
+        },
+        { $sort: { weeks: -1, totalHrs: -1 } },
+        {
+          $group: {
+            _id: '$weeks',
+            badges: {
+              $push: { _id: '$_id', hrs: '$totalHrs', weeks: '$weeks' },
+            },
+          },
+        },
+      ])
       .then((results) => {
         results.forEach((streak) => {
           streak.badges.every((bdge) => {
             for (let i = 0; i < badgeCollection.length; i += 1) {
-              if (badgeCollection[i].badge?.type === 'X Hours for X Week Streak' && badgeCollection[i].badge?.weeks === bdge.weeks && bdge.hrs === hrs && !removed) {
-                changeBadgeCount(personId, badgeCollection[i].badge._id, badgeCollection[i].badge.count - 1);
+              if (
+                badgeCollection[i].badge?.type
+                  === 'X Hours for X Week Streak'
+                && badgeCollection[i].badge?.weeks === bdge.weeks
+                && bdge.hrs === hrs
+                && !removed
+              ) {
+                changeBadgeCount(
+                  personId,
+                  badgeCollection[i].badge._id,
+                  badgeCollection[i].badge.count - 1,
+                );
                 removed = true;
                 return false;
               }
@@ -616,21 +766,32 @@ const userHelper = function () {
   };
 
   //   'No Infringement Streak',
-  const checkNoInfringementStreak = async function (personId, user, badgeCollection) {
+  const checkNoInfringementStreak = async function (
+    personId,
+    user,
+    badgeCollection,
+  ) {
     let badgeOfType;
     for (let i = 0; i < badgeCollection.length; i += 1) {
       if (badgeCollection[i].badge?.type === 'No Infringement Streak') {
-        if (badgeOfType && badgeOfType.months <= badgeCollection[i].badge.months) {
+        if (
+          badgeOfType
+          && badgeOfType.months <= badgeCollection[i].badge.months
+        ) {
           removeDupBadge(personId, badgeOfType._id);
           badgeOfType = badgeCollection[i].badge;
-        } else if (badgeOfType && badgeOfType.months > badgeCollection[i].badge.months) {
+        } else if (
+          badgeOfType
+          && badgeOfType.months > badgeCollection[i].badge.months
+        ) {
           removeDupBadge(personId, badgeCollection[i].badge._id);
         } else if (!badgeOfType) {
           badgeOfType = badgeCollection[i].badge;
         }
       }
     }
-    await badge.find({ type: 'No Infringement Streak' })
+    await badge
+      .find({ type: 'No Infringement Streak' })
       .sort({ months: -1 })
       .then((results) => {
         if (!Array.isArray(results) || !results.length) {
@@ -641,11 +802,29 @@ const userHelper = function () {
           // Cannot account for time paused yet
 
           if (elem.months <= 12) {
-            if (moment().diff(moment(user.createdDate), 'months', true) >= elem.months) {
-              if (user.infringements.length === 0 || Math.abs(moment().diff(moment(user.infringements[user.infringements?.length - 1].date), 'months', true)) >= elem.months) {
+            if (
+              moment().diff(moment(user.createdDate), 'months', true)
+              >= elem.months
+            ) {
+              if (
+                user.infringements.length === 0
+                || Math.abs(
+                  moment().diff(
+                    moment(
+                      user.infringements[user.infringements?.length - 1].date,
+                    ),
+                    'months',
+                    true,
+                  ),
+                ) >= elem.months
+              ) {
                 if (badgeOfType) {
                   if (badgeOfType._id.toString() !== elem._id.toString()) {
-                    replaceBadge(personId, mongoose.Types.ObjectId(badgeOfType._id), mongoose.Types.ObjectId(elem._id));
+                    replaceBadge(
+                      personId,
+                      mongoose.Types.ObjectId(badgeOfType._id),
+                      mongoose.Types.ObjectId(elem._id),
+                    );
                   }
                   return false;
                 }
@@ -654,11 +833,31 @@ const userHelper = function () {
               }
             }
           } else if (user?.infringements?.length === 0) {
-            if (moment().diff(moment(user.createdDate), 'months', true) >= elem.months) {
-              if (user.oldinfringements.length === 0 || Math.abs(moment().diff(moment(user.oldinfringements[user.oldinfringements?.length - 1].date), 'months', true)) >= (elem.months - 12)) {
+            if (
+              moment().diff(moment(user.createdDate), 'months', true)
+              >= elem.months
+            ) {
+              if (
+                user.oldinfringements.length === 0
+                || Math.abs(
+                  moment().diff(
+                    moment(
+                      user.oldinfringements[user.oldinfringements?.length - 1]
+                        .date,
+                    ),
+                    'months',
+                    true,
+                  ),
+                )
+                  >= elem.months - 12
+              ) {
                 if (badgeOfType) {
                   if (badgeOfType._id.toString() !== elem._id.toString()) {
-                    replaceBadge(personId, mongoose.Types.ObjectId(badgeOfType._id), mongoose.Types.ObjectId(elem._id));
+                    replaceBadge(
+                      personId,
+                      mongoose.Types.ObjectId(badgeOfType._id),
+                      mongoose.Types.ObjectId(elem._id),
+                    );
                   }
                   return false;
                 }
@@ -673,23 +872,32 @@ const userHelper = function () {
   };
 
   // 'Minimum Hours Multiple',
-  const checkMinHoursMultiple = async function (personId, user, badgeCollection) {
+  const checkMinHoursMultiple = async function (
+    personId,
+    user,
+    badgeCollection,
+  ) {
     const badgesOfType = [];
     for (let i = 0; i < badgeCollection.length; i += 1) {
       if (badgeCollection[i].badge?.type === 'Minimum Hours Multiple') {
         badgesOfType.push(badgeCollection[i].badge);
       }
     }
-    await badge.find({ type: 'Minimum Hours Multiple' })
+    await badge
+      .find({ type: 'Minimum Hours Multiple' })
       .sort({ multiple: -1 })
       .then((results) => {
         if (!Array.isArray(results) || !results.length) {
           return;
         }
 
-        for (let i = 0; i < results.length; i += 1) { // this needs to be a for loop so that the returns break before assigning badges for lower multiples
+        for (let i = 0; i < results.length; i += 1) {
+          // this needs to be a for loop so that the returns break before assigning badges for lower multiples
           const elem = results[i]; // making variable elem accessible for below code
-          if ((user.lastWeekTangibleHrs / user.weeklyComittedHours) >= elem.multiple) {
+          if (
+            user.lastWeekTangibleHrs / user.weeklyComittedHours
+            >= elem.multiple
+          ) {
             let theBadge;
             for (let j = 0; j < badgesOfType.length; j += 1) {
               if (badgesOfType[j]._id.toString() === elem._id.toString()) {
@@ -722,16 +930,27 @@ const userHelper = function () {
         }
       }
     }
-    await badge.findOne({ type: 'Personal Max' })
-      .then((results) => {
-        if (user.lastWeekTangibleHrs && user.lastWeekTangibleHrs >= 1 && user.lastWeekTangibleHrs === user.personalBestMaxHrs) {
-          if (badgeOfType) {
-            changeBadgeCount(personId, mongoose.Types.ObjectId(badgeOfType._id), user.personalBestMaxHrs);
-          } else {
-            addBadge(personId, mongoose.Types.ObjectId(results._id), user.personalBestMaxHrs);
-          }
+    await badge.findOne({ type: 'Personal Max' }).then((results) => {
+      if (
+        user.lastWeekTangibleHrs
+        && user.lastWeekTangibleHrs >= 1
+        && user.lastWeekTangibleHrs === user.personalBestMaxHrs
+      ) {
+        if (badgeOfType) {
+          changeBadgeCount(
+            personId,
+            mongoose.Types.ObjectId(badgeOfType._id),
+            user.personalBestMaxHrs,
+          );
+        } else {
+          addBadge(
+            personId,
+            mongoose.Types.ObjectId(results._id),
+            user.personalBestMaxHrs,
+          );
         }
-      });
+      }
+    });
   };
 
   // 'Most Hrs in Week'
@@ -742,101 +961,100 @@ const userHelper = function () {
         badgeOfType = badgeCollection[i].badge;
       }
     }
-    await badge.findOne({ type: 'Most Hrs in Week' })
-      .then((results) => {
-        userProfile.aggregate([
+    await badge.findOne({ type: 'Most Hrs in Week' }).then((results) => {
+      userProfile
+        .aggregate([
           { $match: { isActive: true } },
           { $group: { _id: 1, maxHours: { $max: '$lastWeekTangibleHrs' } } },
-        ]).then((userResults) => {
-          if (user.lastWeekTangibleHrs && user.lastWeekTangibleHrs >= userResults[0].maxHours) {
+        ])
+        .then((userResults) => {
+          if (
+            user.lastWeekTangibleHrs
+            && user.lastWeekTangibleHrs >= userResults[0].maxHours
+          ) {
             if (badgeOfType) {
-              increaseBadgeCount(personId, mongoose.Types.ObjectId(badgeOfType._id));
+              increaseBadgeCount(
+                personId,
+                mongoose.Types.ObjectId(badgeOfType._id),
+              );
             } else {
               addBadge(personId, mongoose.Types.ObjectId(results._id));
             }
           }
         });
-      });
+    });
   };
 
   // 'X Hours for X Week Streak',
   const checkXHrsForXWeeks = async function (personId, user, badgeCollection) {
-    // Handle Increasing the 1 week streak badges
     const badgesOfType = [];
     for (let i = 0; i < badgeCollection.length; i += 1) {
       if (badgeCollection[i].badge?.type === 'X Hours for X Week Streak') {
         badgesOfType.push(badgeCollection[i].badge);
       }
     }
-    await badge.find({ type: 'X Hours for X Week Streak', weeks: 1 })
-      .sort({ totalHrs: -1 })
+    // lastWeekTangibleHrs is rounded to the integer's smallest tenth place.
+    const roundedTangibleHrs = Math.floor(user.lastWeekTangibleHrs / 10) * 10;
+
+    // get all the badges with weeks > 1 that are of the following type.
+    await badge
+      .aggregate([
+        { $match: { type: 'X Hours for X Week Streak', weeks: { $gte: 1 } } },
+        {
+          $group: {
+            _id: '$weeks',
+            badges: {
+              $push: { _id: '$_id', hrs: '$totalHrs', weeks: '$weeks' },
+            },
+          },
+        },
+        { $sort: { weeks: -1, totalHrs: -1 } },
+      ])
       .then((results) => {
-        results.every((elem) => {
-          if (elem.totalHrs <= user.lastWeekTangibleHrs) {
-            let theBadge;
-            for (let i = 0; i < badgesOfType.length; i += 1) {
-              if (badgesOfType[i]._id.toString() === elem._id.toString()) {
-                theBadge = badgesOfType[i]._id;
-                break;
-              }
-            }
-            if (theBadge) {
-              increaseBadgeCount(personId, mongoose.Types.ObjectId(theBadge));
-              return false;
-            }
-            addBadge(personId, mongoose.Types.ObjectId(elem._id));
-            return false;
-          }
-          return true;
-        });
-      });
-    // Check each Streak Greater than One to check if it works
-    await badge.aggregate([
-      { $match: { type: 'X Hours for X Week Streak', weeks: { $gt: 1 } } },
-      { $sort: { weeks: -1, totalHrs: -1 } },
-      { $group: { _id: '$weeks', badges: { $push: { _id: '$_id', hrs: '$totalHrs', weeks: '$weeks' } } } },
-    ])
-      .then((results) => {
-        let lastHr = -1;
         results.forEach((streak) => {
           streak.badges.every((bdge) => {
-            let badgeOfType;
-            for (let i = 0; i < badgeCollection.length; i += 1) {
-              if (badgeCollection[i].badge?.type === 'X Hours for X Week Streak' && badgeCollection[i].badge?.weeks === bdge.weeks) {
-                if (badgeOfType && badgeOfType.totalHrs <= badgeCollection[i].badge.totalHrs) {
-                  removeDupBadge(personId, badgeOfType._id);
-                  badgeOfType = badgeCollection[i].badge;
-                } else if (badgeOfType && badgeOfType.totalHrs > badgeCollection[i].badge.totalHrs) {
-                  removeDupBadge(personId, badgeCollection[i].badge._id);
-                } else if (!badgeOfType) {
-                  badgeOfType = badgeCollection[i].badge;
+            // only filter out badges that have total hours equal to a user's last week tangible hours.
+            if (bdge.hrs === roundedTangibleHrs) {
+              console.log('Badges', bdge);
+              let count = 0;
+              if (user.savedTangibleHrs.length >= bdge.weeks) {
+                const endOfArr = user.savedTangibleHrs.length - 1;
+                /* check tangible hours based on the last 200 weeks.
+                 *start the loop from the most recent week, and count the streak.
+                 */
+                for (let i = endOfArr; i >= 0; i--) {
+                  count++;
+                  console.log(user.savedTangibleHrs[i], i);
+                  if (user.savedTangibleHrs[i] < bdge.hrs) {
+                    count--;
+                    break;
+                  }
                 }
-              }
-            }
-            // check if it is possible to earn this streak
-            if (user.savedTangibleHrs.length >= bdge.weeks) {
-              let awardBadge = true;
-              const endOfArr = user.savedTangibleHrs.length - 1;
-              for (let i = endOfArr; i >= (endOfArr - bdge.weeks + 1); i -= 1) {
-                if (user.savedTangibleHrs[i] < bdge.hrs) {
-                  awardBadge = false;
-                  return true;
-                }
-              }
-              // if all checks for award badge are green double check that we havent already awarded a higher streak for the same number of hours
-              if (awardBadge && bdge.hrs > lastHr) {
-                lastHr = bdge.hrs;
-                if (badgeOfType && badgeOfType.totalHrs < bdge.hrs) {
-                  replaceBadge(personId, mongoose.Types.ObjectId(badgeOfType._id), mongoose.Types.ObjectId(bdge._id));
-                  removePrevHrBadge(personId, user, badgeCollection, bdge.hrs, bdge.weeks);
-                } else if (!badgeOfType) {
+
+                // if there's a badge with a streak that matches the count
+                if (count === bdge.weeks) {
+                  for (let i = 0; i < badgesOfType.length; i++) {
+                    if (badgesOfType[i].totalHrs === bdge.hrs) {
+                      if (badgesOfType[i].weeks < bdge.weeks) {
+                        removeDupBadge(
+                          personId,
+                          mongoose.Types.ObjectId(badgesOfType[i]._id),
+                        );
+                      }
+                    }
+                  }
+
+                  for (let i = 0; i < badgesOfType.length; i++) {
+                    if (
+                      badgesOfType[i]._id.toString() === bdge._id.toString()
+                    ) {
+                      return false;
+                    }
+                  }
+
                   addBadge(personId, mongoose.Types.ObjectId(bdge._id));
-                  removePrevHrBadge(personId, user, badgeCollection, bdge.hrs, bdge.weeks);
-                } else if (badgeOfType && badgeOfType.totalHrs === bdge.hrs) {
-                  increaseBadgeCount(personId, mongoose.Types.ObjectId(badgeOfType._id));
-                  removePrevHrBadge(personId, user, badgeCollection, bdge.hrs, bdge.weeks);
+                  return false;
                 }
-                return false;
               }
             }
             return true;
@@ -846,7 +1064,11 @@ const userHelper = function () {
   };
 
   // 'Lead a team of X+'
-  const checkLeadTeamOfXplus = async function (personId, user, badgeCollection) {
+  const checkLeadTeamOfXplus = async function (
+    personId,
+    user,
+    badgeCollection,
+  ) {
     if (!hasPermission(user.role, 'checkLeadTeamOfXplus')) {
       return;
     }
@@ -877,10 +1099,16 @@ const userHelper = function () {
     let badgeOfType;
     for (let i = 0; i < badgeCollection.length; i += 1) {
       if (badgeCollection[i].badge?.type === 'Lead a team of X+') {
-        if (badgeOfType && badgeOfType.people <= badgeCollection[i].badge.people) {
+        if (
+          badgeOfType
+          && badgeOfType.people <= badgeCollection[i].badge.people
+        ) {
           removeDupBadge(personId, badgeOfType._id);
           badgeOfType = badgeCollection[i].badge;
-        } else if (badgeOfType && badgeOfType.people > badgeCollection[i].badge.people) {
+        } else if (
+          badgeOfType
+          && badgeOfType.people > badgeCollection[i].badge.people
+        ) {
           removeDupBadge(personId, badgeCollection[i].badge._id);
         } else if (!badgeOfType) {
           badgeOfType = badgeCollection[i].badge;
@@ -888,7 +1116,8 @@ const userHelper = function () {
       }
     }
 
-    await badge.find({ type: 'Lead a team of X+' })
+    await badge
+      .find({ type: 'Lead a team of X+' })
       .sort({ people: -1 })
       .then((results) => {
         if (!Array.isArray(results) || !results.length) {
@@ -898,8 +1127,15 @@ const userHelper = function () {
         results.every((elem) => {
           if (teamMembers && teamMembers.length >= elem.people) {
             if (badgeOfType) {
-              if (badgeOfType._id.toString() !== elem._id.toString() && badgeOfType.people < elem.people) {
-                replaceBadge(personId, mongoose.Types.ObjectId(badgeOfType._id), mongoose.Types.ObjectId(elem._id));
+              if (
+                badgeOfType._id.toString() !== elem._id.toString()
+                && badgeOfType.people < elem.people
+              ) {
+                replaceBadge(
+                  personId,
+                  mongoose.Types.ObjectId(badgeOfType._id),
+                  mongoose.Types.ObjectId(elem._id),
+                );
               }
               return false;
             }
@@ -914,27 +1150,47 @@ const userHelper = function () {
   // 'Total Hrs in Category'
   const checkTotalHrsInCat = async function (personId, user, badgeCollection) {
     const categoryTangibleHrs = user.categoryTangibleHrs || [];
-    const categories = ['Food', 'Energy', 'Housing', 'Education', 'Society', 'Economics', 'Stewardship'];
+    const categories = [
+      'Food',
+      'Energy',
+      'Housing',
+      'Education',
+      'Society',
+      'Economics',
+      'Stewardship',
+    ];
     if (categoryTangibleHrs.length === 0) {
       return;
     }
 
     categories.forEach(async (category) => {
-      const categoryHrs = categoryTangibleHrs.find(elem => elem.category === category);
+      const categoryHrs = categoryTangibleHrs.find(
+        elem => elem.category === category,
+      );
       let badgeOfType;
       for (let i = 0; i < badgeCollection.length; i += 1) {
-        if (badgeCollection[i].badge?.type === 'Total Hrs in Category' && badgeCollection[i].badge?.category === category) {
-          if (badgeOfType && badgeOfType.totalHrs <= badgeCollection[i].badge.totalHrs) {
+        if (
+          badgeCollection[i].badge?.type === 'Total Hrs in Category'
+          && badgeCollection[i].badge?.category === category
+        ) {
+          if (
+            badgeOfType
+            && badgeOfType.totalHrs <= badgeCollection[i].badge.totalHrs
+          ) {
             removeDupBadge(personId, badgeOfType._id);
             badgeOfType = badgeCollection[i].badge;
-          } else if (badgeOfType && badgeOfType.totalHrs > badgeCollection[i].badge.totalHrs) {
+          } else if (
+            badgeOfType
+            && badgeOfType.totalHrs > badgeCollection[i].badge.totalHrs
+          ) {
             removeDupBadge(personId, badgeCollection[i].badge._id);
           } else if (!badgeOfType) {
             badgeOfType = badgeCollection[i].badge;
           }
         }
       }
-      await badge.find({ type: 'Total Hrs in Category', category })
+      await badge
+        .find({ type: 'Total Hrs in Category', category })
         .sort({ totalHrs: -1 })
         .then((results) => {
           if (!Array.isArray(results) || !results.length || !categoryHrs) {
@@ -944,8 +1200,15 @@ const userHelper = function () {
           results.every((elem) => {
             if (categoryHrs.hrs >= elem.totalHrs) {
               if (badgeOfType) {
-                if (badgeOfType._id.toString() !== elem._id.toString() && badgeOfType.totalHrs < elem.totalHrs) {
-                  replaceBadge(personId, mongoose.Types.ObjectId(badgeOfType._id), mongoose.Types.ObjectId(elem._id));
+                if (
+                  badgeOfType._id.toString() !== elem._id.toString()
+                  && badgeOfType.totalHrs < elem.totalHrs
+                ) {
+                  replaceBadge(
+                    personId,
+                    mongoose.Types.ObjectId(badgeOfType._id),
+                    mongoose.Types.ObjectId(elem._id),
+                  );
                 }
                 return false;
               }
@@ -993,16 +1256,30 @@ const userHelper = function () {
       .endOf('week')
       .format('YYYY-MM-DD');
 
-    return timeEntries.find({ personId: userId, dateOfWork: { $gte: pdtstart, $lte: pdtend }, isTangible: true }, 'totalSeconds')
+    return timeEntries
+      .find(
+        {
+          personId: userId,
+          dateOfWork: { $gte: pdtstart, $lte: pdtend },
+          isTangible: true,
+        },
+        'totalSeconds',
+      )
       .then((results) => {
-        const totalTangibleWeeklySeconds = results.reduce((acc, { totalSeconds }) => acc + totalSeconds, 0);
+        const totalTangibleWeeklySeconds = results.reduce(
+          (acc, { totalSeconds }) => acc + totalSeconds,
+          0,
+        );
         return (totalTangibleWeeklySeconds / 3600).toFixed(2);
       });
   };
 
   const deActivateUser = async () => {
     try {
-      const users = await userProfile.find({ isActive: true, endDate: { $exists: true } }, '_id isActive endDate');
+      const users = await userProfile.find(
+        { isActive: true, endDate: { $exists: true } },
+        '_id isActive endDate',
+      );
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
         const { endDate } = user;
@@ -1018,14 +1295,18 @@ const userHelper = function () {
           const id = user._id;
           const person = await userProfile.findById(id);
           const lastDay = moment(person.endDate).format('YYYY-MM-DD');
-          logger.logInfo(`User with id: ${user._id} was de-acticated at ${moment().format()}.`);
+          logger.logInfo(
+            `User with id: ${
+              user._id
+            } was de-acticated at ${moment().format()}.`,
+          );
           const subject = `IMPORTANT:${person.firstName} ${person.lastName} has been deactivated in the Highest Good Network`;
 
           const emailBody = `<p> Hi Admin! </p>
 
           <p>This email is to let you know that ${person.firstName} ${person.lastName} has completed their scheduled last day (${lastDay}) and been deactivated in the Highest Good Network application. </p>
           
-          <p>This is their email from the system: ${person.email }. Please email them to let them know their work is complete and thank them for their volunteer time with One Community. </p>
+          <p>This is their email from the system: ${person.email}. Please email them to let them know their work is complete and thank them for their volunteer time with One Community. </p>
           
           <p> Thanks! </p>
           


### PR DESCRIPTION
This is a bugfix for auto-assignment of XhoursForXWeeks streak. The new changes in the code enables the following:

If it is a streak of the same number (i.e. 3-week 40 hour streak being replaced by a 4-week 40-hour streak), then the previous one should drop off because the badge would be a continuation of the previous badge. 

If, however, the badge is a NEW streak (i.e. 50-hour streak started, but they already had a 40-hour streak), then they should still keep the 40-hour streak because that was a different accomplishment. 

And nobody should ever earn two different streaks the same week... meaning earning a 50-hour streak should not also earn you a 40-hour streak, you should only always earn the highest number. 

Note:- It will not increase the badge count of a similar streak.

 It does not block an admin from manually assigning any number of such badges, and thus may also enable duplicate creation of badges. However, it will remove the duplicate and wrong streak badges that were manually assigned every new week on Sunday.