### PR TITLE
Jinchao fix default role as Volunteer after role deletion

### DIFF
--- a/src/controllers/rolesController.js
+++ b/src/controllers/rolesController.js
@@ -1,3 +1,5 @@
+const UserProfile = require('../models/userProfile');
+const cache = require('../utilities/nodeCache')();
 
 const rolesController = function (Role) {
   const getAllRoles = function (req, res) {
@@ -65,17 +67,29 @@ const rolesController = function (Role) {
       res.status(403).send('You are not authorized to make changes in the roles.');
     }
     Role.findById(roleId)
-      .then((result) => {
+      .then(result => (
         result
           .remove()
-          .then(res.status(200).send({ message: 'Deleted role' }))
-          .catch((error) => {
-            res.status(400).send(error);
-          });
-      })
-      .catch((error) => {
-        res.status(400).send(error);
-      });
+          .then(UserProfile
+            .updateMany({ role: result.roleName }, { role: 'Volunteer' })
+            .then(() => {
+              const isUserInCache = cache.hasCache('allusers');
+              if (isUserInCache) {
+                const allUserData = JSON.parse(cache.getCache('allusers'));
+                allUserData.forEach((user) => {
+                  if (user.role === result.roleName) {
+                    user.role = 'Volunteer';
+                    cache.removeCache(`user-${user._id}`);
+                  }
+                });
+                cache.setCache('allusers', JSON.stringify(allUserData));
+              }
+              res.status(200).send({ message: 'Deleted role' });
+            })
+            .catch(error => res.status(400).send({ error })))
+          .catch(error => res.status(400).send({ error }))
+      ))
+      .catch(error => res.status(400).send({ error }));
   };
 
 


### PR DESCRIPTION
# Description
Fix bug:
(PRIORITY LOW) Jae/Raul: After creating a role and setting it to a user, if this role is deleted, the user role becomes Administrator by default. Should be 'Volunteer'.

## Mainly changes explained:
Extend `rolesController.deleteRoleById` :
After role deletion, update all users which currently in that role to volunteer.
Update the user cache after changing users' roles.

## How to test:

1. Log in as an owner user (if you don't have one, use `suigunfjc@gmail.com, Ff12345678!`)
2. Go to dashboard -> Other Link -> permissions management -> add new role
3. Create a new role and assign it to any user (create a new user or change a user's role on its profile page)
4. Permissions management -> click on the new role  -> delete role
5. Go back and check if the users' roles have changed to volunteer on their profile page.

## Note:
The roles displayed on the user management page will be outdated after role deletion or changing from user profile page. Please confirm the user's role by checking the profile page
![Screenshot 2023-03-01 210714](https://user-images.githubusercontent.com/94319381/222336364-ffb983aa-6057-4c82-a6cf-76f080e144f6.png)
