### PR TITLE
Raul improve owner message feature

### DIFF
--- a/src/controllers/ownerStandardMessageController.js
+++ b/src/controllers/ownerStandardMessageController.js
@@ -4,7 +4,7 @@ const ownerStandardMessageController = function (OwnerStandardMessage) {
       res.status(403).send('You are not authorized to create messages!');
     }
     const ownerStandardMessage = new OwnerStandardMessage();
-    ownerStandardMessage.message = req.body.newMessage;
+    ownerStandardMessage.message = req.body.newStandardMessage;
     ownerStandardMessage.save().then(() => res.status(201).json({
       _serverMessage: 'Message succesfuly created!',
       ownerStandardMessage,
@@ -24,7 +24,7 @@ const ownerStandardMessageController = function (OwnerStandardMessage) {
     OwnerStandardMessage.deleteMany({})
     .then((result) => {
       result
-        .then(res.status(200).send({ _serverMessage: 'Message deleted!' }))
+        .then(res.status(200).send({ _serverMessage: 'Standard Message deleted!' }))
         .catch((error) => {
           res.status(400).send(error);
         });
@@ -42,11 +42,11 @@ const ownerStandardMessageController = function (OwnerStandardMessage) {
 
     return OwnerStandardMessage.findById(id, (error, ownerStandardMessage) => {
       if (error || ownerStandardMessage === null) {
-        res.status(400).send('No ownerMessage found');
+        res.status(400).send('No ownerStandardMessage found');
         return;
       }
 
-      ownerStandardMessage.message = req.body.newMessage;
+      ownerStandardMessage.message = req.body.newStandardMessage;
       ownerStandardMessage.save()
         .then(results => res.status(201).send(results))
         .catch(errors => res.status(400).send(errors));

--- a/src/controllers/ownerStandardMessageController.js
+++ b/src/controllers/ownerStandardMessageController.js
@@ -1,0 +1,64 @@
+const ownerStandardMessageController = function (OwnerStandardMessage) {
+  const postOwnerStandardMessage = function (req, res) {
+    if (req.body.requestor.role !== 'Owner') {
+      res.status(403).send('You are not authorized to create messages!');
+    }
+    const ownerStandardMessage = new OwnerStandardMessage();
+    ownerStandardMessage.message = req.body.newMessage;
+    ownerStandardMessage.save().then(() => res.status(201).json({
+      _serverMessage: 'Message succesfuly created!',
+      ownerStandardMessage,
+    })).catch(err => res.status(500).send({ err }));
+  };
+
+  const getOwnerStandardMessage = function (req, res) {
+    OwnerStandardMessage.find()
+      .then(results => res.status(200).send(results))
+      .catch(error => res.status(404).send(error));
+  };
+
+  const deleteOwnerStandardMessage = function (req, res) {
+    if (req.body.requestor.role !== 'Owner') {
+      res.status(403).send('You are not authorized to delete messages!');
+    }
+    OwnerStandardMessage.deleteMany({})
+    .then((result) => {
+      result
+        .then(res.status(200).send({ _serverMessage: 'Message deleted!' }))
+        .catch((error) => {
+          res.status(400).send(error);
+        });
+    })
+    .catch((error) => {
+      res.status(400).send(error);
+    });
+  };
+
+  const updateOwnerStandardMessage = function (req, res) {
+    if (req.body.requestor.role !== 'Owner') {
+      res.status(403).send('You are not authorized to update messages!');
+    }
+    const { id } = req.params;
+
+    return OwnerStandardMessage.findById(id, (error, ownerStandardMessage) => {
+      if (error || ownerStandardMessage === null) {
+        res.status(400).send('No ownerMessage found');
+        return;
+      }
+
+      ownerStandardMessage.message = req.body.newMessage;
+      ownerStandardMessage.save()
+        .then(results => res.status(201).send(results))
+        .catch(errors => res.status(400).send(errors));
+    });
+  };
+
+  return {
+    postOwnerStandardMessage,
+    getOwnerStandardMessage,
+    deleteOwnerStandardMessage,
+    updateOwnerStandardMessage,
+  };
+};
+
+module.exports = ownerStandardMessageController;

--- a/src/models/ownerStandardMessage.js
+++ b/src/models/ownerStandardMessage.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const OwnerStandardMessage = new Schema({
+  message: { type: String },
+});
+
+module.exports = mongoose.model('ownerStandardMessage', OwnerStandardMessage, 'ownerStandardMessage');

--- a/src/routes/ownerStandardMessageRouter.js
+++ b/src/routes/ownerStandardMessageRouter.js
@@ -1,0 +1,19 @@
+const express = require('express');
+
+const routes = function (ownerStandardMessage) {
+  const controller = require('../controllers/ownerStandardMessageController')(ownerStandardMessage);
+  const OwnerStandardMessageRouter = express.Router();
+  // const imageUploadHelper = require('../helpers/imageUploadHelper');
+
+  OwnerStandardMessageRouter.route('/ownerMessage')
+  .post(controller.postOwnerStandardMessage)
+  .get(controller.getOwnerStandardMessage)
+  .delete(controller.deleteOwnerStandardMessage);
+
+  OwnerStandardMessageRouter.route('/ownerMessage/:id')
+  .put(controller.updateOwnerStandardMessage);
+
+return OwnerStandardMessageRouter;
+};
+
+module.exports = routes;

--- a/src/routes/ownerStandardMessageRouter.js
+++ b/src/routes/ownerStandardMessageRouter.js
@@ -3,14 +3,13 @@ const express = require('express');
 const routes = function (ownerStandardMessage) {
   const controller = require('../controllers/ownerStandardMessageController')(ownerStandardMessage);
   const OwnerStandardMessageRouter = express.Router();
-  // const imageUploadHelper = require('../helpers/imageUploadHelper');
 
-  OwnerStandardMessageRouter.route('/ownerMessage')
+  OwnerStandardMessageRouter.route('/ownerStandardMessage')
   .post(controller.postOwnerStandardMessage)
   .get(controller.getOwnerStandardMessage)
   .delete(controller.deleteOwnerStandardMessage);
 
-  OwnerStandardMessageRouter.route('/ownerMessage/:id')
+  OwnerStandardMessageRouter.route('/ownerStandardMessage/:id')
   .put(controller.updateOwnerStandardMessage);
 
 return OwnerStandardMessageRouter;

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -15,6 +15,7 @@ const inventoryItem = require('../models/inventoryItem');
 const inventoryItemType = require('../models/inventoryItemType');
 const role = require('../models/role');
 const ownerMessage = require('../models/ownerMessage');
+const ownerStandardMessage = require('../models/ownerStandardMessage');
 
 const userProfileRouter = require('../routes/userProfileRouter')(userProfile);
 const badgeRouter = require('../routes/badgeRouter')(badge);
@@ -41,6 +42,7 @@ const taskEditSuggestion = require('../models/taskEditSuggestion');
 const taskEditSuggestionRouter = require('../routes/taskEditSuggestionRouter')(taskEditSuggestion);
 const roleRouter = require('../routes/roleRouter')(role);
 const ownerMessageRouter = require('../routes/ownerMessageRouter')(ownerMessage);
+const ownerStandardMessageRouter = require('../routes/ownerStandardMessageRouter')(ownerStandardMessage);
 
 module.exports = function (app) {
   app.use('/api', forgotPwdRouter);
@@ -66,4 +68,5 @@ module.exports = function (app) {
   app.use('/api', taskEditSuggestionRouter);
   app.use('/api', roleRouter);
   app.use('/api', ownerMessageRouter);
+  app.use('/api', ownerStandardMessageRouter);
 };


### PR DESCRIPTION
# Description
(DASHBOARD COMPONENT - PRIORITY LOW) - New Requests

> (PRIORITY LOW) Jae: Add to top of app a section that the “Owner” class (only) can edit to post a message to all users of the app like, “Happy Holidays”. (WIP - Raul)
> I’d like the UI for posting the message to have the ability for me to set an expiration date so it’ll automatically return to the logo on that date
> **New Requests:** 
> I. Change “or add a picture” to “Or add a picture (max size ## x ## pixels and XX KB).
> II. Please add a “Clear All” button that will remove whatever has been saved there and return it to blank. (A big red X)

## Mainly changes explained:
A new feature was added to the owner message component. Now, we have a standard message that is displayed when no message is submitted. Also, it was installed the option of changing this standard message. New icons were put there as well. The clear/remove icon just displays when we have a common message.

## How to test:
1. this PR is related to the frontend [PR #733](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/733). You have to use both to test this feature.
2. git checkout raul_improve_owner_message_feature
3. npm install
4. npm run start:local
5. log in as **OWNER**
6. A pen should be displayed for you:
![image](https://user-images.githubusercontent.com/29555732/227401999-b94239e9-e77b-493b-847c-989b67b4ec88.png)

7. click and try to update the standard message. Also, create common messages to test. For image messages, try using these - the resolutions were made for this resource:
![image](https://user-images.githubusercontent.com/29555732/227402343-d04713fe-7f6d-437d-a6ec-c8e9996180f9.png)
![Logo](https://user-images.githubusercontent.com/29555732/227402344-99f8af5e-fe39-43a7-ad56-ffd9eb2806f1.png)

8. The pen should only be displayed for owner accounts. The messages have to be displayed for everyone.
9. This resource is made only for computers (width higher than 1400px).