### PR TITLE
Jinchao fix active/inactive button in user management and user profile page

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -617,6 +617,18 @@ const userProfileController = function (UserProfile) {
         user
           .save()
           .then(() => {
+            const isUserInCache = cache.hasCache('allusers');
+            if (isUserInCache) {
+              const allUserData = JSON.parse(cache.getCache('allusers'));
+              const userIdx = allUserData.findIndex(users => users._id === userId);
+              const userData = allUserData[userIdx];
+              if (!status) {
+                userData.endDate = user.endDate.toISOString();
+              }
+              userData.isActive = user.isActive;
+              allUserData.splice(userIdx, 1, userData);
+              cache.setCache('allusers', JSON.stringify(allUserData));
+            }
             res.status(200).send({
               message: 'status updated',
             });


### PR DESCRIPTION
# Description
Fix bug:
(PRIORITY MEDIUM) Jae: Fix ability to make people inactive from their Profile Page (WIP Jinchao)
a.	Admin login → Profile Page → Click green dot at top to make inactive. Then go to Other Links → User Management → Find the person → You’ll see they are still showing green dot like they are active… The don’t show up anymore on the Leaderboard but they show up active here and eventually show back up on the leaderboard. They should be made inactive everywhere and STAY INACTIVE

## Mainly changes explained:
Extend `userProfileController.changeUserStatus` :
Update the `allusers` cache after changing user's status.

## How to test:

1. Admin login -> User Management
2. Click the green/grey dot to inactive/active a user and see the immediate change on both the user management page and the user profile page.
![Screenshot 2023-03-08 214309](https://user-images.githubusercontent.com/94319381/223931091-422295a0-b88c-4de0-b9eb-dd800b858fb3.png)
3. Go to a user's profile page and click the green/grey dot to active and inactive the user and see the immediate change on both the user management page and user profile page.
![Screenshot 2023-03-08 214356](https://user-images.githubusercontent.com/94319381/223931094-33a98b28-65bd-4c1c-a2c3-35fb62a9f023.png)
4. Log in to that user's account to check the account status.
