### PR TITLE
Raul add owner section to the top

### DIFF
--- a/src/controllers/ownerMessageController.js
+++ b/src/controllers/ownerMessageController.js
@@ -53,7 +53,6 @@ const ownerMessageController = function (OwnerMessage) {
     });
   };
 
-
   return {
     postOwnerMessage,
     getOwnerMessage,

--- a/src/controllers/ownerMessageController.js
+++ b/src/controllers/ownerMessageController.js
@@ -1,15 +1,39 @@
-
 const ownerMessageController = function (OwnerMessage) {
   const postOwnerMessage = function (req, res) {
     const ownerMessage = new OwnerMessage();
     ownerMessage.message = req.body.newMessage;
+    ownerMessage.save().then(() => res.status(201).json({
+      _serverMessage: 'Message succesfuly created!',
+      ownerMessage,
+    })).catch(err => res.status(500).send({ err }));
+  };
 
-    ownerMessage.save().then(results => res.status(201).send(results)).catch(err => res.status(500).send({ err }));
+  const getOwnerMessage = function (req, res) {
+    OwnerMessage.find()
+      .sort({ message: 1 })
+      .then(results => res.status(200).send(results))
+      .catch(error => res.status(404).send(error));
+  };
+
+  const deleteOwnerMessage = function (req, res) {
+    OwnerMessage.deleteMany({})
+    .then((result) => {
+      result
+        .then(res.status(200).send({ _serverMessage: 'Message deleted!' }))
+        .catch((error) => {
+          res.status(400).send(error);
+        });
+    })
+    .catch((error) => {
+      res.status(400).send(error);
+    });
   };
 
 
   return {
     postOwnerMessage,
+    getOwnerMessage,
+    deleteOwnerMessage,
   };
 };
 

--- a/src/controllers/ownerMessageController.js
+++ b/src/controllers/ownerMessageController.js
@@ -1,5 +1,8 @@
 const ownerMessageController = function (OwnerMessage) {
   const postOwnerMessage = function (req, res) {
+    if (req.body.requestor.role !== 'Owner') {
+      res.status(403).send('You are not authorized to create messages!');
+    }
     const ownerMessage = new OwnerMessage();
     ownerMessage.message = req.body.newMessage;
     ownerMessage.save().then(() => res.status(201).json({
@@ -10,12 +13,14 @@ const ownerMessageController = function (OwnerMessage) {
 
   const getOwnerMessage = function (req, res) {
     OwnerMessage.find()
-      .sort({ message: 1 })
       .then(results => res.status(200).send(results))
       .catch(error => res.status(404).send(error));
   };
 
   const deleteOwnerMessage = function (req, res) {
+    if (req.body.requestor.role !== 'Owner') {
+      res.status(403).send('You are not authorized to delete messages!');
+    }
     OwnerMessage.deleteMany({})
     .then((result) => {
       result
@@ -29,11 +34,31 @@ const ownerMessageController = function (OwnerMessage) {
     });
   };
 
+  const updateOwnerMessage = function (req, res) {
+    if (req.body.requestor.role !== 'Owner') {
+      res.status(403).send('You are not authorized to update messages!');
+    }
+    const { id } = req.params;
+
+    return OwnerMessage.findById(id, (error, ownerMessage) => {
+      if (error || ownerMessage === null) {
+        res.status(400).send('No ownerMessage found');
+        return;
+      }
+
+      ownerMessage.message = req.body.newMessage;
+      ownerMessage.save()
+        .then(results => res.status(201).send(results))
+        .catch(errors => res.status(400).send(errors));
+    });
+  };
+
 
   return {
     postOwnerMessage,
     getOwnerMessage,
     deleteOwnerMessage,
+    updateOwnerMessage,
   };
 };
 

--- a/src/controllers/ownerMessageController.js
+++ b/src/controllers/ownerMessageController.js
@@ -1,0 +1,16 @@
+
+const ownerMessageController = function (OwnerMessage) {
+  const postOwnerMessage = function (req, res) {
+    const ownerMessage = new OwnerMessage();
+    ownerMessage.message = req.body.newMessage;
+
+    ownerMessage.save().then(results => res.status(201).send(results)).catch(err => res.status(500).send({ err }));
+  };
+
+
+  return {
+    postOwnerMessage,
+  };
+};
+
+module.exports = ownerMessageController;

--- a/src/controllers/rolesController.js
+++ b/src/controllers/rolesController.js
@@ -49,7 +49,7 @@ const rolesController = function (Role) {
         res.status(400).send('No valid records found');
         return;
       }
-      record.roleName = req.body.roleName;
+      record.roleName = req.body.roleName
       record.permissions = req.body.permissions;
       record.permissionsBackEnd = req.body.permissionsBackEnd;
 

--- a/src/controllers/rolesController.js
+++ b/src/controllers/rolesController.js
@@ -49,7 +49,7 @@ const rolesController = function (Role) {
         res.status(400).send('No valid records found');
         return;
       }
-      record.roleName = req.body.roleName
+      record.roleName = req.body.roleName;
       record.permissions = req.body.permissions;
       record.permissionsBackEnd = req.body.permissionsBackEnd;
 

--- a/src/models/ownerMessage.js
+++ b/src/models/ownerMessage.js
@@ -2,7 +2,6 @@ const mongoose = require('mongoose');
 
 const { Schema } = mongoose;
 
-
 const OwnerMessage = new Schema({
   message: { type: String, required: true },
 });

--- a/src/models/ownerMessage.js
+++ b/src/models/ownerMessage.js
@@ -3,7 +3,7 @@ const mongoose = require('mongoose');
 const { Schema } = mongoose;
 
 const OwnerMessage = new Schema({
-  message: { type: String, required: true },
+  message: { type: String },
 });
 
 module.exports = mongoose.model('ownerMessage', OwnerMessage, 'ownerMessage');

--- a/src/models/ownerMessage.js
+++ b/src/models/ownerMessage.js
@@ -1,0 +1,10 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+
+const OwnerMessage = new Schema({
+  message: { type: String, required: true },
+});
+
+module.exports = mongoose.model('ownerMessage', OwnerMessage, 'ownerMessage');

--- a/src/routes/ownerMessageRouter.js
+++ b/src/routes/ownerMessageRouter.js
@@ -4,8 +4,10 @@ const routes = function (ownerMessage) {
   const controller = require('../controllers/ownerMessageController')(ownerMessage);
   const OwnerMessageRouter = express.Router();
 
-  OwnerMessageRouter.route('/ownermessage')
-  .post(controller.postOwnerMessage);
+  OwnerMessageRouter.route('/ownerMessage')
+  .post(controller.postOwnerMessage)
+  .get(controller.getOwnerMessage)
+  .delete(controller.deleteOwnerMessage);
 
 return OwnerMessageRouter;
 };

--- a/src/routes/ownerMessageRouter.js
+++ b/src/routes/ownerMessageRouter.js
@@ -9,6 +9,9 @@ const routes = function (ownerMessage) {
   .get(controller.getOwnerMessage)
   .delete(controller.deleteOwnerMessage);
 
+  OwnerMessageRouter.route('/ownerMessage/:id')
+  .put(controller.updateOwnerMessage);
+
 return OwnerMessageRouter;
 };
 

--- a/src/routes/ownerMessageRouter.js
+++ b/src/routes/ownerMessageRouter.js
@@ -1,0 +1,13 @@
+const express = require('express');
+
+const routes = function (ownerMessage) {
+  const controller = require('../controllers/ownerMessageController')(ownerMessage);
+  const OwnerMessageRouter = express.Router();
+
+  OwnerMessageRouter.route('/ownermessage')
+  .post(controller.postOwnerMessage);
+
+return OwnerMessageRouter;
+};
+
+module.exports = routes;

--- a/src/routes/ownerMessageRouter.js
+++ b/src/routes/ownerMessageRouter.js
@@ -3,6 +3,7 @@ const express = require('express');
 const routes = function (ownerMessage) {
   const controller = require('../controllers/ownerMessageController')(ownerMessage);
   const OwnerMessageRouter = express.Router();
+  // const imageUploadHelper = require('../helpers/imageUploadHelper');
 
   OwnerMessageRouter.route('/ownerMessage')
   .post(controller.postOwnerMessage)
@@ -10,7 +11,7 @@ const routes = function (ownerMessage) {
   .delete(controller.deleteOwnerMessage);
 
   OwnerMessageRouter.route('/ownerMessage/:id')
-  .patch(controller.updateOwnerMessage);
+  .put(controller.updateOwnerMessage);
 
 return OwnerMessageRouter;
 };

--- a/src/routes/ownerMessageRouter.js
+++ b/src/routes/ownerMessageRouter.js
@@ -10,7 +10,7 @@ const routes = function (ownerMessage) {
   .delete(controller.deleteOwnerMessage);
 
   OwnerMessageRouter.route('/ownerMessage/:id')
-  .put(controller.updateOwnerMessage);
+  .patch(controller.updateOwnerMessage);
 
 return OwnerMessageRouter;
 };

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -14,6 +14,7 @@ const badge = require('../models/badge');
 const inventoryItem = require('../models/inventoryItem');
 const inventoryItemType = require('../models/inventoryItemType');
 const role = require('../models/role');
+const ownerMessage = require('../models/ownerMessage');
 
 const userProfileRouter = require('../routes/userProfileRouter')(userProfile);
 const badgeRouter = require('../routes/badgeRouter')(badge);
@@ -39,6 +40,7 @@ const timeZoneAPIRouter = require('../routes/timeZoneAPIRoutes')();
 const taskEditSuggestion = require('../models/taskEditSuggestion');
 const taskEditSuggestionRouter = require('../routes/taskEditSuggestionRouter')(taskEditSuggestion);
 const roleRouter = require('../routes/roleRouter')(role);
+const ownerMessageRouter = require('../routes/ownerMessageRouter')(ownerMessage);
 
 
 module.exports = function (app) {
@@ -64,4 +66,5 @@ module.exports = function (app) {
   app.use('/api', timeZoneAPIRouter);
   app.use('/api', taskEditSuggestionRouter);
   app.use('/api', roleRouter);
+  app.use('/api', ownerMessageRouter);
 };

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -42,7 +42,6 @@ const taskEditSuggestionRouter = require('../routes/taskEditSuggestionRouter')(t
 const roleRouter = require('../routes/roleRouter')(role);
 const ownerMessageRouter = require('../routes/ownerMessageRouter')(ownerMessage);
 
-
 module.exports = function (app) {
   app.use('/api', forgotPwdRouter);
   app.use('/api', loginRouter);


### PR DESCRIPTION
# Description
(DASHBOARD COMPONENT - PRIORITY LOW) 

> (PRIORITY LOW) Jae: Add to top of app a section that the “Owner” class (only) can edit to post a message to all users of the app like, “Happy Holidays”. (WIP - Raul)
> When not showing a custom message, it should show our horizontal logo. Give me the dimensions I’m allowed and I’ll have our graphics guy create one just for this.
> I’d like the UI for posting the message to have the ability for me to set an expiration date so it’ll automatically return to the logo on that date

## Mainly changes explained:
An owner message section was added to the Header. So now, owner accounts can post messages by image or text on the header for all the volunteers.

## How to test:
1. this PR is related to frontend [PR #698](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/698). You have to use both to test this feature.
2. git checkout raul_add_owner_section_to_the_top
3. npm run build
4. npm run start
5. log in as **OWNER**
6. A pen should be displayed for you:
![header](https://user-images.githubusercontent.com/29555732/223524828-d0572c7c-eec8-4a70-a1c9-45a148b955d8.png)

7. click and try to create and delete messages. For image messages, try using this one - which the resolution is made for this resource:
![image](https://user-images.githubusercontent.com/29555732/223524950-192aa6ab-212a-4504-859e-11a4efa6e2a2.png)

8. The pen should only be displayed for owner accounts. The message has to be displayed for everyone.
9. This resource is made only for computers (width higher than 1400px).

