### PR TITLE
Xhours forx weeks

### DIFF
--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -926,7 +926,6 @@ const userHelper = function () {
           streak.badges.every((bdge) => {
             // only filter out badges that have total hours equal to a user's last week tangible hours.
             if (bdge.hrs === roundedTangibleHrs) {
-              console.log('Badges', bdge);
               let count = 0;
               if (user.savedTangibleHrs.length >= bdge.weeks) {
                 const endOfArr = user.savedTangibleHrs.length - 1;

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -1,59 +1,60 @@
-const mongoose = require('mongoose');
-const moment = require('moment-timezone');
-const _ = require('lodash');
-const userProfile = require('../models/userProfile');
-const timeEntries = require('../models/timeentry');
-const badge = require('../models/badge');
-const myTeam = require('./helperModels/myTeam');
-const dashboardHelper = require('./dashboardhelper')();
-const reportHelper = require('./reporthelper')();
+const mongoose = require("mongoose");
+const moment = require("moment-timezone");
+const _ = require("lodash");
+const userProfile = require("../models/userProfile");
+const timeEntries = require("../models/timeentry");
+const badge = require("../models/badge");
+const myTeam = require("./helperModels/myTeam");
+const dashboardHelper = require("./dashboardhelper")();
+const reportHelper = require("./reporthelper")();
 
-const emailSender = require('../utilities/emailSender');
+const emailSender = require("../utilities/emailSender");
 
-const logger = require('../startup/logger');
-const hasPermission = require('../utilities/permissions');
+const logger = require("../startup/logger");
+const hasPermission = require("../utilities/permissions");
 
 const userHelper = function () {
   const getTeamMembers = function (user) {
     const userId = mongoose.Types.ObjectId(user._id);
     // var teamid = userdetails.teamId;
     return myTeam.findById(userId).select({
-      'myTeam._id': 1,
-      'myTeam.role': 1,
-      'myTeam.fullName': 1,
+      "myTeam._id": 1,
+      "myTeam.role": 1,
+      "myTeam.fullName": 1,
       _id: 0,
     });
   };
 
   const getUserName = async function (userId) {
     const userid = mongoose.Types.ObjectId(userId);
-    return userProfile.findById(userid, 'firstName lastName');
+    return userProfile.findById(userid, "firstName lastName");
   };
 
   const validateProfilePic = function (profilePic) {
-    const picParts = profilePic.split('base64');
+    const picParts = profilePic.split("base64");
     let result = true;
     const errors = [];
 
     if (picParts.length < 2) {
       return {
         result: false,
-        errors: 'Invalid image',
+        errors: "Invalid image",
       };
     }
 
     // validate size
     const imageSize = picParts[1].length;
-    const sizeInBytes = (4 * Math.ceil(imageSize / 3) * 0.5624896334383812) / 1024;
+    const sizeInBytes =
+      (4 * Math.ceil(imageSize / 3) * 0.5624896334383812) / 1024;
 
     if (sizeInBytes > 50) {
-      errors.push('Image size should not exceed 50KB');
+      errors.push("Image size should not exceed 50KB");
       result = false;
     }
 
-    const imageType = picParts[0].split('/')[1];
-    if (imageType !== 'jpeg;' && imageType !== 'png;') {
-      errors.push('Image type shoud be either jpeg or png.');
+    const imageType = picParts[0].split("/")[1];
+    if (imageType !== "jpeg;" && imageType !== "png;") {
+      errors.push("Image type shoud be either jpeg or png.");
       result = false;
     }
 
@@ -67,7 +68,7 @@ const userHelper = function () {
     firstName,
     lastName,
     infringement,
-    totalInfringements,
+    totalInfringements
   ) {
     const text = `Dear <b>${firstName} ${lastName}</b>,
         <p>Oops, it looks like something happened and you’ve managed to get a blue square.</p>
@@ -93,10 +94,10 @@ const userHelper = function () {
    * @return {void}
    */
   const emailWeeklySummariesForAllUsers = async (weekIndex = 1) => {
-    const currentFormattedDate = moment().tz('America/Los_Angeles').format();
+    const currentFormattedDate = moment().tz("America/Los_Angeles").format();
 
     logger.logInfo(
-      `Job for emailing all users' weekly summaries starting at ${currentFormattedDate}`,
+      `Job for emailing all users' weekly summaries starting at ${currentFormattedDate}`
     );
 
     const emails = [];
@@ -104,15 +105,19 @@ const userHelper = function () {
     try {
       const results = await reportHelper.weeklySummaries(weekIndex, weekIndex);
 
-      let emailBody = '<h2>Weekly Summaries for all active users:</h2>';
+      let emailBody = "<h2>Weekly Summaries for all active users:</h2>";
 
-      const weeklySummaryNotProvidedMessage = '<div><b>Weekly Summary:</b> <span style="color: red;"> Not provided! </span> </div>';
+      const weeklySummaryNotProvidedMessage =
+        '<div><b>Weekly Summary:</b> <span style="color: red;"> Not provided! </span> </div>';
 
-      const weeklySummaryNotRequiredMessage = '<div><b>Weekly Summary:</b> <span style="color: magenta;"> Not required for this user </span></div>';
+      const weeklySummaryNotRequiredMessage =
+        '<div><b>Weekly Summary:</b> <span style="color: magenta;"> Not required for this user </span></div>';
 
-      results.sort((a, b) => `${a.firstName} ${a.lastName}`.localeCompare(
-          `${b.firstName} ${b.lastname}`,
-        ));
+      results.sort((a, b) =>
+        `${a.firstName} ${a.lastName}`.localeCompare(
+          `${b.firstName} ${b.lastname}`
+        )
+      );
 
       for (let i = 0; i < results.length; i += 1) {
         const result = results[i];
@@ -138,7 +143,7 @@ const userHelper = function () {
 
         const mediaUrlLink = mediaUrl
           ? `<a href="${mediaUrl}">${mediaUrl}</a>`
-          : 'Not provided!';
+          : "Not provided!";
 
         let weeklySummaryMessage = weeklySummaryNotProvidedMessage;
 
@@ -150,8 +155,8 @@ const userHelper = function () {
               <div>
                 <b>Weekly Summary</b>
                 (for the week ending on <b>${moment(dueDate)
-                  .tz('America/Los_Angeles')
-                  .format('YYYY-MMM-DD')}</b>):
+                  .tz("America/Los_Angeles")
+                  .format("YYYY-MMM-DD")}</b>):
               </div>
               <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}">
                 ${summary}
@@ -175,16 +180,16 @@ const userHelper = function () {
             weeklySummariesCount === 8
               ? `<p style="color: blue;"><b>Total Valid Weekly Summaries: ${weeklySummariesCount}</b></p>`
               : `<p><b>Total Valid Weekly Summaries</b>: ${
-                  weeklySummariesCount || 'No valid submissions yet!'
+                  weeklySummariesCount || "No valid submissions yet!"
                 }</p>`
           }
           ${
             hoursLogged >= weeklyComittedHours
               ? `<p><b>Hours logged</b>: ${hoursLogged.toFixed(
-                  2,
+                  2
                 )} / ${weeklyComittedHours}</p>`
               : `<p style="color: red;"><b>Hours logged</b>: ${hoursLogged.toFixed(
-                  2,
+                  2
                 )} / ${weeklyComittedHours}</p>`
           }
           ${weeklySummaryMessage}
@@ -194,8 +199,10 @@ const userHelper = function () {
       // Necessary because our version of node is outdated
       // and doesn't have String.prototype.replaceAll
       let emailString = [...new Set(emails)].toString();
-      while (emailString.includes(',')) emailString = emailString.replace(',', '\n');
-      while (emailString.includes('\n')) emailString = emailString.replace('\n', ', ');
+      while (emailString.includes(","))
+        emailString = emailString.replace(",", "\n");
+      while (emailString.includes("\n"))
+        emailString = emailString.replace("\n", ", ");
 
       emailBody += `\n
         <div>
@@ -207,10 +214,10 @@ const userHelper = function () {
       `;
 
       emailSender(
-        'onecommunityglobal@gmail.com, sangam.pravah@gmail.com, onecommunityhospitality@gmail.com',
-        'Weekly Summaries for all active users...',
+        "onecommunityglobal@gmail.com, sangam.pravah@gmail.com, onecommunityhospitality@gmail.com",
+        "Weekly Summaries for all active users...",
         emailBody,
-        null,
+        null
       );
     } catch (err) {
       logger.logException(err);
@@ -234,8 +241,8 @@ const userHelper = function () {
           weeklySummaries: {
             $each: [
               {
-                dueDate: moment().tz('America/Los_Angeles').endOf('week'),
-                summary: '',
+                dueDate: moment().tz("America/Los_Angeles").endOf("week"),
+                summary: "",
               },
             ],
             $position: 0,
@@ -251,12 +258,12 @@ const userHelper = function () {
               {
                 $inc: { weeklySummariesCount: 1 },
               },
-              { new: true },
+              { new: true }
             )
-            .catch(error => logger.logException(error));
+            .catch((error) => logger.logException(error));
         }
       })
-      .catch(error => logger.logException(error));
+      .catch((error) => logger.logException(error));
   };
 
   /**
@@ -268,25 +275,25 @@ const userHelper = function () {
    */
   const assignBlueSquareForTimeNotMet = async () => {
     try {
-      const currentFormattedDate = moment().tz('America/Los_Angeles').format();
+      const currentFormattedDate = moment().tz("America/Los_Angeles").format();
 
       logger.logInfo(
-        `Job for assigning blue square for commitment not met starting at ${currentFormattedDate}`,
+        `Job for assigning blue square for commitment not met starting at ${currentFormattedDate}`
       );
 
       const pdtStartOfLastWeek = moment()
-        .tz('America/Los_Angeles')
-        .startOf('week')
-        .subtract(1, 'week');
+        .tz("America/Los_Angeles")
+        .startOf("week")
+        .subtract(1, "week");
 
       const pdtEndOfLastWeek = moment()
-        .tz('America/Los_Angeles')
-        .endOf('week')
-        .subtract(1, 'week');
+        .tz("America/Los_Angeles")
+        .endOf("week")
+        .subtract(1, "week");
 
       const users = await userProfile.find(
         { isActive: true },
-        '_id weeklySummaries',
+        "_id weeklySummaries"
       );
 
       for (let i = 0; i < users.length; i += 1) {
@@ -297,8 +304,8 @@ const userHelper = function () {
         let hasWeeklySummary = false;
 
         if (
-          Array.isArray(user.weeklySummaries)
-          && user.weeklySummaries.length
+          Array.isArray(user.weeklySummaries) &&
+          user.weeklySummaries.length
         ) {
           const { summary } = user.weeklySummaries[0];
           if (summary) {
@@ -312,7 +319,7 @@ const userHelper = function () {
         const results = await dashboardHelper.laborthisweek(
           personId,
           pdtStartOfLastWeek,
-          pdtEndOfLastWeek,
+          pdtEndOfLastWeek
         );
 
         const { weeklyComittedHours, timeSpent_hrs: timeSpent } = results[0];
@@ -336,20 +343,20 @@ const userHelper = function () {
               lastWeekTangibleHrs: timeSpent || 0,
             },
           },
-          { new: true },
+          { new: true }
         );
 
         if (updateResult?.weeklySummaryNotReq) {
           hasWeeklySummary = true;
         }
 
-        const cutOffDate = moment().subtract(1, 'year');
+        const cutOffDate = moment().subtract(1, "year");
 
         const oldInfringements = [];
         for (let k = 0; k < updateResult?.infringements.length; k += 1) {
           if (
-            updateResult?.infringements
-            && moment(updateResult?.infringements[k].date).diff(cutOffDate) >= 0
+            updateResult?.infringements &&
+            moment(updateResult?.infringements[k].date).diff(cutOffDate) >= 0
           ) {
             oldInfringements.push(updateResult.infringements[k]);
           } else {
@@ -365,27 +372,27 @@ const userHelper = function () {
                 oldInfringements: { $each: oldInfringements, $slice: -10 },
               },
             },
-            { new: true },
+            { new: true }
           );
         }
 
         if (timeNotMet || !hasWeeklySummary) {
           if (timeNotMet && !hasWeeklySummary) {
             description = `System auto-assigned infringement for two reasons: not meeting weekly volunteer time commitment as well as not submitting a weekly summary. For the hours portion, you logged ${timeSpent} hours against committed effort of ${weeklyComittedHours} hours in the week starting ${pdtStartOfLastWeek.format(
-              'dddd YYYY-MM-DD',
-            )} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
+              "dddd YYYY-MM-DD"
+            )} and ending ${pdtEndOfLastWeek.format("dddd YYYY-MM-DD")}.`;
           } else if (timeNotMet) {
             description = `System auto-assigned infringement for not meeting weekly volunteer time commitment. You logged ${timeSpent} hours against committed effort of ${weeklyComittedHours} hours in the week starting ${pdtStartOfLastWeek.format(
-              'dddd YYYY-MM-DD',
-            )} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
+              "dddd YYYY-MM-DD"
+            )} and ending ${pdtEndOfLastWeek.format("dddd YYYY-MM-DD")}.`;
           } else {
             description = `System auto-assigned infringement for not submitting a weekly summary for the week starting ${pdtStartOfLastWeek.format(
-              'dddd YYYY-MM-DD',
-            )} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
+              "dddd YYYY-MM-DD"
+            )} and ending ${pdtEndOfLastWeek.format("dddd YYYY-MM-DD")}.`;
           }
 
           const infringement = {
-            date: moment().utc().format('YYYY-MM-DD'),
+            date: moment().utc().format("YYYY-MM-DD"),
             description,
           };
 
@@ -396,32 +403,32 @@ const userHelper = function () {
                 infringements: infringement,
               },
             },
-            { new: true },
+            { new: true }
           );
 
           emailSender(
             status.email,
-            'New Infringement Assigned',
+            "New Infringement Assigned",
             getInfringementEmailBody(
               status.firstName,
               status.lastName,
               infringement,
-              status.infringements.length,
+              status.infringements.length
             ),
             null,
-            'onecommunityglobal@gmail.com',
+            "onecommunityglobal@gmail.com"
           );
 
           const categories = await dashboardHelper.laborThisWeekByCategory(
             personId,
             pdtStartOfLastWeek,
-            pdtEndOfLastWeek,
+            pdtEndOfLastWeek
           );
 
           if (Array.isArray(categories) && categories.length > 0) {
             await userProfile.findOneAndUpdate(
               { _id: personId, categoryTangibleHrs: { $exists: false } },
-              { $set: { categoryTangibleHrs: [] } },
+              { $set: { categoryTangibleHrs: [] } }
             );
           } else {
             continue;
@@ -431,20 +438,20 @@ const userHelper = function () {
             const elem = categories[j];
 
             if (elem._id == null) {
-              elem._id = 'Other';
+              elem._id = "Other";
             }
 
             const updateResult2 = await userProfile.findOneAndUpdate(
-              { _id: personId, 'categoryTangibleHrs.category': elem._id },
-              { $inc: { 'categoryTangibleHrs.$.hrs': elem.timeSpent_hrs } },
-              { new: true },
+              { _id: personId, "categoryTangibleHrs.category": elem._id },
+              { $inc: { "categoryTangibleHrs.$.hrs": elem.timeSpent_hrs } },
+              { new: true }
             );
 
             if (!updateResult2) {
               await userProfile.findOneAndUpdate(
                 {
                   _id: personId,
-                  'categoryTangibleHrs.category': { $ne: elem._id },
+                  "categoryTangibleHrs.category": { $ne: elem._id },
                 },
                 {
                   $addToSet: {
@@ -453,7 +460,7 @@ const userHelper = function () {
                       hrs: elem.timeSpent_hrs,
                     },
                   },
-                },
+                }
               );
             }
           }
@@ -465,12 +472,12 @@ const userHelper = function () {
 
     // processWeeklySummaries for nonActive users
     try {
-      const inactiveUsers = await userProfile.find({ isActive: false }, '_id');
+      const inactiveUsers = await userProfile.find({ isActive: false }, "_id");
       for (let i = 0; i < inactiveUsers.length; i += 1) {
         const user = inactiveUsers[i];
         await processWeeklySummariesByUserId(
           mongoose.Types.ObjectId(user._id),
-          false,
+          false
         );
       }
     } catch (err) {
@@ -479,13 +486,13 @@ const userHelper = function () {
   };
 
   const deleteBlueSquareAfterYear = async () => {
-    const currentFormattedDate = moment().tz('America/Los_Angeles').format();
+    const currentFormattedDate = moment().tz("America/Los_Angeles").format();
 
     logger.logInfo(
-      `Job for deleting blue squares older than 1 year starting at ${currentFormattedDate}`,
+      `Job for deleting blue squares older than 1 year starting at ${currentFormattedDate}`
     );
 
-    const cutOffDate = moment().subtract(1, 'year').format('YYYY-MM-DD');
+    const cutOffDate = moment().subtract(1, "year").format("YYYY-MM-DD");
 
     try {
       const results = await userProfile.updateMany(
@@ -498,7 +505,7 @@ const userHelper = function () {
               },
             },
           },
-        },
+        }
       );
 
       logger.logInfo(results);
@@ -508,16 +515,16 @@ const userHelper = function () {
   };
 
   const reActivateUser = async () => {
-    const currentFormattedDate = moment().tz('America/Los_Angeles').format();
+    const currentFormattedDate = moment().tz("America/Los_Angeles").format();
 
     logger.logInfo(
-      `Job for activating users based on scheduled re-activation date starting at ${currentFormattedDate}`,
+      `Job for activating users based on scheduled re-activation date starting at ${currentFormattedDate}`
     );
 
     try {
       const users = await userProfile.find(
         { isActive: false, reactivationDate: { $exists: true } },
-        '_id isActive reactivationDate',
+        "_id isActive reactivationDate"
       );
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
@@ -532,20 +539,20 @@ const userHelper = function () {
                 endDate: user.endDate,
               },
             },
-            { new: true },
+            { new: true }
           );
           logger.logInfo(
             `User with id: ${user._id} was re-acticated at ${moment()
-              .tz('America/Los_Angeles')
-              .format()}.`,
+              .tz("America/Los_Angeles")
+              .format()}.`
           );
           const id = user._id;
           const person = await userProfile.findById(id);
-          const endDate = moment(person.endDate).format('YYYY-MM-DD');
+          const endDate = moment(person.endDate).format("YYYY-MM-DD");
           logger.logInfo(
             `User with id: ${
               user._id
-            } was re-acticated at ${moment().format()}.`,
+            } was re-acticated at ${moment().format()}.`
           );
           const subject = `IMPORTANT:${person.firstName} ${person.lastName} has been RE-activated in the Highest Good Network`;
 
@@ -560,11 +567,11 @@ const userHelper = function () {
           <p>The HGN A.I. (and One Community)</p>`;
 
           emailSender(
-            'onecommunityglobal@gmail.com',
+            "onecommunityglobal@gmail.com",
             subject,
             emailBody,
             null,
-            null,
+            null
           );
         }
       }
@@ -578,7 +585,7 @@ const userHelper = function () {
     current,
     firstName,
     lastName,
-    emailAddress,
+    emailAddress
   ) {
     if (!current) return;
     const newOriginal = original.toObject();
@@ -588,56 +595,56 @@ const userHelper = function () {
     newInfringements = _.differenceWith(
       newCurrent,
       newOriginal,
-      (arrVal, othVal) => arrVal._id.equals(othVal._id),
+      (arrVal, othVal) => arrVal._id.equals(othVal._id)
     );
     newInfringements.forEach((element) => {
       emailSender(
         emailAddress,
-        'New Infringement Assigned',
+        "New Infringement Assigned",
         getInfringementEmailBody(
           firstName,
           lastName,
           element,
-          totalInfringements,
+          totalInfringements
         ),
         null,
-        'onecommunityglobal@gmail.com',
+        "onecommunityglobal@gmail.com"
       );
     });
   };
 
   const replaceBadge = async function (personId, oldBadgeId, newBadgeId) {
-    console.log('Replacing Badge', personId, oldBadgeId, newBadgeId);
+    console.log("Replacing Badge", personId, oldBadgeId, newBadgeId);
     userProfile.updateOne(
-      { _id: personId, 'badgeCollection.badge': oldBadgeId },
+      { _id: personId, "badgeCollection.badge": oldBadgeId },
       {
         $set: {
-          'badgeCollection.$.badge': newBadgeId,
-          'badgeCollection.$.lastModified': Date.now().toString(),
-          'badgeCollection.$.count': 1,
+          "badgeCollection.$.badge": newBadgeId,
+          "badgeCollection.$.lastModified": Date.now().toString(),
+          "badgeCollection.$.count": 1,
         },
       },
       (err) => {
         if (err) {
           console.log(err);
         }
-      },
+      }
     );
   };
 
   const increaseBadgeCount = async function (personId, badgeId) {
-    console.log('Increase Badge Count', personId, badgeId);
+    console.log("Increase Badge Count", personId, badgeId);
     userProfile.updateOne(
-      { _id: personId, 'badgeCollection.badge': badgeId },
+      { _id: personId, "badgeCollection.badge": badgeId },
       {
-        $inc: { 'badgeCollection.$.count': 1 },
-        $set: { 'badgeCollection.$.lastModified': Date.now().toString() },
+        $inc: { "badgeCollection.$.count": 1 },
+        $set: { "badgeCollection.$.lastModified": Date.now().toString() },
       },
       (err) => {
         if (err) {
           console.log(err);
         }
-      },
+      }
     );
   };
 
@@ -645,9 +652,9 @@ const userHelper = function () {
     personId,
     badgeId,
     count = 1,
-    featured = false,
+    featured = false
   ) {
-    console.log('Adding Badge ', personId, badgeId, count);
+    console.log("Adding Badge ", personId, badgeId, count);
     userProfile.findByIdAndUpdate(
       personId,
       {
@@ -664,12 +671,12 @@ const userHelper = function () {
         if (err) {
           console.log(err);
         }
-      },
+      }
     );
   };
 
   const removeDupBadge = async function (personId, badgeId) {
-    console.log('Removing Badge ', personId, badgeId);
+    console.log("Removing Badge ", personId, badgeId);
     userProfile.findByIdAndUpdate(
       personId,
       {
@@ -681,28 +688,28 @@ const userHelper = function () {
         if (err) {
           console.log(err);
         }
-      },
+      }
     );
   };
 
   const changeBadgeCount = async function (personId, badgeId, count) {
-    console.log('Changing Badge Count', personId, badgeId, count);
+    console.log("Changing Badge Count", personId, badgeId, count);
     if (count === 0) {
       removeDupBadge(personId, badgeId);
     } else {
       userProfile.updateOne(
-        { _id: personId, 'badgeCollection.badge': badgeId },
+        { _id: personId, "badgeCollection.badge": badgeId },
         {
           $set: {
-            'badgeCollection.$.count': count,
-            'badgeCollection.$.lastModified': Date.now().toString(),
+            "badgeCollection.$.count": count,
+            "badgeCollection.$.lastModified": Date.now().toString(),
           },
         },
         (err) => {
           if (err) {
             console.log(err);
           }
-        },
+        }
       );
     }
   };
@@ -713,7 +720,7 @@ const userHelper = function () {
     user,
     badgeCollection,
     hrs,
-    weeks,
+    weeks
   ) {
     // Check each Streak Greater than One to check if it works
     if (weeks < 3) {
@@ -724,7 +731,7 @@ const userHelper = function () {
       .aggregate([
         {
           $match: {
-            type: 'X Hours for X Week Streak',
+            type: "X Hours for X Week Streak",
             weeks: { $gt: 1, $lt: weeks },
             totalHrs: hrs,
           },
@@ -732,9 +739,9 @@ const userHelper = function () {
         { $sort: { weeks: -1, totalHrs: -1 } },
         {
           $group: {
-            _id: '$weeks',
+            _id: "$weeks",
             badges: {
-              $push: { _id: '$_id', hrs: '$totalHrs', weeks: '$weeks' },
+              $push: { _id: "$_id", hrs: "$totalHrs", weeks: "$weeks" },
             },
           },
         },
@@ -744,16 +751,16 @@ const userHelper = function () {
           streak.badges.every((bdge) => {
             for (let i = 0; i < badgeCollection.length; i += 1) {
               if (
-                badgeCollection[i].badge?.type
-                  === 'X Hours for X Week Streak'
-                && badgeCollection[i].badge?.weeks === bdge.weeks
-                && bdge.hrs === hrs
-                && !removed
+                badgeCollection[i].badge?.type ===
+                  "X Hours for X Week Streak" &&
+                badgeCollection[i].badge?.weeks === bdge.weeks &&
+                bdge.hrs === hrs &&
+                !removed
               ) {
                 changeBadgeCount(
                   personId,
                   badgeCollection[i].badge._id,
-                  badgeCollection[i].badge.count - 1,
+                  badgeCollection[i].badge.count - 1
                 );
                 removed = true;
                 return false;
@@ -769,20 +776,20 @@ const userHelper = function () {
   const checkNoInfringementStreak = async function (
     personId,
     user,
-    badgeCollection,
+    badgeCollection
   ) {
     let badgeOfType;
     for (let i = 0; i < badgeCollection.length; i += 1) {
-      if (badgeCollection[i].badge?.type === 'No Infringement Streak') {
+      if (badgeCollection[i].badge?.type === "No Infringement Streak") {
         if (
-          badgeOfType
-          && badgeOfType.months <= badgeCollection[i].badge.months
+          badgeOfType &&
+          badgeOfType.months <= badgeCollection[i].badge.months
         ) {
           removeDupBadge(personId, badgeOfType._id);
           badgeOfType = badgeCollection[i].badge;
         } else if (
-          badgeOfType
-          && badgeOfType.months > badgeCollection[i].badge.months
+          badgeOfType &&
+          badgeOfType.months > badgeCollection[i].badge.months
         ) {
           removeDupBadge(personId, badgeCollection[i].badge._id);
         } else if (!badgeOfType) {
@@ -791,7 +798,7 @@ const userHelper = function () {
       }
     }
     await badge
-      .find({ type: 'No Infringement Streak' })
+      .find({ type: "No Infringement Streak" })
       .sort({ months: -1 })
       .then((results) => {
         if (!Array.isArray(results) || !results.length) {
@@ -803,19 +810,19 @@ const userHelper = function () {
 
           if (elem.months <= 12) {
             if (
-              moment().diff(moment(user.createdDate), 'months', true)
-              >= elem.months
+              moment().diff(moment(user.createdDate), "months", true) >=
+              elem.months
             ) {
               if (
-                user.infringements.length === 0
-                || Math.abs(
+                user.infringements.length === 0 ||
+                Math.abs(
                   moment().diff(
                     moment(
-                      user.infringements[user.infringements?.length - 1].date,
+                      user.infringements[user.infringements?.length - 1].date
                     ),
-                    'months',
-                    true,
-                  ),
+                    "months",
+                    true
+                  )
                 ) >= elem.months
               ) {
                 if (badgeOfType) {
@@ -823,7 +830,7 @@ const userHelper = function () {
                     replaceBadge(
                       personId,
                       mongoose.Types.ObjectId(badgeOfType._id),
-                      mongoose.Types.ObjectId(elem._id),
+                      mongoose.Types.ObjectId(elem._id)
                     );
                   }
                   return false;
@@ -834,29 +841,29 @@ const userHelper = function () {
             }
           } else if (user?.infringements?.length === 0) {
             if (
-              moment().diff(moment(user.createdDate), 'months', true)
-              >= elem.months
+              moment().diff(moment(user.createdDate), "months", true) >=
+              elem.months
             ) {
               if (
-                user.oldinfringements.length === 0
-                || Math.abs(
+                user.oldinfringements.length === 0 ||
+                Math.abs(
                   moment().diff(
                     moment(
                       user.oldinfringements[user.oldinfringements?.length - 1]
-                        .date,
+                        .date
                     ),
-                    'months',
-                    true,
-                  ),
-                )
-                  >= elem.months - 12
+                    "months",
+                    true
+                  )
+                ) >=
+                  elem.months - 12
               ) {
                 if (badgeOfType) {
                   if (badgeOfType._id.toString() !== elem._id.toString()) {
                     replaceBadge(
                       personId,
                       mongoose.Types.ObjectId(badgeOfType._id),
-                      mongoose.Types.ObjectId(elem._id),
+                      mongoose.Types.ObjectId(elem._id)
                     );
                   }
                   return false;
@@ -875,16 +882,16 @@ const userHelper = function () {
   const checkMinHoursMultiple = async function (
     personId,
     user,
-    badgeCollection,
+    badgeCollection
   ) {
     const badgesOfType = [];
     for (let i = 0; i < badgeCollection.length; i += 1) {
-      if (badgeCollection[i].badge?.type === 'Minimum Hours Multiple') {
+      if (badgeCollection[i].badge?.type === "Minimum Hours Multiple") {
         badgesOfType.push(badgeCollection[i].badge);
       }
     }
     await badge
-      .find({ type: 'Minimum Hours Multiple' })
+      .find({ type: "Minimum Hours Multiple" })
       .sort({ multiple: -1 })
       .then((results) => {
         if (!Array.isArray(results) || !results.length) {
@@ -895,8 +902,8 @@ const userHelper = function () {
           // this needs to be a for loop so that the returns break before assigning badges for lower multiples
           const elem = results[i]; // making variable elem accessible for below code
           if (
-            user.lastWeekTangibleHrs / user.weeklyComittedHours
-            >= elem.multiple
+            user.lastWeekTangibleHrs / user.weeklyComittedHours >=
+            elem.multiple
           ) {
             let theBadge;
             for (let j = 0; j < badgesOfType.length; j += 1) {
@@ -921,7 +928,7 @@ const userHelper = function () {
   const checkPersonalMax = async function (personId, user, badgeCollection) {
     let badgeOfType;
     for (let i = 0; i < badgeCollection.length; i += 1) {
-      if (badgeCollection[i].badge?.type === 'Personal Max') {
+      if (badgeCollection[i].badge?.type === "Personal Max") {
         if (badgeOfType) {
           removeDupBadge(personId, badgeOfType._id);
           badgeOfType = badgeCollection[i].badge;
@@ -930,23 +937,23 @@ const userHelper = function () {
         }
       }
     }
-    await badge.findOne({ type: 'Personal Max' }).then((results) => {
+    await badge.findOne({ type: "Personal Max" }).then((results) => {
       if (
-        user.lastWeekTangibleHrs
-        && user.lastWeekTangibleHrs >= 1
-        && user.lastWeekTangibleHrs === user.personalBestMaxHrs
+        user.lastWeekTangibleHrs &&
+        user.lastWeekTangibleHrs >= 1 &&
+        user.lastWeekTangibleHrs === user.personalBestMaxHrs
       ) {
         if (badgeOfType) {
           changeBadgeCount(
             personId,
             mongoose.Types.ObjectId(badgeOfType._id),
-            user.personalBestMaxHrs,
+            user.personalBestMaxHrs
           );
         } else {
           addBadge(
             personId,
             mongoose.Types.ObjectId(results._id),
-            user.personalBestMaxHrs,
+            user.personalBestMaxHrs
           );
         }
       }
@@ -957,25 +964,25 @@ const userHelper = function () {
   const checkMostHrsWeek = async function (personId, user, badgeCollection) {
     let badgeOfType;
     for (let i = 0; i < badgeCollection.length; i += 1) {
-      if (badgeCollection[i].badge?.type === 'Most Hrs in Week') {
+      if (badgeCollection[i].badge?.type === "Most Hrs in Week") {
         badgeOfType = badgeCollection[i].badge;
       }
     }
-    await badge.findOne({ type: 'Most Hrs in Week' }).then((results) => {
+    await badge.findOne({ type: "Most Hrs in Week" }).then((results) => {
       userProfile
         .aggregate([
           { $match: { isActive: true } },
-          { $group: { _id: 1, maxHours: { $max: '$lastWeekTangibleHrs' } } },
+          { $group: { _id: 1, maxHours: { $max: "$lastWeekTangibleHrs" } } },
         ])
         .then((userResults) => {
           if (
-            user.lastWeekTangibleHrs
-            && user.lastWeekTangibleHrs >= userResults[0].maxHours
+            user.lastWeekTangibleHrs &&
+            user.lastWeekTangibleHrs >= userResults[0].maxHours
           ) {
             if (badgeOfType) {
               increaseBadgeCount(
                 personId,
-                mongoose.Types.ObjectId(badgeOfType._id),
+                mongoose.Types.ObjectId(badgeOfType._id)
               );
             } else {
               addBadge(personId, mongoose.Types.ObjectId(results._id));
@@ -989,7 +996,7 @@ const userHelper = function () {
   const checkXHrsForXWeeks = async function (personId, user, badgeCollection) {
     const badgesOfType = [];
     for (let i = 0; i < badgeCollection.length; i += 1) {
-      if (badgeCollection[i].badge?.type === 'X Hours for X Week Streak') {
+      if (badgeCollection[i].badge?.type === "X Hours for X Week Streak") {
         badgesOfType.push(badgeCollection[i].badge);
       }
     }
@@ -999,12 +1006,12 @@ const userHelper = function () {
     // get all the badges with weeks > 1 that are of the following type.
     await badge
       .aggregate([
-        { $match: { type: 'X Hours for X Week Streak', weeks: { $gte: 1 } } },
+        { $match: { type: "X Hours for X Week Streak", weeks: { $gte: 1 } } },
         {
           $group: {
-            _id: '$weeks',
+            _id: "$weeks",
             badges: {
-              $push: { _id: '$_id', hrs: '$totalHrs', weeks: '$weeks' },
+              $push: { _id: "$_id", hrs: "$totalHrs", weeks: "$weeks" },
             },
           },
         },
@@ -1015,7 +1022,7 @@ const userHelper = function () {
           streak.badges.every((bdge) => {
             // only filter out badges that have total hours equal to a user's last week tangible hours.
             if (bdge.hrs === roundedTangibleHrs) {
-              console.log('Badges', bdge);
+              console.log("Badges", bdge);
               let count = 0;
               if (user.savedTangibleHrs.length >= bdge.weeks) {
                 const endOfArr = user.savedTangibleHrs.length - 1;
@@ -1024,13 +1031,13 @@ const userHelper = function () {
                  */
                 for (let i = endOfArr; i >= 0; i--) {
                   count++;
-                  console.log(user.savedTangibleHrs[i], i);
-                  if (user.savedTangibleHrs[i] < bdge.hrs) {
+                  let roundedTangibleHrs =
+                    Math.floor(user.savedTangibleHrs[i] / 10) * 10;
+                  if (roundedTangibleHrs !== bdge.hrs) {
                     count--;
                     break;
                   }
                 }
-
                 // if there's a badge with a streak that matches the count
                 if (count === bdge.weeks) {
                   for (let i = 0; i < badgesOfType.length; i++) {
@@ -1038,7 +1045,7 @@ const userHelper = function () {
                       if (badgesOfType[i].weeks < bdge.weeks) {
                         removeDupBadge(
                           personId,
-                          mongoose.Types.ObjectId(badgesOfType[i]._id),
+                          mongoose.Types.ObjectId(badgesOfType[i]._id)
                         );
                       }
                     }
@@ -1067,9 +1074,9 @@ const userHelper = function () {
   const checkLeadTeamOfXplus = async function (
     personId,
     user,
-    badgeCollection,
+    badgeCollection
   ) {
-    if (!hasPermission(user.role, 'checkLeadTeamOfXplus')) {
+    if (!hasPermission(user.role, "checkLeadTeamOfXplus")) {
       return;
     }
     let teamMembers;
@@ -1085,7 +1092,7 @@ const userHelper = function () {
 
     const objIds = {};
     teamMembers = teamMembers.filter((elem) => {
-      if (hasPermission(elem.role, 'checkLeadTeamOfXplus')) {
+      if (hasPermission(elem.role, "checkLeadTeamOfXplus")) {
         return false;
       }
 
@@ -1098,16 +1105,16 @@ const userHelper = function () {
 
     let badgeOfType;
     for (let i = 0; i < badgeCollection.length; i += 1) {
-      if (badgeCollection[i].badge?.type === 'Lead a team of X+') {
+      if (badgeCollection[i].badge?.type === "Lead a team of X+") {
         if (
-          badgeOfType
-          && badgeOfType.people <= badgeCollection[i].badge.people
+          badgeOfType &&
+          badgeOfType.people <= badgeCollection[i].badge.people
         ) {
           removeDupBadge(personId, badgeOfType._id);
           badgeOfType = badgeCollection[i].badge;
         } else if (
-          badgeOfType
-          && badgeOfType.people > badgeCollection[i].badge.people
+          badgeOfType &&
+          badgeOfType.people > badgeCollection[i].badge.people
         ) {
           removeDupBadge(personId, badgeCollection[i].badge._id);
         } else if (!badgeOfType) {
@@ -1117,7 +1124,7 @@ const userHelper = function () {
     }
 
     await badge
-      .find({ type: 'Lead a team of X+' })
+      .find({ type: "Lead a team of X+" })
       .sort({ people: -1 })
       .then((results) => {
         if (!Array.isArray(results) || !results.length) {
@@ -1128,13 +1135,13 @@ const userHelper = function () {
           if (teamMembers && teamMembers.length >= elem.people) {
             if (badgeOfType) {
               if (
-                badgeOfType._id.toString() !== elem._id.toString()
-                && badgeOfType.people < elem.people
+                badgeOfType._id.toString() !== elem._id.toString() &&
+                badgeOfType.people < elem.people
               ) {
                 replaceBadge(
                   personId,
                   mongoose.Types.ObjectId(badgeOfType._id),
-                  mongoose.Types.ObjectId(elem._id),
+                  mongoose.Types.ObjectId(elem._id)
                 );
               }
               return false;
@@ -1151,13 +1158,13 @@ const userHelper = function () {
   const checkTotalHrsInCat = async function (personId, user, badgeCollection) {
     const categoryTangibleHrs = user.categoryTangibleHrs || [];
     const categories = [
-      'Food',
-      'Energy',
-      'Housing',
-      'Education',
-      'Society',
-      'Economics',
-      'Stewardship',
+      "Food",
+      "Energy",
+      "Housing",
+      "Education",
+      "Society",
+      "Economics",
+      "Stewardship",
     ];
     if (categoryTangibleHrs.length === 0) {
       return;
@@ -1165,23 +1172,23 @@ const userHelper = function () {
 
     categories.forEach(async (category) => {
       const categoryHrs = categoryTangibleHrs.find(
-        elem => elem.category === category,
+        (elem) => elem.category === category
       );
       let badgeOfType;
       for (let i = 0; i < badgeCollection.length; i += 1) {
         if (
-          badgeCollection[i].badge?.type === 'Total Hrs in Category'
-          && badgeCollection[i].badge?.category === category
+          badgeCollection[i].badge?.type === "Total Hrs in Category" &&
+          badgeCollection[i].badge?.category === category
         ) {
           if (
-            badgeOfType
-            && badgeOfType.totalHrs <= badgeCollection[i].badge.totalHrs
+            badgeOfType &&
+            badgeOfType.totalHrs <= badgeCollection[i].badge.totalHrs
           ) {
             removeDupBadge(personId, badgeOfType._id);
             badgeOfType = badgeCollection[i].badge;
           } else if (
-            badgeOfType
-            && badgeOfType.totalHrs > badgeCollection[i].badge.totalHrs
+            badgeOfType &&
+            badgeOfType.totalHrs > badgeCollection[i].badge.totalHrs
           ) {
             removeDupBadge(personId, badgeCollection[i].badge._id);
           } else if (!badgeOfType) {
@@ -1190,7 +1197,7 @@ const userHelper = function () {
         }
       }
       await badge
-        .find({ type: 'Total Hrs in Category', category })
+        .find({ type: "Total Hrs in Category", category })
         .sort({ totalHrs: -1 })
         .then((results) => {
           if (!Array.isArray(results) || !results.length || !categoryHrs) {
@@ -1201,13 +1208,13 @@ const userHelper = function () {
             if (categoryHrs.hrs >= elem.totalHrs) {
               if (badgeOfType) {
                 if (
-                  badgeOfType._id.toString() !== elem._id.toString()
-                  && badgeOfType.totalHrs < elem.totalHrs
+                  badgeOfType._id.toString() !== elem._id.toString() &&
+                  badgeOfType.totalHrs < elem.totalHrs
                 ) {
                   replaceBadge(
                     personId,
                     mongoose.Types.ObjectId(badgeOfType._id),
-                    mongoose.Types.ObjectId(elem._id),
+                    mongoose.Types.ObjectId(elem._id)
                   );
                 }
                 return false;
@@ -1225,7 +1232,7 @@ const userHelper = function () {
     try {
       const users = await userProfile
         .find({ isActive: true })
-        .populate('badgeCollection.badge');
+        .populate("badgeCollection.badge");
 
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
@@ -1248,13 +1255,13 @@ const userHelper = function () {
   const getTangibleHoursReportedThisWeekByUserId = function (personId) {
     const userId = mongoose.Types.ObjectId(personId);
     const pdtstart = moment()
-      .tz('America/Los_Angeles')
-      .startOf('week')
-      .format('YYYY-MM-DD');
+      .tz("America/Los_Angeles")
+      .startOf("week")
+      .format("YYYY-MM-DD");
     const pdtend = moment()
-      .tz('America/Los_Angeles')
-      .endOf('week')
-      .format('YYYY-MM-DD');
+      .tz("America/Los_Angeles")
+      .endOf("week")
+      .format("YYYY-MM-DD");
 
     return timeEntries
       .find(
@@ -1263,12 +1270,12 @@ const userHelper = function () {
           dateOfWork: { $gte: pdtstart, $lte: pdtend },
           isTangible: true,
         },
-        'totalSeconds',
+        "totalSeconds"
       )
       .then((results) => {
         const totalTangibleWeeklySeconds = results.reduce(
           (acc, { totalSeconds }) => acc + totalSeconds,
-          0,
+          0
         );
         return (totalTangibleWeeklySeconds / 3600).toFixed(2);
       });
@@ -1278,27 +1285,27 @@ const userHelper = function () {
     try {
       const users = await userProfile.find(
         { isActive: true, endDate: { $exists: true } },
-        '_id isActive endDate',
+        "_id isActive endDate"
       );
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
         const { endDate } = user;
         endDate.setHours(endDate.getHours() + 7);
-        if (moment().isAfter(moment(endDate).add(1, 'days'))) {
+        if (moment().isAfter(moment(endDate).add(1, "days"))) {
           await userProfile.findByIdAndUpdate(
             user._id,
             user.set({
               isActive: false,
             }),
-            { new: true },
+            { new: true }
           );
           const id = user._id;
           const person = await userProfile.findById(id);
-          const lastDay = moment(person.endDate).format('YYYY-MM-DD');
+          const lastDay = moment(person.endDate).format("YYYY-MM-DD");
           logger.logInfo(
             `User with id: ${
               user._id
-            } was de-acticated at ${moment().format()}.`,
+            } was de-acticated at ${moment().format()}.`
           );
           const subject = `IMPORTANT:${person.firstName} ${person.lastName} has been deactivated in the Highest Good Network`;
 
@@ -1313,11 +1320,11 @@ const userHelper = function () {
           <p>The HGN A.I. (and One Community)</p>`;
 
           emailSender(
-            'onecommunityglobal@gmail.com',
+            "onecommunityglobal@gmail.com",
             subject,
             emailBody,
             null,
-            null,
+            null
           );
         }
       }

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -63,18 +63,24 @@ const userHelper = function () {
     };
   };
 
-  const getInfringementEmailBody = function (firstName, lastName, infringement, totalInfringements) {
+  const getInfringementEmailBody = function (
+    firstName,
+    lastName,
+    infringement,
+    totalInfringements,
+  ) {
     const text = `Dear <b>${firstName} ${lastName}</b>,
         <p>Oops, it looks like something happened and you’ve managed to get a blue square.</p>
         <p><b>Date Assigned:</b> ${infringement.date}</p>
         <p><b>Description:</b> ${infringement.description}</p>
-        <p><b>Total Infringements:</b> This is your <b>${moment.localeData().ordinal(totalInfringements)}</b> blue square of 5.</p>
+        <p><b>Total Infringements:</b> This is your <b>${moment
+          .localeData()
+          .ordinal(totalInfringements)}</b> blue square of 5.</p>
         <p>Life happens and we understand that. That’s why we allow 5 of them before taking action. This action usually includes removal from our team though, so please let your direct supervisor know what happened and do your best to avoid future blue squares if you are getting close to 5 and wish to avoid termination. Each blue square drops off after a year.</p>
         <p>Thank you,<br />
         One Community</p>`;
     return text;
   };
-
 
   /**
    * This function will send out an email listing all users that have a summary provided for a specific week.
@@ -89,7 +95,9 @@ const userHelper = function () {
   const emailWeeklySummariesForAllUsers = async (weekIndex = 1) => {
     const currentFormattedDate = moment().tz('America/Los_Angeles').format();
 
-    logger.logInfo(`Job for emailing all users' weekly summaries starting at ${currentFormattedDate}`);
+    logger.logInfo(
+      `Job for emailing all users' weekly summaries starting at ${currentFormattedDate}`,
+    );
 
     const emails = [];
 
@@ -102,13 +110,21 @@ const userHelper = function () {
 
       const weeklySummaryNotRequiredMessage = '<div><b>Weekly Summary:</b> <span style="color: magenta;"> Not required for this user </span></div>';
 
-      results.sort((a, b) => (`${a.firstName} ${a.lastName}`).localeCompare(`${b.firstName} ${b.lastname}`));
+      results.sort((a, b) => `${a.firstName} ${a.lastName}`.localeCompare(
+          `${b.firstName} ${b.lastname}`,
+        ));
 
       for (let i = 0; i < results.length; i += 1) {
         const result = results[i];
 
         const {
-          firstName, lastName, email, weeklySummaries, mediaUrl, weeklySummariesCount, weeklyComittedHours,
+          firstName,
+          lastName,
+          email,
+          weeklySummaries,
+          mediaUrl,
+          weeklySummariesCount,
+          weeklyComittedHours,
         } = result;
 
         if (email !== undefined && email !== null) {
@@ -118,9 +134,11 @@ const userHelper = function () {
         // weeklySummaries array will have only one item fetched (if present),
         // consequently totalSeconds array will also have only one item in the array (if present)
         // hence totalSeconds[0] should be used
-        const hoursLogged = ((result.totalSeconds[0] / 3600) || 0);
+        const hoursLogged = result.totalSeconds[0] / 3600 || 0;
 
-        const mediaUrlLink = mediaUrl ? `<a href="${mediaUrl}">${mediaUrl}</a>` : 'Not provided!';
+        const mediaUrlLink = mediaUrl
+          ? `<a href="${mediaUrl}">${mediaUrl}</a>`
+          : 'Not provided!';
 
         let weeklySummaryMessage = weeklySummaryNotProvidedMessage;
 
@@ -131,7 +149,9 @@ const userHelper = function () {
             weeklySummaryMessage = `
               <div>
                 <b>Weekly Summary</b>
-                (for the week ending on <b>${moment(dueDate).tz('America/Los_Angeles').format('YYYY-MMM-DD')}</b>):
+                (for the week ending on <b>${moment(dueDate)
+                  .tz('America/Los_Angeles')
+                  .format('YYYY-MMM-DD')}</b>):
               </div>
               <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}">
                 ${summary}
@@ -147,24 +167,33 @@ const userHelper = function () {
         <div style="padding: 20px 0; margin-top: 5px; border-bottom: 1px solid #828282;">
           <b>Name:</b> ${firstName} ${lastName}
           <p>
-            <b>Media URL:</b> ${mediaUrlLink || '<span style="color: red;">Not provided!</span>'}
+            <b>Media URL:</b> ${
+              mediaUrlLink || '<span style="color: red;">Not provided!</span>'
+            }
           </p>
-          ${weeklySummariesCount === 8
-    ? `<p style="color: blue;"><b>Total Valid Weekly Summaries: ${weeklySummariesCount}</b></p>`
-    : `<p><b>Total Valid Weekly Summaries</b>: ${weeklySummariesCount || 'No valid submissions yet!'}</p>`
-}
           ${
-  hoursLogged >= weeklyComittedHours
-    ? `<p><b>Hours logged</b>: ${hoursLogged.toFixed(2)} / ${weeklyComittedHours}</p>`
-    : `<p style="color: red;"><b>Hours logged</b>: ${hoursLogged.toFixed(2)} / ${weeklyComittedHours}</p>`
-}
+            weeklySummariesCount === 8
+              ? `<p style="color: blue;"><b>Total Valid Weekly Summaries: ${weeklySummariesCount}</b></p>`
+              : `<p><b>Total Valid Weekly Summaries</b>: ${
+                  weeklySummariesCount || 'No valid submissions yet!'
+                }</p>`
+          }
+          ${
+            hoursLogged >= weeklyComittedHours
+              ? `<p><b>Hours logged</b>: ${hoursLogged.toFixed(
+                  2,
+                )} / ${weeklyComittedHours}</p>`
+              : `<p style="color: red;"><b>Hours logged</b>: ${hoursLogged.toFixed(
+                  2,
+                )} / ${weeklyComittedHours}</p>`
+          }
           ${weeklySummaryMessage}
         </div>`;
       }
 
       // Necessary because our version of node is outdated
       // and doesn't have String.prototype.replaceAll
-      let emailString = [...(new Set(emails))].toString();
+      let emailString = [...new Set(emails)].toString();
       while (emailString.includes(',')) emailString = emailString.replace(',', '\n');
       while (emailString.includes('\n')) emailString = emailString.replace('\n', ', ');
 
@@ -187,7 +216,6 @@ const userHelper = function () {
       logger.logException(err);
     }
   };
-
 
   /**
    * This function will process the weeklySummaries array in the following way:
@@ -218,9 +246,13 @@ const userHelper = function () {
       .then(() => {
         if (hasWeeklySummary) {
           userProfile
-            .findByIdAndUpdate(personId, {
-              $inc: { weeklySummariesCount: 1 },
-            }, { new: true })
+            .findByIdAndUpdate(
+              personId,
+              {
+                $inc: { weeklySummariesCount: 1 },
+              },
+              { new: true },
+            )
             .catch(error => logger.logException(error));
         }
       })
@@ -238,13 +270,24 @@ const userHelper = function () {
     try {
       const currentFormattedDate = moment().tz('America/Los_Angeles').format();
 
-      logger.logInfo(`Job for assigning blue square for commitment not met starting at ${currentFormattedDate}`);
+      logger.logInfo(
+        `Job for assigning blue square for commitment not met starting at ${currentFormattedDate}`,
+      );
 
-      const pdtStartOfLastWeek = moment().tz('America/Los_Angeles').startOf('week').subtract(1, 'week');
+      const pdtStartOfLastWeek = moment()
+        .tz('America/Los_Angeles')
+        .startOf('week')
+        .subtract(1, 'week');
 
-      const pdtEndOfLastWeek = moment().tz('America/Los_Angeles').endOf('week').subtract(1, 'week');
+      const pdtEndOfLastWeek = moment()
+        .tz('America/Los_Angeles')
+        .endOf('week')
+        .subtract(1, 'week');
 
-      const users = await userProfile.find({ isActive: true }, '_id weeklySummaries');
+      const users = await userProfile.find(
+        { isActive: true },
+        '_id weeklySummaries',
+      );
 
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
@@ -253,7 +296,10 @@ const userHelper = function () {
 
         let hasWeeklySummary = false;
 
-        if (Array.isArray(user.weeklySummaries) && user.weeklySummaries.length) {
+        if (
+          Array.isArray(user.weeklySummaries)
+          && user.weeklySummaries.length
+        ) {
           const { summary } = user.weeklySummaries[0];
           if (summary) {
             hasWeeklySummary = true;
@@ -263,11 +309,15 @@ const userHelper = function () {
         //  This needs to run AFTER the check for weekly summary above because the summaries array will be updated/shifted after this function runs.
         await processWeeklySummariesByUserId(personId, hasWeeklySummary);
 
-        const results = await dashboardHelper.laborthisweek(personId, pdtStartOfLastWeek, pdtEndOfLastWeek);
+        const results = await dashboardHelper.laborthisweek(
+          personId,
+          pdtStartOfLastWeek,
+          pdtEndOfLastWeek,
+        );
 
         const { weeklyComittedHours, timeSpent_hrs: timeSpent } = results[0];
 
-        const timeNotMet = (timeSpent < weeklyComittedHours);
+        const timeNotMet = timeSpent < weeklyComittedHours;
         let description;
 
         const updateResult = await userProfile.findByIdAndUpdate(
@@ -293,12 +343,14 @@ const userHelper = function () {
           hasWeeklySummary = true;
         }
 
-        const cutOffDate = moment()
-          .subtract(1, 'year');
+        const cutOffDate = moment().subtract(1, 'year');
 
         const oldInfringements = [];
         for (let k = 0; k < updateResult?.infringements.length; k += 1) {
-          if (updateResult?.infringements && moment(updateResult?.infringements[k].date).diff(cutOffDate) >= 0) {
+          if (
+            updateResult?.infringements
+            && moment(updateResult?.infringements[k].date).diff(cutOffDate) >= 0
+          ) {
             oldInfringements.push(updateResult.infringements[k]);
           } else {
             break;
@@ -306,36 +358,46 @@ const userHelper = function () {
         }
 
         if (oldInfringements.length) {
-          userProfile
-            .findByIdAndUpdate(personId, {
+          userProfile.findByIdAndUpdate(
+            personId,
+            {
               $push: {
                 oldInfringements: { $each: oldInfringements, $slice: -10 },
               },
-            }, { new: true });
+            },
+            { new: true },
+          );
         }
 
-        if (timeNotMet || (!hasWeeklySummary)) {
+        if (timeNotMet || !hasWeeklySummary) {
           if (timeNotMet && !hasWeeklySummary) {
-            description = `System auto-assigned infringement for two reasons: not meeting weekly volunteer time commitment as well as not submitting a weekly summary. For the hours portion, you logged ${timeSpent} hours against committed effort of ${weeklyComittedHours} hours in the week starting ${pdtStartOfLastWeek.format('dddd YYYY-MM-DD')} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
+            description = `System auto-assigned infringement for two reasons: not meeting weekly volunteer time commitment as well as not submitting a weekly summary. For the hours portion, you logged ${timeSpent} hours against committed effort of ${weeklyComittedHours} hours in the week starting ${pdtStartOfLastWeek.format(
+              'dddd YYYY-MM-DD',
+            )} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
           } else if (timeNotMet) {
-            description = `System auto-assigned infringement for not meeting weekly volunteer time commitment. You logged ${timeSpent} hours against committed effort of ${weeklyComittedHours} hours in the week starting ${pdtStartOfLastWeek.format('dddd YYYY-MM-DD')} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
+            description = `System auto-assigned infringement for not meeting weekly volunteer time commitment. You logged ${timeSpent} hours against committed effort of ${weeklyComittedHours} hours in the week starting ${pdtStartOfLastWeek.format(
+              'dddd YYYY-MM-DD',
+            )} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
           } else {
-            description = `System auto-assigned infringement for not submitting a weekly summary for the week starting ${pdtStartOfLastWeek.format('dddd YYYY-MM-DD')} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
+            description = `System auto-assigned infringement for not submitting a weekly summary for the week starting ${pdtStartOfLastWeek.format(
+              'dddd YYYY-MM-DD',
+            )} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
           }
 
           const infringement = {
-            date: moment()
-              .utc()
-              .format('YYYY-MM-DD'),
+            date: moment().utc().format('YYYY-MM-DD'),
             description,
           };
 
-          const status = await userProfile
-            .findByIdAndUpdate(personId, {
+          const status = await userProfile.findByIdAndUpdate(
+            personId,
+            {
               $push: {
                 infringements: infringement,
               },
-            }, { new: true });
+            },
+            { new: true },
+          );
 
           emailSender(
             status.email,
@@ -350,14 +412,17 @@ const userHelper = function () {
             'onecommunityglobal@gmail.com',
           );
 
-          const categories = await dashboardHelper.laborThisWeekByCategory(personId, pdtStartOfLastWeek, pdtEndOfLastWeek);
+          const categories = await dashboardHelper.laborThisWeekByCategory(
+            personId,
+            pdtStartOfLastWeek,
+            pdtEndOfLastWeek,
+          );
 
           if (Array.isArray(categories) && categories.length > 0) {
-            await userProfile
-              .findOneAndUpdate(
-                { _id: personId, categoryTangibleHrs: { $exists: false } },
-                { $set: { categoryTangibleHrs: [] } },
-              );
+            await userProfile.findOneAndUpdate(
+              { _id: personId, categoryTangibleHrs: { $exists: false } },
+              { $set: { categoryTangibleHrs: [] } },
+            );
           } else {
             continue;
           }
@@ -369,28 +434,27 @@ const userHelper = function () {
               elem._id = 'Other';
             }
 
-            const updateResult2 = await userProfile
-              .findOneAndUpdate(
-                { _id: personId, 'categoryTangibleHrs.category': elem._id },
-                { $inc: { 'categoryTangibleHrs.$.hrs': elem.timeSpent_hrs } },
-                { new: true },
-              );
+            const updateResult2 = await userProfile.findOneAndUpdate(
+              { _id: personId, 'categoryTangibleHrs.category': elem._id },
+              { $inc: { 'categoryTangibleHrs.$.hrs': elem.timeSpent_hrs } },
+              { new: true },
+            );
 
             if (!updateResult2) {
-              await userProfile
-                .findOneAndUpdate(
-                  {
-                    _id: personId,
-                    'categoryTangibleHrs.category': { $ne: elem._id },
-                  },
-                  {
-                    $addToSet: {
-                      categoryTangibleHrs: {
-                        category: elem._id, hrs: elem.timeSpent_hrs,
-                      },
+              await userProfile.findOneAndUpdate(
+                {
+                  _id: personId,
+                  'categoryTangibleHrs.category': { $ne: elem._id },
+                },
+                {
+                  $addToSet: {
+                    categoryTangibleHrs: {
+                      category: elem._id,
+                      hrs: elem.timeSpent_hrs,
                     },
                   },
-                );
+                },
+              );
             }
           }
         }
@@ -404,7 +468,10 @@ const userHelper = function () {
       const inactiveUsers = await userProfile.find({ isActive: false }, '_id');
       for (let i = 0; i < inactiveUsers.length; i += 1) {
         const user = inactiveUsers[i];
-        await processWeeklySummariesByUserId(mongoose.Types.ObjectId(user._id), false);
+        await processWeeklySummariesByUserId(
+          mongoose.Types.ObjectId(user._id),
+          false,
+        );
       }
     } catch (err) {
       logger.logException(err);
@@ -414,12 +481,15 @@ const userHelper = function () {
   const deleteBlueSquareAfterYear = async () => {
     const currentFormattedDate = moment().tz('America/Los_Angeles').format();
 
-    logger.logInfo(`Job for deleting blue squares older than 1 year starting at ${currentFormattedDate}`);
+    logger.logInfo(
+      `Job for deleting blue squares older than 1 year starting at ${currentFormattedDate}`,
+    );
 
     const cutOffDate = moment().subtract(1, 'year').format('YYYY-MM-DD');
 
     try {
-      const results = await userProfile.updateMany({},
+      const results = await userProfile.updateMany(
+        {},
         {
           $pull: {
             infringements: {
@@ -428,7 +498,8 @@ const userHelper = function () {
               },
             },
           },
-        });
+        },
+      );
 
       logger.logInfo(results);
     } catch (err) {
@@ -439,11 +510,15 @@ const userHelper = function () {
   const reActivateUser = async () => {
     const currentFormattedDate = moment().tz('America/Los_Angeles').format();
 
-
-    logger.logInfo(`Job for activating users based on scheduled re-activation date starting at ${currentFormattedDate}`);
+    logger.logInfo(
+      `Job for activating users based on scheduled re-activation date starting at ${currentFormattedDate}`,
+    );
 
     try {
-      const users = await userProfile.find({ isActive: false, reactivationDate: { $exists: true } }, '_id isActive reactivationDate');
+      const users = await userProfile.find(
+        { isActive: false, reactivationDate: { $exists: true } },
+        '_id isActive reactivationDate',
+      );
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
         if (moment().isSameOrAfter(moment(user.reactivationDate))) {
@@ -456,13 +531,22 @@ const userHelper = function () {
               $unset: {
                 endDate: user.endDate,
               },
-            }, { new: true },
+            },
+            { new: true },
           );
-          logger.logInfo(`User with id: ${user._id} was re-acticated at ${moment().tz('America/Los_Angeles').format()}.`);
+          logger.logInfo(
+            `User with id: ${user._id} was re-acticated at ${moment()
+              .tz('America/Los_Angeles')
+              .format()}.`,
+          );
           const id = user._id;
           const person = await userProfile.findById(id);
           const endDate = moment(person.endDate).format('YYYY-MM-DD');
-          logger.logInfo(`User with id: ${user._id} was re-acticated at ${moment().format()}.`);
+          logger.logInfo(
+            `User with id: ${
+              user._id
+            } was re-acticated at ${moment().format()}.`,
+          );
           const subject = `IMPORTANT:${person.firstName} ${person.lastName} has been RE-activated in the Highest Good Network`;
 
           const emailBody = `<p> Hi Admin! </p>
@@ -510,7 +594,12 @@ const userHelper = function () {
       emailSender(
         emailAddress,
         'New Infringement Assigned',
-        getInfringementEmailBody(firstName, lastName, element, totalInfringements),
+        getInfringementEmailBody(
+          firstName,
+          lastName,
+          element,
+          totalInfringements,
+        ),
         null,
         'onecommunityglobal@gmail.com',
       );
@@ -519,56 +608,81 @@ const userHelper = function () {
 
   const replaceBadge = async function (personId, oldBadgeId, newBadgeId) {
     console.log('Replacing Badge', personId, oldBadgeId, newBadgeId);
-    userProfile.updateOne({ _id: personId, 'badgeCollection.badge': oldBadgeId },
-      { $set: { 'badgeCollection.$.badge': newBadgeId, 'badgeCollection.$.lastModified': Date.now().toString(), 'badgeCollection.$.count': 1 } },
+    userProfile.updateOne(
+      { _id: personId, 'badgeCollection.badge': oldBadgeId },
+      {
+        $set: {
+          'badgeCollection.$.badge': newBadgeId,
+          'badgeCollection.$.lastModified': Date.now().toString(),
+          'badgeCollection.$.count': 1,
+        },
+      },
       (err) => {
         if (err) {
           console.log(err);
         }
-      });
+      },
+    );
   };
 
   const increaseBadgeCount = async function (personId, badgeId) {
     console.log('Increase Badge Count', personId, badgeId);
-    userProfile.updateOne({ _id: personId, 'badgeCollection.badge': badgeId },
-      { $inc: { 'badgeCollection.$.count': 1 }, $set: { 'badgeCollection.$.lastModified': Date.now().toString() } },
+    userProfile.updateOne(
+      { _id: personId, 'badgeCollection.badge': badgeId },
+      {
+        $inc: { 'badgeCollection.$.count': 1 },
+        $set: { 'badgeCollection.$.lastModified': Date.now().toString() },
+      },
       (err) => {
         if (err) {
           console.log(err);
         }
-      });
+      },
+    );
   };
 
-  const addBadge = async function (personId, badgeId, count = 1, featured = false) {
+  const addBadge = async function (
+    personId,
+    badgeId,
+    count = 1,
+    featured = false,
+  ) {
     console.log('Adding Badge ', personId, badgeId, count);
-    userProfile.findByIdAndUpdate(personId,
+    userProfile.findByIdAndUpdate(
+      personId,
       {
-        $push:
-        {
+        $push: {
           badgeCollection: {
-            badge: badgeId, count, featured, lastModified: Date.now().toString(),
+            badge: badgeId,
+            count,
+            featured,
+            lastModified: Date.now().toString(),
           },
         },
-      }, (err) => {
+      },
+      (err) => {
         if (err) {
           console.log(err);
         }
-      });
+      },
+    );
   };
 
   const removeDupBadge = async function (personId, badgeId) {
     console.log('Removing Badge ', personId, badgeId);
-    userProfile.findByIdAndUpdate(personId,
+    userProfile.findByIdAndUpdate(
+      personId,
       {
-        $pull:
-        {
+        $pull: {
           badgeCollection: { badge: badgeId },
         },
-      }, (err) => {
+      },
+      (err) => {
         if (err) {
           console.log(err);
         }
-      });
+      },
+    );
   };
 
   const changeBadgeCount = async function (personId, badgeId, count) {
@@ -576,35 +690,71 @@ const userHelper = function () {
     if (count === 0) {
       removeDupBadge(personId, badgeId);
     } else {
-      userProfile.updateOne({ _id: personId, 'badgeCollection.badge': badgeId },
-        { $set: { 'badgeCollection.$.count': count, 'badgeCollection.$.lastModified': Date.now().toString() } },
+      userProfile.updateOne(
+        { _id: personId, 'badgeCollection.badge': badgeId },
+        {
+          $set: {
+            'badgeCollection.$.count': count,
+            'badgeCollection.$.lastModified': Date.now().toString(),
+          },
+        },
         (err) => {
           if (err) {
             console.log(err);
           }
-        });
+        },
+      );
     }
   };
 
-
   // remove the last badge you earned on this streak(not including 1)
-  const removePrevHrBadge = async function (personId, user, badgeCollection, hrs, weeks) {
+  const removePrevHrBadge = async function (
+    personId,
+    user,
+    badgeCollection,
+    hrs,
+    weeks,
+  ) {
     // Check each Streak Greater than One to check if it works
     if (weeks < 3) {
       return;
     }
     let removed = false;
-    await badge.aggregate([
-      { $match: { type: 'X Hours for X Week Streak', weeks: { $gt: 1, $lt: weeks }, totalHrs: hrs } },
-      { $sort: { weeks: -1, totalHrs: -1 } },
-      { $group: { _id: '$weeks', badges: { $push: { _id: '$_id', hrs: '$totalHrs', weeks: '$weeks' } } } },
-    ])
+    await badge
+      .aggregate([
+        {
+          $match: {
+            type: 'X Hours for X Week Streak',
+            weeks: { $gt: 1, $lt: weeks },
+            totalHrs: hrs,
+          },
+        },
+        { $sort: { weeks: -1, totalHrs: -1 } },
+        {
+          $group: {
+            _id: '$weeks',
+            badges: {
+              $push: { _id: '$_id', hrs: '$totalHrs', weeks: '$weeks' },
+            },
+          },
+        },
+      ])
       .then((results) => {
         results.forEach((streak) => {
           streak.badges.every((bdge) => {
             for (let i = 0; i < badgeCollection.length; i += 1) {
-              if (badgeCollection[i].badge?.type === 'X Hours for X Week Streak' && badgeCollection[i].badge?.weeks === bdge.weeks && bdge.hrs === hrs && !removed) {
-                changeBadgeCount(personId, badgeCollection[i].badge._id, badgeCollection[i].badge.count - 1);
+              if (
+                badgeCollection[i].badge?.type
+                  === 'X Hours for X Week Streak'
+                && badgeCollection[i].badge?.weeks === bdge.weeks
+                && bdge.hrs === hrs
+                && !removed
+              ) {
+                changeBadgeCount(
+                  personId,
+                  badgeCollection[i].badge._id,
+                  badgeCollection[i].badge.count - 1,
+                );
                 removed = true;
                 return false;
               }
@@ -616,21 +766,32 @@ const userHelper = function () {
   };
 
   //   'No Infringement Streak',
-  const checkNoInfringementStreak = async function (personId, user, badgeCollection) {
+  const checkNoInfringementStreak = async function (
+    personId,
+    user,
+    badgeCollection,
+  ) {
     let badgeOfType;
     for (let i = 0; i < badgeCollection.length; i += 1) {
       if (badgeCollection[i].badge?.type === 'No Infringement Streak') {
-        if (badgeOfType && badgeOfType.months <= badgeCollection[i].badge.months) {
+        if (
+          badgeOfType
+          && badgeOfType.months <= badgeCollection[i].badge.months
+        ) {
           removeDupBadge(personId, badgeOfType._id);
           badgeOfType = badgeCollection[i].badge;
-        } else if (badgeOfType && badgeOfType.months > badgeCollection[i].badge.months) {
+        } else if (
+          badgeOfType
+          && badgeOfType.months > badgeCollection[i].badge.months
+        ) {
           removeDupBadge(personId, badgeCollection[i].badge._id);
         } else if (!badgeOfType) {
           badgeOfType = badgeCollection[i].badge;
         }
       }
     }
-    await badge.find({ type: 'No Infringement Streak' })
+    await badge
+      .find({ type: 'No Infringement Streak' })
       .sort({ months: -1 })
       .then((results) => {
         if (!Array.isArray(results) || !results.length) {
@@ -641,11 +802,29 @@ const userHelper = function () {
           // Cannot account for time paused yet
 
           if (elem.months <= 12) {
-            if (moment().diff(moment(user.createdDate), 'months', true) >= elem.months) {
-              if (user.infringements.length === 0 || Math.abs(moment().diff(moment(user.infringements[user.infringements?.length - 1].date), 'months', true)) >= elem.months) {
+            if (
+              moment().diff(moment(user.createdDate), 'months', true)
+              >= elem.months
+            ) {
+              if (
+                user.infringements.length === 0
+                || Math.abs(
+                  moment().diff(
+                    moment(
+                      user.infringements[user.infringements?.length - 1].date,
+                    ),
+                    'months',
+                    true,
+                  ),
+                ) >= elem.months
+              ) {
                 if (badgeOfType) {
                   if (badgeOfType._id.toString() !== elem._id.toString()) {
-                    replaceBadge(personId, mongoose.Types.ObjectId(badgeOfType._id), mongoose.Types.ObjectId(elem._id));
+                    replaceBadge(
+                      personId,
+                      mongoose.Types.ObjectId(badgeOfType._id),
+                      mongoose.Types.ObjectId(elem._id),
+                    );
                   }
                   return false;
                 }
@@ -654,11 +833,31 @@ const userHelper = function () {
               }
             }
           } else if (user?.infringements?.length === 0) {
-            if (moment().diff(moment(user.createdDate), 'months', true) >= elem.months) {
-              if (user.oldinfringements.length === 0 || Math.abs(moment().diff(moment(user.oldinfringements[user.oldinfringements?.length - 1].date), 'months', true)) >= (elem.months - 12)) {
+            if (
+              moment().diff(moment(user.createdDate), 'months', true)
+              >= elem.months
+            ) {
+              if (
+                user.oldinfringements.length === 0
+                || Math.abs(
+                  moment().diff(
+                    moment(
+                      user.oldinfringements[user.oldinfringements?.length - 1]
+                        .date,
+                    ),
+                    'months',
+                    true,
+                  ),
+                )
+                  >= elem.months - 12
+              ) {
                 if (badgeOfType) {
                   if (badgeOfType._id.toString() !== elem._id.toString()) {
-                    replaceBadge(personId, mongoose.Types.ObjectId(badgeOfType._id), mongoose.Types.ObjectId(elem._id));
+                    replaceBadge(
+                      personId,
+                      mongoose.Types.ObjectId(badgeOfType._id),
+                      mongoose.Types.ObjectId(elem._id),
+                    );
                   }
                   return false;
                 }
@@ -673,23 +872,32 @@ const userHelper = function () {
   };
 
   // 'Minimum Hours Multiple',
-  const checkMinHoursMultiple = async function (personId, user, badgeCollection) {
+  const checkMinHoursMultiple = async function (
+    personId,
+    user,
+    badgeCollection,
+  ) {
     const badgesOfType = [];
     for (let i = 0; i < badgeCollection.length; i += 1) {
       if (badgeCollection[i].badge?.type === 'Minimum Hours Multiple') {
         badgesOfType.push(badgeCollection[i].badge);
       }
     }
-    await badge.find({ type: 'Minimum Hours Multiple' })
+    await badge
+      .find({ type: 'Minimum Hours Multiple' })
       .sort({ multiple: -1 })
       .then((results) => {
         if (!Array.isArray(results) || !results.length) {
           return;
         }
 
-        for (let i = 0; i < results.length; i += 1) { // this needs to be a for loop so that the returns break before assigning badges for lower multiples
+        for (let i = 0; i < results.length; i += 1) {
+          // this needs to be a for loop so that the returns break before assigning badges for lower multiples
           const elem = results[i]; // making variable elem accessible for below code
-          if ((user.lastWeekTangibleHrs / user.weeklyComittedHours) >= elem.multiple) {
+          if (
+            user.lastWeekTangibleHrs / user.weeklyComittedHours
+            >= elem.multiple
+          ) {
             let theBadge;
             for (let j = 0; j < badgesOfType.length; j += 1) {
               if (badgesOfType[j]._id.toString() === elem._id.toString()) {
@@ -722,16 +930,27 @@ const userHelper = function () {
         }
       }
     }
-    await badge.findOne({ type: 'Personal Max' })
-      .then((results) => {
-        if (user.lastWeekTangibleHrs && user.lastWeekTangibleHrs >= 1 && user.lastWeekTangibleHrs === user.personalBestMaxHrs) {
-          if (badgeOfType) {
-            changeBadgeCount(personId, mongoose.Types.ObjectId(badgeOfType._id), user.personalBestMaxHrs);
-          } else {
-            addBadge(personId, mongoose.Types.ObjectId(results._id), user.personalBestMaxHrs);
-          }
+    await badge.findOne({ type: 'Personal Max' }).then((results) => {
+      if (
+        user.lastWeekTangibleHrs
+        && user.lastWeekTangibleHrs >= 1
+        && user.lastWeekTangibleHrs === user.personalBestMaxHrs
+      ) {
+        if (badgeOfType) {
+          changeBadgeCount(
+            personId,
+            mongoose.Types.ObjectId(badgeOfType._id),
+            user.personalBestMaxHrs,
+          );
+        } else {
+          addBadge(
+            personId,
+            mongoose.Types.ObjectId(results._id),
+            user.personalBestMaxHrs,
+          );
         }
-      });
+      }
+    });
   };
 
   // 'Most Hrs in Week'
@@ -742,101 +961,100 @@ const userHelper = function () {
         badgeOfType = badgeCollection[i].badge;
       }
     }
-    await badge.findOne({ type: 'Most Hrs in Week' })
-      .then((results) => {
-        userProfile.aggregate([
+    await badge.findOne({ type: 'Most Hrs in Week' }).then((results) => {
+      userProfile
+        .aggregate([
           { $match: { isActive: true } },
           { $group: { _id: 1, maxHours: { $max: '$lastWeekTangibleHrs' } } },
-        ]).then((userResults) => {
-          if (user.lastWeekTangibleHrs && user.lastWeekTangibleHrs >= userResults[0].maxHours) {
+        ])
+        .then((userResults) => {
+          if (
+            user.lastWeekTangibleHrs
+            && user.lastWeekTangibleHrs >= userResults[0].maxHours
+          ) {
             if (badgeOfType) {
-              increaseBadgeCount(personId, mongoose.Types.ObjectId(badgeOfType._id));
+              increaseBadgeCount(
+                personId,
+                mongoose.Types.ObjectId(badgeOfType._id),
+              );
             } else {
               addBadge(personId, mongoose.Types.ObjectId(results._id));
             }
           }
         });
-      });
+    });
   };
 
   // 'X Hours for X Week Streak',
   const checkXHrsForXWeeks = async function (personId, user, badgeCollection) {
-    // Handle Increasing the 1 week streak badges
     const badgesOfType = [];
     for (let i = 0; i < badgeCollection.length; i += 1) {
       if (badgeCollection[i].badge?.type === 'X Hours for X Week Streak') {
         badgesOfType.push(badgeCollection[i].badge);
       }
     }
-    await badge.find({ type: 'X Hours for X Week Streak', weeks: 1 })
-      .sort({ totalHrs: -1 })
+    // lastWeekTangibleHrs is rounded to the integer's smallest tenth place.
+    const roundedTangibleHrs = Math.floor(user.lastWeekTangibleHrs / 10) * 10;
+
+    // get all the badges with weeks > 1 that are of the following type.
+    await badge
+      .aggregate([
+        { $match: { type: 'X Hours for X Week Streak', weeks: { $gte: 1 } } },
+        {
+          $group: {
+            _id: '$weeks',
+            badges: {
+              $push: { _id: '$_id', hrs: '$totalHrs', weeks: '$weeks' },
+            },
+          },
+        },
+        { $sort: { weeks: -1, totalHrs: -1 } },
+      ])
       .then((results) => {
-        results.every((elem) => {
-          if (elem.totalHrs <= user.lastWeekTangibleHrs) {
-            let theBadge;
-            for (let i = 0; i < badgesOfType.length; i += 1) {
-              if (badgesOfType[i]._id.toString() === elem._id.toString()) {
-                theBadge = badgesOfType[i]._id;
-                break;
-              }
-            }
-            if (theBadge) {
-              increaseBadgeCount(personId, mongoose.Types.ObjectId(theBadge));
-              return false;
-            }
-            addBadge(personId, mongoose.Types.ObjectId(elem._id));
-            return false;
-          }
-          return true;
-        });
-      });
-    // Check each Streak Greater than One to check if it works
-    await badge.aggregate([
-      { $match: { type: 'X Hours for X Week Streak', weeks: { $gt: 1 } } },
-      { $sort: { weeks: -1, totalHrs: -1 } },
-      { $group: { _id: '$weeks', badges: { $push: { _id: '$_id', hrs: '$totalHrs', weeks: '$weeks' } } } },
-    ])
-      .then((results) => {
-        let lastHr = -1;
         results.forEach((streak) => {
           streak.badges.every((bdge) => {
-            let badgeOfType;
-            for (let i = 0; i < badgeCollection.length; i += 1) {
-              if (badgeCollection[i].badge?.type === 'X Hours for X Week Streak' && badgeCollection[i].badge?.weeks === bdge.weeks) {
-                if (badgeOfType && badgeOfType.totalHrs <= badgeCollection[i].badge.totalHrs) {
-                  removeDupBadge(personId, badgeOfType._id);
-                  badgeOfType = badgeCollection[i].badge;
-                } else if (badgeOfType && badgeOfType.totalHrs > badgeCollection[i].badge.totalHrs) {
-                  removeDupBadge(personId, badgeCollection[i].badge._id);
-                } else if (!badgeOfType) {
-                  badgeOfType = badgeCollection[i].badge;
+            // only filter out badges that have total hours equal to a user's last week tangible hours.
+            if (bdge.hrs === roundedTangibleHrs) {
+              console.log('Badges', bdge);
+              let count = 0;
+              if (user.savedTangibleHrs.length >= bdge.weeks) {
+                const endOfArr = user.savedTangibleHrs.length - 1;
+                /* check tangible hours based on the last 200 weeks.
+                 *start the loop from the most recent week, and count the streak.
+                 */
+                for (let i = endOfArr; i >= 0; i--) {
+                  count++;
+                  console.log(user.savedTangibleHrs[i], i);
+                  if (user.savedTangibleHrs[i] < bdge.hrs) {
+                    count--;
+                    break;
+                  }
                 }
-              }
-            }
-            // check if it is possible to earn this streak
-            if (user.savedTangibleHrs.length >= bdge.weeks) {
-              let awardBadge = true;
-              const endOfArr = user.savedTangibleHrs.length - 1;
-              for (let i = endOfArr; i >= (endOfArr - bdge.weeks + 1); i -= 1) {
-                if (user.savedTangibleHrs[i] < bdge.hrs) {
-                  awardBadge = false;
-                  return true;
-                }
-              }
-              // if all checks for award badge are green double check that we havent already awarded a higher streak for the same number of hours
-              if (awardBadge && bdge.hrs > lastHr) {
-                lastHr = bdge.hrs;
-                if (badgeOfType && badgeOfType.totalHrs < bdge.hrs) {
-                  replaceBadge(personId, mongoose.Types.ObjectId(badgeOfType._id), mongoose.Types.ObjectId(bdge._id));
-                  removePrevHrBadge(personId, user, badgeCollection, bdge.hrs, bdge.weeks);
-                } else if (!badgeOfType) {
+
+                // if there's a badge with a streak that matches the count
+                if (count === bdge.weeks) {
+                  for (let i = 0; i < badgesOfType.length; i++) {
+                    if (badgesOfType[i].totalHrs === bdge.hrs) {
+                      if (badgesOfType[i].weeks < bdge.weeks) {
+                        removeDupBadge(
+                          personId,
+                          mongoose.Types.ObjectId(badgesOfType[i]._id),
+                        );
+                      }
+                    }
+                  }
+
+                  for (let i = 0; i < badgesOfType.length; i++) {
+                    if (
+                      badgesOfType[i]._id.toString() === bdge._id.toString()
+                    ) {
+                      return false;
+                    }
+                  }
+
                   addBadge(personId, mongoose.Types.ObjectId(bdge._id));
-                  removePrevHrBadge(personId, user, badgeCollection, bdge.hrs, bdge.weeks);
-                } else if (badgeOfType && badgeOfType.totalHrs === bdge.hrs) {
-                  increaseBadgeCount(personId, mongoose.Types.ObjectId(badgeOfType._id));
-                  removePrevHrBadge(personId, user, badgeCollection, bdge.hrs, bdge.weeks);
+                  return false;
                 }
-                return false;
               }
             }
             return true;
@@ -846,7 +1064,11 @@ const userHelper = function () {
   };
 
   // 'Lead a team of X+'
-  const checkLeadTeamOfXplus = async function (personId, user, badgeCollection) {
+  const checkLeadTeamOfXplus = async function (
+    personId,
+    user,
+    badgeCollection,
+  ) {
     if (!hasPermission(user.role, 'checkLeadTeamOfXplus')) {
       return;
     }
@@ -877,10 +1099,16 @@ const userHelper = function () {
     let badgeOfType;
     for (let i = 0; i < badgeCollection.length; i += 1) {
       if (badgeCollection[i].badge?.type === 'Lead a team of X+') {
-        if (badgeOfType && badgeOfType.people <= badgeCollection[i].badge.people) {
+        if (
+          badgeOfType
+          && badgeOfType.people <= badgeCollection[i].badge.people
+        ) {
           removeDupBadge(personId, badgeOfType._id);
           badgeOfType = badgeCollection[i].badge;
-        } else if (badgeOfType && badgeOfType.people > badgeCollection[i].badge.people) {
+        } else if (
+          badgeOfType
+          && badgeOfType.people > badgeCollection[i].badge.people
+        ) {
           removeDupBadge(personId, badgeCollection[i].badge._id);
         } else if (!badgeOfType) {
           badgeOfType = badgeCollection[i].badge;
@@ -888,7 +1116,8 @@ const userHelper = function () {
       }
     }
 
-    await badge.find({ type: 'Lead a team of X+' })
+    await badge
+      .find({ type: 'Lead a team of X+' })
       .sort({ people: -1 })
       .then((results) => {
         if (!Array.isArray(results) || !results.length) {
@@ -898,8 +1127,15 @@ const userHelper = function () {
         results.every((elem) => {
           if (teamMembers && teamMembers.length >= elem.people) {
             if (badgeOfType) {
-              if (badgeOfType._id.toString() !== elem._id.toString() && badgeOfType.people < elem.people) {
-                replaceBadge(personId, mongoose.Types.ObjectId(badgeOfType._id), mongoose.Types.ObjectId(elem._id));
+              if (
+                badgeOfType._id.toString() !== elem._id.toString()
+                && badgeOfType.people < elem.people
+              ) {
+                replaceBadge(
+                  personId,
+                  mongoose.Types.ObjectId(badgeOfType._id),
+                  mongoose.Types.ObjectId(elem._id),
+                );
               }
               return false;
             }
@@ -914,27 +1150,47 @@ const userHelper = function () {
   // 'Total Hrs in Category'
   const checkTotalHrsInCat = async function (personId, user, badgeCollection) {
     const categoryTangibleHrs = user.categoryTangibleHrs || [];
-    const categories = ['Food', 'Energy', 'Housing', 'Education', 'Society', 'Economics', 'Stewardship'];
+    const categories = [
+      'Food',
+      'Energy',
+      'Housing',
+      'Education',
+      'Society',
+      'Economics',
+      'Stewardship',
+    ];
     if (categoryTangibleHrs.length === 0) {
       return;
     }
 
     categories.forEach(async (category) => {
-      const categoryHrs = categoryTangibleHrs.find(elem => elem.category === category);
+      const categoryHrs = categoryTangibleHrs.find(
+        elem => elem.category === category,
+      );
       let badgeOfType;
       for (let i = 0; i < badgeCollection.length; i += 1) {
-        if (badgeCollection[i].badge?.type === 'Total Hrs in Category' && badgeCollection[i].badge?.category === category) {
-          if (badgeOfType && badgeOfType.totalHrs <= badgeCollection[i].badge.totalHrs) {
+        if (
+          badgeCollection[i].badge?.type === 'Total Hrs in Category'
+          && badgeCollection[i].badge?.category === category
+        ) {
+          if (
+            badgeOfType
+            && badgeOfType.totalHrs <= badgeCollection[i].badge.totalHrs
+          ) {
             removeDupBadge(personId, badgeOfType._id);
             badgeOfType = badgeCollection[i].badge;
-          } else if (badgeOfType && badgeOfType.totalHrs > badgeCollection[i].badge.totalHrs) {
+          } else if (
+            badgeOfType
+            && badgeOfType.totalHrs > badgeCollection[i].badge.totalHrs
+          ) {
             removeDupBadge(personId, badgeCollection[i].badge._id);
           } else if (!badgeOfType) {
             badgeOfType = badgeCollection[i].badge;
           }
         }
       }
-      await badge.find({ type: 'Total Hrs in Category', category })
+      await badge
+        .find({ type: 'Total Hrs in Category', category })
         .sort({ totalHrs: -1 })
         .then((results) => {
           if (!Array.isArray(results) || !results.length || !categoryHrs) {
@@ -944,8 +1200,15 @@ const userHelper = function () {
           results.every((elem) => {
             if (categoryHrs.hrs >= elem.totalHrs) {
               if (badgeOfType) {
-                if (badgeOfType._id.toString() !== elem._id.toString() && badgeOfType.totalHrs < elem.totalHrs) {
-                  replaceBadge(personId, mongoose.Types.ObjectId(badgeOfType._id), mongoose.Types.ObjectId(elem._id));
+                if (
+                  badgeOfType._id.toString() !== elem._id.toString()
+                  && badgeOfType.totalHrs < elem.totalHrs
+                ) {
+                  replaceBadge(
+                    personId,
+                    mongoose.Types.ObjectId(badgeOfType._id),
+                    mongoose.Types.ObjectId(elem._id),
+                  );
                 }
                 return false;
               }
@@ -993,16 +1256,30 @@ const userHelper = function () {
       .endOf('week')
       .format('YYYY-MM-DD');
 
-    return timeEntries.find({ personId: userId, dateOfWork: { $gte: pdtstart, $lte: pdtend }, isTangible: true }, 'totalSeconds')
+    return timeEntries
+      .find(
+        {
+          personId: userId,
+          dateOfWork: { $gte: pdtstart, $lte: pdtend },
+          isTangible: true,
+        },
+        'totalSeconds',
+      )
       .then((results) => {
-        const totalTangibleWeeklySeconds = results.reduce((acc, { totalSeconds }) => acc + totalSeconds, 0);
+        const totalTangibleWeeklySeconds = results.reduce(
+          (acc, { totalSeconds }) => acc + totalSeconds,
+          0,
+        );
         return (totalTangibleWeeklySeconds / 3600).toFixed(2);
       });
   };
 
   const deActivateUser = async () => {
     try {
-      const users = await userProfile.find({ isActive: true, endDate: { $exists: true } }, '_id isActive endDate');
+      const users = await userProfile.find(
+        { isActive: true, endDate: { $exists: true } },
+        '_id isActive endDate',
+      );
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
         const { endDate } = user;
@@ -1018,14 +1295,18 @@ const userHelper = function () {
           const id = user._id;
           const person = await userProfile.findById(id);
           const lastDay = moment(person.endDate).format('YYYY-MM-DD');
-          logger.logInfo(`User with id: ${user._id} was de-acticated at ${moment().format()}.`);
+          logger.logInfo(
+            `User with id: ${
+              user._id
+            } was de-acticated at ${moment().format()}.`,
+          );
           const subject = `IMPORTANT:${person.firstName} ${person.lastName} has been deactivated in the Highest Good Network`;
 
           const emailBody = `<p> Hi Admin! </p>
 
           <p>This email is to let you know that ${person.firstName} ${person.lastName} has completed their scheduled last day (${lastDay}) and been deactivated in the Highest Good Network application. </p>
           
-          <p>This is their email from the system: ${person.email }. Please email them to let them know their work is complete and thank them for their volunteer time with One Community. </p>
+          <p>This is their email from the system: ${person.email}. Please email them to let them know their work is complete and thank them for their volunteer time with One Community. </p>
           
           <p> Thanks! </p>
           

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -1,60 +1,59 @@
-const mongoose = require("mongoose");
-const moment = require("moment-timezone");
-const _ = require("lodash");
-const userProfile = require("../models/userProfile");
-const timeEntries = require("../models/timeentry");
-const badge = require("../models/badge");
-const myTeam = require("./helperModels/myTeam");
-const dashboardHelper = require("./dashboardhelper")();
-const reportHelper = require("./reporthelper")();
+const mongoose = require('mongoose');
+const moment = require('moment-timezone');
+const _ = require('lodash');
+const userProfile = require('../models/userProfile');
+const timeEntries = require('../models/timeentry');
+const badge = require('../models/badge');
+const myTeam = require('./helperModels/myTeam');
+const dashboardHelper = require('./dashboardhelper')();
+const reportHelper = require('./reporthelper')();
 
-const emailSender = require("../utilities/emailSender");
+const emailSender = require('../utilities/emailSender');
 
-const logger = require("../startup/logger");
-const hasPermission = require("../utilities/permissions");
+const logger = require('../startup/logger');
+const hasPermission = require('../utilities/permissions');
 
 const userHelper = function () {
   const getTeamMembers = function (user) {
     const userId = mongoose.Types.ObjectId(user._id);
     // var teamid = userdetails.teamId;
     return myTeam.findById(userId).select({
-      "myTeam._id": 1,
-      "myTeam.role": 1,
-      "myTeam.fullName": 1,
+      'myTeam._id': 1,
+      'myTeam.role': 1,
+      'myTeam.fullName': 1,
       _id: 0,
     });
   };
 
   const getUserName = async function (userId) {
     const userid = mongoose.Types.ObjectId(userId);
-    return userProfile.findById(userid, "firstName lastName");
+    return userProfile.findById(userid, 'firstName lastName');
   };
 
   const validateProfilePic = function (profilePic) {
-    const picParts = profilePic.split("base64");
+    const picParts = profilePic.split('base64');
     let result = true;
     const errors = [];
 
     if (picParts.length < 2) {
       return {
         result: false,
-        errors: "Invalid image",
+        errors: 'Invalid image',
       };
     }
 
     // validate size
     const imageSize = picParts[1].length;
-    const sizeInBytes =
-      (4 * Math.ceil(imageSize / 3) * 0.5624896334383812) / 1024;
+    const sizeInBytes = (4 * Math.ceil(imageSize / 3) * 0.5624896334383812) / 1024;
 
     if (sizeInBytes > 50) {
-      errors.push("Image size should not exceed 50KB");
+      errors.push('Image size should not exceed 50KB');
       result = false;
     }
 
-    const imageType = picParts[0].split("/")[1];
-    if (imageType !== "jpeg;" && imageType !== "png;") {
-      errors.push("Image type shoud be either jpeg or png.");
+    const imageType = picParts[0].split('/')[1];
+    if (imageType !== 'jpeg;' && imageType !== 'png;') {
+      errors.push('Image type shoud be either jpeg or png.');
       result = false;
     }
 
@@ -68,7 +67,7 @@ const userHelper = function () {
     firstName,
     lastName,
     infringement,
-    totalInfringements
+    totalInfringements,
   ) {
     const text = `Dear <b>${firstName} ${lastName}</b>,
         <p>Oops, it looks like something happened and you’ve managed to get a blue square.</p>
@@ -94,10 +93,10 @@ const userHelper = function () {
    * @return {void}
    */
   const emailWeeklySummariesForAllUsers = async (weekIndex = 1) => {
-    const currentFormattedDate = moment().tz("America/Los_Angeles").format();
+    const currentFormattedDate = moment().tz('America/Los_Angeles').format();
 
     logger.logInfo(
-      `Job for emailing all users' weekly summaries starting at ${currentFormattedDate}`
+      `Job for emailing all users' weekly summaries starting at ${currentFormattedDate}`,
     );
 
     const emails = [];
@@ -105,7 +104,7 @@ const userHelper = function () {
     try {
       const results = await reportHelper.weeklySummaries(weekIndex, weekIndex);
 
-      let emailBody = "<h2>Weekly Summaries for all active users:</h2>";
+      let emailBody = '<h2>Weekly Summaries for all active users:</h2>';
 
       const weeklySummaryNotProvidedMessage =
         '<div><b>Weekly Summary:</b> <span style="color: red;"> Not provided! </span> </div>';
@@ -114,9 +113,7 @@ const userHelper = function () {
         '<div><b>Weekly Summary:</b> <span style="color: magenta;"> Not required for this user </span></div>';
 
       results.sort((a, b) =>
-        `${a.firstName} ${a.lastName}`.localeCompare(
-          `${b.firstName} ${b.lastname}`
-        )
+        `${a.firstName} ${a.lastName}`.localeCompare(`${b.firstName} ${b.lastname}`),
       );
 
       for (let i = 0; i < results.length; i += 1) {
@@ -141,9 +138,7 @@ const userHelper = function () {
         // hence totalSeconds[0] should be used
         const hoursLogged = result.totalSeconds[0] / 3600 || 0;
 
-        const mediaUrlLink = mediaUrl
-          ? `<a href="${mediaUrl}">${mediaUrl}</a>`
-          : "Not provided!";
+        const mediaUrlLink = mediaUrl ? `<a href="${mediaUrl}">${mediaUrl}</a>` : 'Not provided!';
 
         let weeklySummaryMessage = weeklySummaryNotProvidedMessage;
 
@@ -155,8 +150,8 @@ const userHelper = function () {
               <div>
                 <b>Weekly Summary</b>
                 (for the week ending on <b>${moment(dueDate)
-                  .tz("America/Los_Angeles")
-                  .format("YYYY-MMM-DD")}</b>):
+                  .tz('America/Los_Angeles')
+                  .format('YYYY-MMM-DD')}</b>):
               </div>
               <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}">
                 ${summary}
@@ -172,24 +167,20 @@ const userHelper = function () {
         <div style="padding: 20px 0; margin-top: 5px; border-bottom: 1px solid #828282;">
           <b>Name:</b> ${firstName} ${lastName}
           <p>
-            <b>Media URL:</b> ${
-              mediaUrlLink || '<span style="color: red;">Not provided!</span>'
-            }
+            <b>Media URL:</b> ${mediaUrlLink || '<span style="color: red;">Not provided!</span>'}
           </p>
           ${
             weeklySummariesCount === 8
               ? `<p style="color: blue;"><b>Total Valid Weekly Summaries: ${weeklySummariesCount}</b></p>`
               : `<p><b>Total Valid Weekly Summaries</b>: ${
-                  weeklySummariesCount || "No valid submissions yet!"
+                  weeklySummariesCount || 'No valid submissions yet!'
                 }</p>`
           }
           ${
             hoursLogged >= weeklyComittedHours
-              ? `<p><b>Hours logged</b>: ${hoursLogged.toFixed(
-                  2
-                )} / ${weeklyComittedHours}</p>`
+              ? `<p><b>Hours logged</b>: ${hoursLogged.toFixed(2)} / ${weeklyComittedHours}</p>`
               : `<p style="color: red;"><b>Hours logged</b>: ${hoursLogged.toFixed(
-                  2
+                  2,
                 )} / ${weeklyComittedHours}</p>`
           }
           ${weeklySummaryMessage}
@@ -199,10 +190,8 @@ const userHelper = function () {
       // Necessary because our version of node is outdated
       // and doesn't have String.prototype.replaceAll
       let emailString = [...new Set(emails)].toString();
-      while (emailString.includes(","))
-        emailString = emailString.replace(",", "\n");
-      while (emailString.includes("\n"))
-        emailString = emailString.replace("\n", ", ");
+      while (emailString.includes(',')) emailString = emailString.replace(',', '\n');
+      while (emailString.includes('\n')) emailString = emailString.replace('\n', ', ');
 
       emailBody += `\n
         <div>
@@ -214,10 +203,10 @@ const userHelper = function () {
       `;
 
       emailSender(
-        "onecommunityglobal@gmail.com, sangam.pravah@gmail.com, onecommunityhospitality@gmail.com",
-        "Weekly Summaries for all active users...",
+        'onecommunityglobal@gmail.com, sangam.pravah@gmail.com, onecommunityhospitality@gmail.com',
+        'Weekly Summaries for all active users...',
         emailBody,
-        null
+        null,
       );
     } catch (err) {
       logger.logException(err);
@@ -241,8 +230,8 @@ const userHelper = function () {
           weeklySummaries: {
             $each: [
               {
-                dueDate: moment().tz("America/Los_Angeles").endOf("week"),
-                summary: "",
+                dueDate: moment().tz('America/Los_Angeles').endOf('week'),
+                summary: '',
               },
             ],
             $position: 0,
@@ -258,7 +247,7 @@ const userHelper = function () {
               {
                 $inc: { weeklySummariesCount: 1 },
               },
-              { new: true }
+              { new: true },
             )
             .catch((error) => logger.logException(error));
         }
@@ -275,26 +264,20 @@ const userHelper = function () {
    */
   const assignBlueSquareForTimeNotMet = async () => {
     try {
-      const currentFormattedDate = moment().tz("America/Los_Angeles").format();
+      const currentFormattedDate = moment().tz('America/Los_Angeles').format();
 
       logger.logInfo(
-        `Job for assigning blue square for commitment not met starting at ${currentFormattedDate}`
+        `Job for assigning blue square for commitment not met starting at ${currentFormattedDate}`,
       );
 
       const pdtStartOfLastWeek = moment()
-        .tz("America/Los_Angeles")
-        .startOf("week")
-        .subtract(1, "week");
+        .tz('America/Los_Angeles')
+        .startOf('week')
+        .subtract(1, 'week');
 
-      const pdtEndOfLastWeek = moment()
-        .tz("America/Los_Angeles")
-        .endOf("week")
-        .subtract(1, "week");
+      const pdtEndOfLastWeek = moment().tz('America/Los_Angeles').endOf('week').subtract(1, 'week');
 
-      const users = await userProfile.find(
-        { isActive: true },
-        "_id weeklySummaries"
-      );
+      const users = await userProfile.find({ isActive: true }, '_id weeklySummaries');
 
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
@@ -303,10 +286,7 @@ const userHelper = function () {
 
         let hasWeeklySummary = false;
 
-        if (
-          Array.isArray(user.weeklySummaries) &&
-          user.weeklySummaries.length
-        ) {
+        if (Array.isArray(user.weeklySummaries) && user.weeklySummaries.length) {
           const { summary } = user.weeklySummaries[0];
           if (summary) {
             hasWeeklySummary = true;
@@ -319,7 +299,7 @@ const userHelper = function () {
         const results = await dashboardHelper.laborthisweek(
           personId,
           pdtStartOfLastWeek,
-          pdtEndOfLastWeek
+          pdtEndOfLastWeek,
         );
 
         const { weeklyComittedHours, timeSpent_hrs: timeSpent } = results[0];
@@ -343,14 +323,14 @@ const userHelper = function () {
               lastWeekTangibleHrs: timeSpent || 0,
             },
           },
-          { new: true }
+          { new: true },
         );
 
         if (updateResult?.weeklySummaryNotReq) {
           hasWeeklySummary = true;
         }
 
-        const cutOffDate = moment().subtract(1, "year");
+        const cutOffDate = moment().subtract(1, 'year');
 
         const oldInfringements = [];
         for (let k = 0; k < updateResult?.infringements.length; k += 1) {
@@ -372,27 +352,27 @@ const userHelper = function () {
                 oldInfringements: { $each: oldInfringements, $slice: -10 },
               },
             },
-            { new: true }
+            { new: true },
           );
         }
 
         if (timeNotMet || !hasWeeklySummary) {
           if (timeNotMet && !hasWeeklySummary) {
             description = `System auto-assigned infringement for two reasons: not meeting weekly volunteer time commitment as well as not submitting a weekly summary. For the hours portion, you logged ${timeSpent} hours against committed effort of ${weeklyComittedHours} hours in the week starting ${pdtStartOfLastWeek.format(
-              "dddd YYYY-MM-DD"
-            )} and ending ${pdtEndOfLastWeek.format("dddd YYYY-MM-DD")}.`;
+              'dddd YYYY-MM-DD',
+            )} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
           } else if (timeNotMet) {
             description = `System auto-assigned infringement for not meeting weekly volunteer time commitment. You logged ${timeSpent} hours against committed effort of ${weeklyComittedHours} hours in the week starting ${pdtStartOfLastWeek.format(
-              "dddd YYYY-MM-DD"
-            )} and ending ${pdtEndOfLastWeek.format("dddd YYYY-MM-DD")}.`;
+              'dddd YYYY-MM-DD',
+            )} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
           } else {
             description = `System auto-assigned infringement for not submitting a weekly summary for the week starting ${pdtStartOfLastWeek.format(
-              "dddd YYYY-MM-DD"
-            )} and ending ${pdtEndOfLastWeek.format("dddd YYYY-MM-DD")}.`;
+              'dddd YYYY-MM-DD',
+            )} and ending ${pdtEndOfLastWeek.format('dddd YYYY-MM-DD')}.`;
           }
 
           const infringement = {
-            date: moment().utc().format("YYYY-MM-DD"),
+            date: moment().utc().format('YYYY-MM-DD'),
             description,
           };
 
@@ -403,32 +383,32 @@ const userHelper = function () {
                 infringements: infringement,
               },
             },
-            { new: true }
+            { new: true },
           );
 
           emailSender(
             status.email,
-            "New Infringement Assigned",
+            'New Infringement Assigned',
             getInfringementEmailBody(
               status.firstName,
               status.lastName,
               infringement,
-              status.infringements.length
+              status.infringements.length,
             ),
             null,
-            "onecommunityglobal@gmail.com"
+            'onecommunityglobal@gmail.com',
           );
 
           const categories = await dashboardHelper.laborThisWeekByCategory(
             personId,
             pdtStartOfLastWeek,
-            pdtEndOfLastWeek
+            pdtEndOfLastWeek,
           );
 
           if (Array.isArray(categories) && categories.length > 0) {
             await userProfile.findOneAndUpdate(
               { _id: personId, categoryTangibleHrs: { $exists: false } },
-              { $set: { categoryTangibleHrs: [] } }
+              { $set: { categoryTangibleHrs: [] } },
             );
           } else {
             continue;
@@ -438,20 +418,20 @@ const userHelper = function () {
             const elem = categories[j];
 
             if (elem._id == null) {
-              elem._id = "Other";
+              elem._id = 'Other';
             }
 
             const updateResult2 = await userProfile.findOneAndUpdate(
-              { _id: personId, "categoryTangibleHrs.category": elem._id },
-              { $inc: { "categoryTangibleHrs.$.hrs": elem.timeSpent_hrs } },
-              { new: true }
+              { _id: personId, 'categoryTangibleHrs.category': elem._id },
+              { $inc: { 'categoryTangibleHrs.$.hrs': elem.timeSpent_hrs } },
+              { new: true },
             );
 
             if (!updateResult2) {
               await userProfile.findOneAndUpdate(
                 {
                   _id: personId,
-                  "categoryTangibleHrs.category": { $ne: elem._id },
+                  'categoryTangibleHrs.category': { $ne: elem._id },
                 },
                 {
                   $addToSet: {
@@ -460,7 +440,7 @@ const userHelper = function () {
                       hrs: elem.timeSpent_hrs,
                     },
                   },
-                }
+                },
               );
             }
           }
@@ -472,13 +452,10 @@ const userHelper = function () {
 
     // processWeeklySummaries for nonActive users
     try {
-      const inactiveUsers = await userProfile.find({ isActive: false }, "_id");
+      const inactiveUsers = await userProfile.find({ isActive: false }, '_id');
       for (let i = 0; i < inactiveUsers.length; i += 1) {
         const user = inactiveUsers[i];
-        await processWeeklySummariesByUserId(
-          mongoose.Types.ObjectId(user._id),
-          false
-        );
+        await processWeeklySummariesByUserId(mongoose.Types.ObjectId(user._id), false);
       }
     } catch (err) {
       logger.logException(err);
@@ -486,13 +463,13 @@ const userHelper = function () {
   };
 
   const deleteBlueSquareAfterYear = async () => {
-    const currentFormattedDate = moment().tz("America/Los_Angeles").format();
+    const currentFormattedDate = moment().tz('America/Los_Angeles').format();
 
     logger.logInfo(
-      `Job for deleting blue squares older than 1 year starting at ${currentFormattedDate}`
+      `Job for deleting blue squares older than 1 year starting at ${currentFormattedDate}`,
     );
 
-    const cutOffDate = moment().subtract(1, "year").format("YYYY-MM-DD");
+    const cutOffDate = moment().subtract(1, 'year').format('YYYY-MM-DD');
 
     try {
       const results = await userProfile.updateMany(
@@ -505,7 +482,7 @@ const userHelper = function () {
               },
             },
           },
-        }
+        },
       );
 
       logger.logInfo(results);
@@ -515,16 +492,16 @@ const userHelper = function () {
   };
 
   const reActivateUser = async () => {
-    const currentFormattedDate = moment().tz("America/Los_Angeles").format();
+    const currentFormattedDate = moment().tz('America/Los_Angeles').format();
 
     logger.logInfo(
-      `Job for activating users based on scheduled re-activation date starting at ${currentFormattedDate}`
+      `Job for activating users based on scheduled re-activation date starting at ${currentFormattedDate}`,
     );
 
     try {
       const users = await userProfile.find(
         { isActive: false, reactivationDate: { $exists: true } },
-        "_id isActive reactivationDate"
+        '_id isActive reactivationDate',
       );
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
@@ -539,21 +516,17 @@ const userHelper = function () {
                 endDate: user.endDate,
               },
             },
-            { new: true }
+            { new: true },
           );
           logger.logInfo(
             `User with id: ${user._id} was re-acticated at ${moment()
-              .tz("America/Los_Angeles")
-              .format()}.`
+              .tz('America/Los_Angeles')
+              .format()}.`,
           );
           const id = user._id;
           const person = await userProfile.findById(id);
-          const endDate = moment(person.endDate).format("YYYY-MM-DD");
-          logger.logInfo(
-            `User with id: ${
-              user._id
-            } was re-acticated at ${moment().format()}.`
-          );
+          const endDate = moment(person.endDate).format('YYYY-MM-DD');
+          logger.logInfo(`User with id: ${user._id} was re-acticated at ${moment().format()}.`);
           const subject = `IMPORTANT:${person.firstName} ${person.lastName} has been RE-activated in the Highest Good Network`;
 
           const emailBody = `<p> Hi Admin! </p>
@@ -566,13 +539,7 @@ const userHelper = function () {
           
           <p>The HGN A.I. (and One Community)</p>`;
 
-          emailSender(
-            "onecommunityglobal@gmail.com",
-            subject,
-            emailBody,
-            null,
-            null
-          );
+          emailSender('onecommunityglobal@gmail.com', subject, emailBody, null, null);
         }
       }
     } catch (err) {
@@ -580,81 +547,63 @@ const userHelper = function () {
     }
   };
 
-  const notifyInfringements = function (
-    original,
-    current,
-    firstName,
-    lastName,
-    emailAddress
-  ) {
+  const notifyInfringements = function (original, current, firstName, lastName, emailAddress) {
     if (!current) return;
     const newOriginal = original.toObject();
     const newCurrent = current.toObject();
     const totalInfringements = newCurrent.length;
     let newInfringements = [];
-    newInfringements = _.differenceWith(
-      newCurrent,
-      newOriginal,
-      (arrVal, othVal) => arrVal._id.equals(othVal._id)
+    newInfringements = _.differenceWith(newCurrent, newOriginal, (arrVal, othVal) =>
+      arrVal._id.equals(othVal._id),
     );
     newInfringements.forEach((element) => {
       emailSender(
         emailAddress,
-        "New Infringement Assigned",
-        getInfringementEmailBody(
-          firstName,
-          lastName,
-          element,
-          totalInfringements
-        ),
+        'New Infringement Assigned',
+        getInfringementEmailBody(firstName, lastName, element, totalInfringements),
         null,
-        "onecommunityglobal@gmail.com"
+        'onecommunityglobal@gmail.com',
       );
     });
   };
 
   const replaceBadge = async function (personId, oldBadgeId, newBadgeId) {
-    console.log("Replacing Badge", personId, oldBadgeId, newBadgeId);
+    console.log('Replacing Badge', personId, oldBadgeId, newBadgeId);
     userProfile.updateOne(
-      { _id: personId, "badgeCollection.badge": oldBadgeId },
+      { _id: personId, 'badgeCollection.badge': oldBadgeId },
       {
         $set: {
-          "badgeCollection.$.badge": newBadgeId,
-          "badgeCollection.$.lastModified": Date.now().toString(),
-          "badgeCollection.$.count": 1,
+          'badgeCollection.$.badge': newBadgeId,
+          'badgeCollection.$.lastModified': Date.now().toString(),
+          'badgeCollection.$.count': 1,
         },
       },
       (err) => {
         if (err) {
           console.log(err);
         }
-      }
+      },
     );
   };
 
   const increaseBadgeCount = async function (personId, badgeId) {
-    console.log("Increase Badge Count", personId, badgeId);
+    console.log('Increase Badge Count', personId, badgeId);
     userProfile.updateOne(
-      { _id: personId, "badgeCollection.badge": badgeId },
+      { _id: personId, 'badgeCollection.badge': badgeId },
       {
-        $inc: { "badgeCollection.$.count": 1 },
-        $set: { "badgeCollection.$.lastModified": Date.now().toString() },
+        $inc: { 'badgeCollection.$.count': 1 },
+        $set: { 'badgeCollection.$.lastModified': Date.now().toString() },
       },
       (err) => {
         if (err) {
           console.log(err);
         }
-      }
+      },
     );
   };
 
-  const addBadge = async function (
-    personId,
-    badgeId,
-    count = 1,
-    featured = false
-  ) {
-    console.log("Adding Badge ", personId, badgeId, count);
+  const addBadge = async function (personId, badgeId, count = 1, featured = false) {
+    console.log('Adding Badge ', personId, badgeId, count);
     userProfile.findByIdAndUpdate(
       personId,
       {
@@ -671,12 +620,12 @@ const userHelper = function () {
         if (err) {
           console.log(err);
         }
-      }
+      },
     );
   };
 
   const removeDupBadge = async function (personId, badgeId) {
-    console.log("Removing Badge ", personId, badgeId);
+    console.log('Removing Badge ', personId, badgeId);
     userProfile.findByIdAndUpdate(
       personId,
       {
@@ -688,40 +637,34 @@ const userHelper = function () {
         if (err) {
           console.log(err);
         }
-      }
+      },
     );
   };
 
   const changeBadgeCount = async function (personId, badgeId, count) {
-    console.log("Changing Badge Count", personId, badgeId, count);
+    console.log('Changing Badge Count', personId, badgeId, count);
     if (count === 0) {
       removeDupBadge(personId, badgeId);
     } else {
       userProfile.updateOne(
-        { _id: personId, "badgeCollection.badge": badgeId },
+        { _id: personId, 'badgeCollection.badge': badgeId },
         {
           $set: {
-            "badgeCollection.$.count": count,
-            "badgeCollection.$.lastModified": Date.now().toString(),
+            'badgeCollection.$.count': count,
+            'badgeCollection.$.lastModified': Date.now().toString(),
           },
         },
         (err) => {
           if (err) {
             console.log(err);
           }
-        }
+        },
       );
     }
   };
 
   // remove the last badge you earned on this streak(not including 1)
-  const removePrevHrBadge = async function (
-    personId,
-    user,
-    badgeCollection,
-    hrs,
-    weeks
-  ) {
+  const removePrevHrBadge = async function (personId, user, badgeCollection, hrs, weeks) {
     // Check each Streak Greater than One to check if it works
     if (weeks < 3) {
       return;
@@ -731,7 +674,7 @@ const userHelper = function () {
       .aggregate([
         {
           $match: {
-            type: "X Hours for X Week Streak",
+            type: 'X Hours for X Week Streak',
             weeks: { $gt: 1, $lt: weeks },
             totalHrs: hrs,
           },
@@ -739,9 +682,9 @@ const userHelper = function () {
         { $sort: { weeks: -1, totalHrs: -1 } },
         {
           $group: {
-            _id: "$weeks",
+            _id: '$weeks',
             badges: {
-              $push: { _id: "$_id", hrs: "$totalHrs", weeks: "$weeks" },
+              $push: { _id: '$_id', hrs: '$totalHrs', weeks: '$weeks' },
             },
           },
         },
@@ -751,8 +694,7 @@ const userHelper = function () {
           streak.badges.every((bdge) => {
             for (let i = 0; i < badgeCollection.length; i += 1) {
               if (
-                badgeCollection[i].badge?.type ===
-                  "X Hours for X Week Streak" &&
+                badgeCollection[i].badge?.type === 'X Hours for X Week Streak' &&
                 badgeCollection[i].badge?.weeks === bdge.weeks &&
                 bdge.hrs === hrs &&
                 !removed
@@ -760,7 +702,7 @@ const userHelper = function () {
                 changeBadgeCount(
                   personId,
                   badgeCollection[i].badge._id,
-                  badgeCollection[i].badge.count - 1
+                  badgeCollection[i].badge.count - 1,
                 );
                 removed = true;
                 return false;
@@ -773,24 +715,14 @@ const userHelper = function () {
   };
 
   //   'No Infringement Streak',
-  const checkNoInfringementStreak = async function (
-    personId,
-    user,
-    badgeCollection
-  ) {
+  const checkNoInfringementStreak = async function (personId, user, badgeCollection) {
     let badgeOfType;
     for (let i = 0; i < badgeCollection.length; i += 1) {
-      if (badgeCollection[i].badge?.type === "No Infringement Streak") {
-        if (
-          badgeOfType &&
-          badgeOfType.months <= badgeCollection[i].badge.months
-        ) {
+      if (badgeCollection[i].badge?.type === 'No Infringement Streak') {
+        if (badgeOfType && badgeOfType.months <= badgeCollection[i].badge.months) {
           removeDupBadge(personId, badgeOfType._id);
           badgeOfType = badgeCollection[i].badge;
-        } else if (
-          badgeOfType &&
-          badgeOfType.months > badgeCollection[i].badge.months
-        ) {
+        } else if (badgeOfType && badgeOfType.months > badgeCollection[i].badge.months) {
           removeDupBadge(personId, badgeCollection[i].badge._id);
         } else if (!badgeOfType) {
           badgeOfType = badgeCollection[i].badge;
@@ -798,7 +730,7 @@ const userHelper = function () {
       }
     }
     await badge
-      .find({ type: "No Infringement Streak" })
+      .find({ type: 'No Infringement Streak' })
       .sort({ months: -1 })
       .then((results) => {
         if (!Array.isArray(results) || !results.length) {
@@ -809,20 +741,15 @@ const userHelper = function () {
           // Cannot account for time paused yet
 
           if (elem.months <= 12) {
-            if (
-              moment().diff(moment(user.createdDate), "months", true) >=
-              elem.months
-            ) {
+            if (moment().diff(moment(user.createdDate), 'months', true) >= elem.months) {
               if (
                 user.infringements.length === 0 ||
                 Math.abs(
                   moment().diff(
-                    moment(
-                      user.infringements[user.infringements?.length - 1].date
-                    ),
-                    "months",
-                    true
-                  )
+                    moment(user.infringements[user.infringements?.length - 1].date),
+                    'months',
+                    true,
+                  ),
                 ) >= elem.months
               ) {
                 if (badgeOfType) {
@@ -830,7 +757,7 @@ const userHelper = function () {
                     replaceBadge(
                       personId,
                       mongoose.Types.ObjectId(badgeOfType._id),
-                      mongoose.Types.ObjectId(elem._id)
+                      mongoose.Types.ObjectId(elem._id),
                     );
                   }
                   return false;
@@ -840,21 +767,15 @@ const userHelper = function () {
               }
             }
           } else if (user?.infringements?.length === 0) {
-            if (
-              moment().diff(moment(user.createdDate), "months", true) >=
-              elem.months
-            ) {
+            if (moment().diff(moment(user.createdDate), 'months', true) >= elem.months) {
               if (
                 user.oldinfringements.length === 0 ||
                 Math.abs(
                   moment().diff(
-                    moment(
-                      user.oldinfringements[user.oldinfringements?.length - 1]
-                        .date
-                    ),
-                    "months",
-                    true
-                  )
+                    moment(user.oldinfringements[user.oldinfringements?.length - 1].date),
+                    'months',
+                    true,
+                  ),
                 ) >=
                   elem.months - 12
               ) {
@@ -863,7 +784,7 @@ const userHelper = function () {
                     replaceBadge(
                       personId,
                       mongoose.Types.ObjectId(badgeOfType._id),
-                      mongoose.Types.ObjectId(elem._id)
+                      mongoose.Types.ObjectId(elem._id),
                     );
                   }
                   return false;
@@ -879,19 +800,15 @@ const userHelper = function () {
   };
 
   // 'Minimum Hours Multiple',
-  const checkMinHoursMultiple = async function (
-    personId,
-    user,
-    badgeCollection
-  ) {
+  const checkMinHoursMultiple = async function (personId, user, badgeCollection) {
     const badgesOfType = [];
     for (let i = 0; i < badgeCollection.length; i += 1) {
-      if (badgeCollection[i].badge?.type === "Minimum Hours Multiple") {
+      if (badgeCollection[i].badge?.type === 'Minimum Hours Multiple') {
         badgesOfType.push(badgeCollection[i].badge);
       }
     }
     await badge
-      .find({ type: "Minimum Hours Multiple" })
+      .find({ type: 'Minimum Hours Multiple' })
       .sort({ multiple: -1 })
       .then((results) => {
         if (!Array.isArray(results) || !results.length) {
@@ -901,10 +818,7 @@ const userHelper = function () {
         for (let i = 0; i < results.length; i += 1) {
           // this needs to be a for loop so that the returns break before assigning badges for lower multiples
           const elem = results[i]; // making variable elem accessible for below code
-          if (
-            user.lastWeekTangibleHrs / user.weeklyComittedHours >=
-            elem.multiple
-          ) {
+          if (user.lastWeekTangibleHrs / user.weeklyComittedHours >= elem.multiple) {
             let theBadge;
             for (let j = 0; j < badgesOfType.length; j += 1) {
               if (badgesOfType[j]._id.toString() === elem._id.toString()) {
@@ -928,7 +842,7 @@ const userHelper = function () {
   const checkPersonalMax = async function (personId, user, badgeCollection) {
     let badgeOfType;
     for (let i = 0; i < badgeCollection.length; i += 1) {
-      if (badgeCollection[i].badge?.type === "Personal Max") {
+      if (badgeCollection[i].badge?.type === 'Personal Max') {
         if (badgeOfType) {
           removeDupBadge(personId, badgeOfType._id);
           badgeOfType = badgeCollection[i].badge;
@@ -937,7 +851,7 @@ const userHelper = function () {
         }
       }
     }
-    await badge.findOne({ type: "Personal Max" }).then((results) => {
+    await badge.findOne({ type: 'Personal Max' }).then((results) => {
       if (
         user.lastWeekTangibleHrs &&
         user.lastWeekTangibleHrs >= 1 &&
@@ -947,14 +861,10 @@ const userHelper = function () {
           changeBadgeCount(
             personId,
             mongoose.Types.ObjectId(badgeOfType._id),
-            user.personalBestMaxHrs
+            user.personalBestMaxHrs,
           );
         } else {
-          addBadge(
-            personId,
-            mongoose.Types.ObjectId(results._id),
-            user.personalBestMaxHrs
-          );
+          addBadge(personId, mongoose.Types.ObjectId(results._id), user.personalBestMaxHrs);
         }
       }
     });
@@ -964,26 +874,20 @@ const userHelper = function () {
   const checkMostHrsWeek = async function (personId, user, badgeCollection) {
     let badgeOfType;
     for (let i = 0; i < badgeCollection.length; i += 1) {
-      if (badgeCollection[i].badge?.type === "Most Hrs in Week") {
+      if (badgeCollection[i].badge?.type === 'Most Hrs in Week') {
         badgeOfType = badgeCollection[i].badge;
       }
     }
-    await badge.findOne({ type: "Most Hrs in Week" }).then((results) => {
+    await badge.findOne({ type: 'Most Hrs in Week' }).then((results) => {
       userProfile
         .aggregate([
           { $match: { isActive: true } },
-          { $group: { _id: 1, maxHours: { $max: "$lastWeekTangibleHrs" } } },
+          { $group: { _id: 1, maxHours: { $max: '$lastWeekTangibleHrs' } } },
         ])
         .then((userResults) => {
-          if (
-            user.lastWeekTangibleHrs &&
-            user.lastWeekTangibleHrs >= userResults[0].maxHours
-          ) {
+          if (user.lastWeekTangibleHrs && user.lastWeekTangibleHrs >= userResults[0].maxHours) {
             if (badgeOfType) {
-              increaseBadgeCount(
-                personId,
-                mongoose.Types.ObjectId(badgeOfType._id)
-              );
+              increaseBadgeCount(personId, mongoose.Types.ObjectId(badgeOfType._id));
             } else {
               addBadge(personId, mongoose.Types.ObjectId(results._id));
             }
@@ -996,22 +900,22 @@ const userHelper = function () {
   const checkXHrsForXWeeks = async function (personId, user, badgeCollection) {
     const badgesOfType = [];
     for (let i = 0; i < badgeCollection.length; i += 1) {
-      if (badgeCollection[i].badge?.type === "X Hours for X Week Streak") {
+      if (badgeCollection[i].badge?.type === 'X Hours for X Week Streak') {
         badgesOfType.push(badgeCollection[i].badge);
       }
     }
     // lastWeekTangibleHrs is rounded to the integer's smallest tenth place.
     const roundedTangibleHrs = Math.floor(user.lastWeekTangibleHrs / 10) * 10;
 
-    // get all the badges with weeks > 1 that are of the following type.
+    // get all the badges with weeks >= 1 that are of the following type.
     await badge
       .aggregate([
-        { $match: { type: "X Hours for X Week Streak", weeks: { $gte: 1 } } },
+        { $match: { type: 'X Hours for X Week Streak', weeks: { $gte: 1 } } },
         {
           $group: {
-            _id: "$weeks",
+            _id: '$weeks',
             badges: {
-              $push: { _id: "$_id", hrs: "$totalHrs", weeks: "$weeks" },
+              $push: { _id: '$_id', hrs: '$totalHrs', weeks: '$weeks' },
             },
           },
         },
@@ -1022,7 +926,7 @@ const userHelper = function () {
           streak.badges.every((bdge) => {
             // only filter out badges that have total hours equal to a user's last week tangible hours.
             if (bdge.hrs === roundedTangibleHrs) {
-              console.log("Badges", bdge);
+              console.log('Badges', bdge);
               let count = 0;
               if (user.savedTangibleHrs.length >= bdge.weeks) {
                 const endOfArr = user.savedTangibleHrs.length - 1;
@@ -1031,9 +935,8 @@ const userHelper = function () {
                  */
                 for (let i = endOfArr; i >= 0; i--) {
                   count++;
-                  let roundedTangibleHrs =
-                    Math.floor(user.savedTangibleHrs[i] / 10) * 10;
-                  if (roundedTangibleHrs !== bdge.hrs) {
+                  const roundedSavedTangibleHrs = Math.floor(user.savedTangibleHrs[i] / 10) * 10;
+                  if (roundedSavedTangibleHrs !== bdge.hrs) {
                     count--;
                     break;
                   }
@@ -1043,18 +946,13 @@ const userHelper = function () {
                   for (let i = 0; i < badgesOfType.length; i++) {
                     if (badgesOfType[i].totalHrs === bdge.hrs) {
                       if (badgesOfType[i].weeks < bdge.weeks) {
-                        removeDupBadge(
-                          personId,
-                          mongoose.Types.ObjectId(badgesOfType[i]._id)
-                        );
+                        removeDupBadge(personId, mongoose.Types.ObjectId(badgesOfType[i]._id));
                       }
                     }
                   }
 
                   for (let i = 0; i < badgesOfType.length; i++) {
-                    if (
-                      badgesOfType[i]._id.toString() === bdge._id.toString()
-                    ) {
+                    if (badgesOfType[i]._id.toString() === bdge._id.toString()) {
                       return false;
                     }
                   }
@@ -1071,12 +969,8 @@ const userHelper = function () {
   };
 
   // 'Lead a team of X+'
-  const checkLeadTeamOfXplus = async function (
-    personId,
-    user,
-    badgeCollection
-  ) {
-    if (!hasPermission(user.role, "checkLeadTeamOfXplus")) {
+  const checkLeadTeamOfXplus = async function (personId, user, badgeCollection) {
+    if (!hasPermission(user.role, 'checkLeadTeamOfXplus')) {
       return;
     }
     let teamMembers;
@@ -1092,7 +986,7 @@ const userHelper = function () {
 
     const objIds = {};
     teamMembers = teamMembers.filter((elem) => {
-      if (hasPermission(elem.role, "checkLeadTeamOfXplus")) {
+      if (hasPermission(elem.role, 'checkLeadTeamOfXplus')) {
         return false;
       }
 
@@ -1105,17 +999,11 @@ const userHelper = function () {
 
     let badgeOfType;
     for (let i = 0; i < badgeCollection.length; i += 1) {
-      if (badgeCollection[i].badge?.type === "Lead a team of X+") {
-        if (
-          badgeOfType &&
-          badgeOfType.people <= badgeCollection[i].badge.people
-        ) {
+      if (badgeCollection[i].badge?.type === 'Lead a team of X+') {
+        if (badgeOfType && badgeOfType.people <= badgeCollection[i].badge.people) {
           removeDupBadge(personId, badgeOfType._id);
           badgeOfType = badgeCollection[i].badge;
-        } else if (
-          badgeOfType &&
-          badgeOfType.people > badgeCollection[i].badge.people
-        ) {
+        } else if (badgeOfType && badgeOfType.people > badgeCollection[i].badge.people) {
           removeDupBadge(personId, badgeCollection[i].badge._id);
         } else if (!badgeOfType) {
           badgeOfType = badgeCollection[i].badge;
@@ -1124,7 +1012,7 @@ const userHelper = function () {
     }
 
     await badge
-      .find({ type: "Lead a team of X+" })
+      .find({ type: 'Lead a team of X+' })
       .sort({ people: -1 })
       .then((results) => {
         if (!Array.isArray(results) || !results.length) {
@@ -1141,7 +1029,7 @@ const userHelper = function () {
                 replaceBadge(
                   personId,
                   mongoose.Types.ObjectId(badgeOfType._id),
-                  mongoose.Types.ObjectId(elem._id)
+                  mongoose.Types.ObjectId(elem._id),
                 );
               }
               return false;
@@ -1158,38 +1046,30 @@ const userHelper = function () {
   const checkTotalHrsInCat = async function (personId, user, badgeCollection) {
     const categoryTangibleHrs = user.categoryTangibleHrs || [];
     const categories = [
-      "Food",
-      "Energy",
-      "Housing",
-      "Education",
-      "Society",
-      "Economics",
-      "Stewardship",
+      'Food',
+      'Energy',
+      'Housing',
+      'Education',
+      'Society',
+      'Economics',
+      'Stewardship',
     ];
     if (categoryTangibleHrs.length === 0) {
       return;
     }
 
     categories.forEach(async (category) => {
-      const categoryHrs = categoryTangibleHrs.find(
-        (elem) => elem.category === category
-      );
+      const categoryHrs = categoryTangibleHrs.find((elem) => elem.category === category);
       let badgeOfType;
       for (let i = 0; i < badgeCollection.length; i += 1) {
         if (
-          badgeCollection[i].badge?.type === "Total Hrs in Category" &&
+          badgeCollection[i].badge?.type === 'Total Hrs in Category' &&
           badgeCollection[i].badge?.category === category
         ) {
-          if (
-            badgeOfType &&
-            badgeOfType.totalHrs <= badgeCollection[i].badge.totalHrs
-          ) {
+          if (badgeOfType && badgeOfType.totalHrs <= badgeCollection[i].badge.totalHrs) {
             removeDupBadge(personId, badgeOfType._id);
             badgeOfType = badgeCollection[i].badge;
-          } else if (
-            badgeOfType &&
-            badgeOfType.totalHrs > badgeCollection[i].badge.totalHrs
-          ) {
+          } else if (badgeOfType && badgeOfType.totalHrs > badgeCollection[i].badge.totalHrs) {
             removeDupBadge(personId, badgeCollection[i].badge._id);
           } else if (!badgeOfType) {
             badgeOfType = badgeCollection[i].badge;
@@ -1197,7 +1077,7 @@ const userHelper = function () {
         }
       }
       await badge
-        .find({ type: "Total Hrs in Category", category })
+        .find({ type: 'Total Hrs in Category', category })
         .sort({ totalHrs: -1 })
         .then((results) => {
           if (!Array.isArray(results) || !results.length || !categoryHrs) {
@@ -1214,7 +1094,7 @@ const userHelper = function () {
                   replaceBadge(
                     personId,
                     mongoose.Types.ObjectId(badgeOfType._id),
-                    mongoose.Types.ObjectId(elem._id)
+                    mongoose.Types.ObjectId(elem._id),
                   );
                 }
                 return false;
@@ -1230,9 +1110,7 @@ const userHelper = function () {
 
   const awardNewBadges = async () => {
     try {
-      const users = await userProfile
-        .find({ isActive: true })
-        .populate("badgeCollection.badge");
+      const users = await userProfile.find({ isActive: true }).populate('badgeCollection.badge');
 
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
@@ -1254,14 +1132,8 @@ const userHelper = function () {
 
   const getTangibleHoursReportedThisWeekByUserId = function (personId) {
     const userId = mongoose.Types.ObjectId(personId);
-    const pdtstart = moment()
-      .tz("America/Los_Angeles")
-      .startOf("week")
-      .format("YYYY-MM-DD");
-    const pdtend = moment()
-      .tz("America/Los_Angeles")
-      .endOf("week")
-      .format("YYYY-MM-DD");
+    const pdtstart = moment().tz('America/Los_Angeles').startOf('week').format('YYYY-MM-DD');
+    const pdtend = moment().tz('America/Los_Angeles').endOf('week').format('YYYY-MM-DD');
 
     return timeEntries
       .find(
@@ -1270,12 +1142,12 @@ const userHelper = function () {
           dateOfWork: { $gte: pdtstart, $lte: pdtend },
           isTangible: true,
         },
-        "totalSeconds"
+        'totalSeconds',
       )
       .then((results) => {
         const totalTangibleWeeklySeconds = results.reduce(
           (acc, { totalSeconds }) => acc + totalSeconds,
-          0
+          0,
         );
         return (totalTangibleWeeklySeconds / 3600).toFixed(2);
       });
@@ -1285,28 +1157,24 @@ const userHelper = function () {
     try {
       const users = await userProfile.find(
         { isActive: true, endDate: { $exists: true } },
-        "_id isActive endDate"
+        '_id isActive endDate',
       );
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
         const { endDate } = user;
         endDate.setHours(endDate.getHours() + 7);
-        if (moment().isAfter(moment(endDate).add(1, "days"))) {
+        if (moment().isAfter(moment(endDate).add(1, 'days'))) {
           await userProfile.findByIdAndUpdate(
             user._id,
             user.set({
               isActive: false,
             }),
-            { new: true }
+            { new: true },
           );
           const id = user._id;
           const person = await userProfile.findById(id);
-          const lastDay = moment(person.endDate).format("YYYY-MM-DD");
-          logger.logInfo(
-            `User with id: ${
-              user._id
-            } was de-acticated at ${moment().format()}.`
-          );
+          const lastDay = moment(person.endDate).format('YYYY-MM-DD');
+          logger.logInfo(`User with id: ${user._id} was de-acticated at ${moment().format()}.`);
           const subject = `IMPORTANT:${person.firstName} ${person.lastName} has been deactivated in the Highest Good Network`;
 
           const emailBody = `<p> Hi Admin! </p>
@@ -1319,13 +1187,7 @@ const userHelper = function () {
           
           <p>The HGN A.I. (and One Community)</p>`;
 
-          emailSender(
-            "onecommunityglobal@gmail.com",
-            subject,
-            emailBody,
-            null,
-            null
-          );
+          emailSender('onecommunityglobal@gmail.com', subject, emailBody, null, null);
         }
       }
     } catch (err) {


### PR DESCRIPTION
This is a bugfix for auto-assignment of XhoursForXWeeks streak. The new changes in the code enables the following:

If it is a streak of the same number (i.e. 3-week 40 hour streak being replaced by a 4-week 40-hour streak), then the previous one should drop off because the badge would be a continuation of the previous badge.

If, however, the badge is a NEW streak (i.e. 50-hour streak started, but they already had a 40-hour streak), then they should still keep the 40-hour streak because that was a different accomplishment.

And nobody should ever earn two different streaks the same week... meaning earning a 50-hour streak should not also earn you a 40-hour streak, you should only always earn the highest number.

Note:- It will not increase the badge count of a similar streak.

It does not block an admin from manually assigning any number of such badges, and thus may also enable duplicate creation of badges. However, it will remove the duplicate and wrong streak badges that were manually assigned every new week on Sunday.

Version 1.2: My previous pull request needed a slight logic change for the code to properly work. This version has that change.