### PR TITLE
Updated way to handle duplicate names.

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -147,6 +147,14 @@ const userProfileController = function (UserProfile) {
       lastName: req.body.lastName,
     });
 
+    if (userDuplicateName && !req.body.allowsDuplicateName) {
+      res.status(400).send({
+        error: 'That name is already in use. Please confirm if you want to use this name.',
+        type: 'name',
+      });
+      return;
+    }
+
     const up = new UserProfile();
     up.password = req.body.password;
     up.role = req.body.role;
@@ -172,12 +180,6 @@ const userProfileController = function (UserProfile) {
 
     up.save()
       .then(() => {
-        if (userDuplicateName) {
-          res.status(200).send({
-            warning: 'User with same name exists, new user with duplicate name created.',
-            _id: up._id,
-          });
-        }
         res.status(200).send({
           _id: up._id,
         });


### PR DESCRIPTION
This is a PR for Other Links → User Management → Create New User ([PR 476] needs finishing, a “duplicate name created” popup happens after it is created, which is good. Need the rest of the below still though)
Make “user with duplicate name” popup require a person to click to confirm that they want to create a person with a duplicate name
Make “user with duplicate name” so it is not case sensitive. Currently a user without any caps is not considered a duplicate of the name that includes capitalization of first names.
The above PR also seems to have broken the auto-refresh for adding a new person… I should see that new person as soon as they are added and now I don’t anymore
How to test:
- With a dev account go to Other Links → User Management → Create New User.
- Create a user with with a name that has been used before (first name + last name).
- Create it with an email that hasn’t been used before and also with one that has been used before.
- A new popup should appear asking to confirm if you want to create the user with a duplicate name.
- Check if it behaves the right way.
- Check if the newly created user shows up.