### PR TITLE
create folder for tasks with subtasks

### DIFF
--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -1411,6 +1411,24 @@ const taskController = function (Task) {
       res.status(400).send(error);
     }
   };
+  const updateChildrenQty = (req, res) => {
+    const { taskId } = req.params;
+    Task.findById(taskId, (error, task) => {
+      if (task) {
+        let newQty = 0;
+        let child = true;
+        if (task.childrenQty > 0) {
+          newQty = task.childrenQty - 1;
+          if (newQty === 0) {
+            child = false;
+          }
+        }
+        task.hasChild = child;
+        task.childrenQty = newQty;
+        task.save();
+      }
+    });
+  };
 
   return {
     postTask,
@@ -1427,6 +1445,7 @@ const taskController = function (Task) {
     moveTask,
     getTasksByUserList,
     getTasksForTeamsByUser,
+    updateChildrenQty
   };
 };
 

--- a/src/models/task.js
+++ b/src/models/task.js
@@ -45,6 +45,7 @@ const taskschema = new Schema({
   position: { type: Number, required: true },
   isActive: { type: Boolean, default: true },
   hasChild: { type: Boolean, default: false },
+  childrenQty: { type: Number, default: 0, required: true },
   createdDatetime: { type: Date },
   modifiedDatetime: { type: Date, default: Date.now() },
   whyInfo: { type: String },

--- a/src/routes/taskRouter.js
+++ b/src/routes/taskRouter.js
@@ -25,6 +25,9 @@ const routes = function (task, userProfile) {
   wbsRouter.route('/task/update/:taskId')
     .put(controller.updateTask);
 
+  wbsRouter.route('/task/delete/children/:taskId')
+    .post(controller.updateChildrenQty);
+
   wbsRouter.route('/task/updateAllParents/:wbsId/')
     .put(controller.updateAllParents);
 


### PR DESCRIPTION
Fixe bug ( PRIORITY MEDIUM) - 5 from PROJECT/TASK/WBS COMPONENT
Creating sub-tasks in a WBS doesn’t create a new folder and makes the tasks uneditable
Logged in as Admin → Other Links → Projects → AAA USE THIS PROJECT → Click WBS Icon → Choose “Jae's WBS - USE THIS” → Choose task not in folder → Edit → Add Task → Should create folder out of parent and including new task.
## Related PRS (if any):

To test this backend PR you need to checkout the [#682](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/682) frontend PR.


Mainly changes explained:
1 - Was added a new field called `childrenQty` in the task Schema ` ./src/models/task.js`  , this field is responsible to count the number of childrens (subtasks) of a task.
2 - Was created a new function in the  `./src/controllers/taskController.js` called  `updateChildrenQty` responsible to update the childrenQty when to delete a subtask of a given task.
3 - Then was added a route in the file` ./src/routes/taskRouter.js`.
![Captura de Tela (236)](https://user-images.githubusercontent.com/39320057/220208772-0045966c-3fd8-403c-998a-6bab142c728f.png)
