### PR TITLE
add one more tab for weekly summary

### DIFF
--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -8,7 +8,7 @@ const reportsController = function () {
       return;
     }
 
-    const weeklySummaries = reporthelper.weeklySummaries(2, 0);
+    const weeklySummaries = reporthelper.weeklySummaries(3, 0);
     weeklySummaries
       .then((results) => {
         const summaries = reporthelper.formatSummaries(results);

--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -112,8 +112,8 @@ const reporthelper = function () {
    * Checks whether a date belongs to a specific week based on week index.
    *
    * @param {string} dueDate The date to check.
-   * @param {integer} weekIndex An integer in the range 0 - 2, where 0 (this week),
-   *                      1 (last week) or 2 (the week before last).
+   * @param {integer} weekIndex An integer in the range 0 - 3, where 0 (this week),
+   *                      1 (last week), 2 (the week before last) or 3 (three weeks ago).
    * @return {boolean} True if match, false otherwise.
    */
   const doesDateBelongToWeek = function (dueDate, weekIndex) {
@@ -126,7 +126,7 @@ const reporthelper = function () {
 
   /**
    * Get the week index relative to this week, eg. 0 (this week),
-   * 1 (last week) or 2 (the week before last).
+   * 1 (last week), 2 (the week before last) or 3 (three weeks ago).
    *
    * @param {string} dueDate The date to check.
    * @return {integer} The week index, -1 if no match.
@@ -135,6 +135,7 @@ const reporthelper = function () {
     if (doesDateBelongToWeek(dueDate, 0)) return 0;
     if (doesDateBelongToWeek(dueDate, 1)) return 1;
     if (doesDateBelongToWeek(dueDate, 2)) return 2;
+    if (doesDateBelongToWeek(dueDate, 3)) return 3;
     return -1;
   };
 
@@ -145,6 +146,7 @@ const reporthelper = function () {
    *  - the 1st entry should always have the dueDate for this week.
    *  - the 2nd entry should always have the dueDate for last week.
    *  - the 3rd entry should always have the dueDate for the week before last.
+   *  - the 4th entry should always have the dueDate for three weeks ago.
    *
    * @param {Object} results An array of user objects with selected fields.
    * @return {Object} An array of user objects with properly sorted weeklySummaries by due date.

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -78,11 +78,11 @@ const userHelper = function () {
 
   /**
    * This function will send out an email listing all users that have a summary provided for a specific week.
-   * A week is represented by an weekIndex: 0, 1 or 2, where 0 is the most recent and 2 the oldest.
+   * A week is represented by an weekIndex: 0, 1, 2 or 3, where 0 is the most recent and 3 the oldest.
    * It relies on the function weeklySummaries(startWeekIndex, endWeekIndex) to get the weekly summaries for the specific week.
    * In this case both the startWeekIndex and endWeekIndex are set to 1 to get the last weeks' summaries for all users.
    *
-   * @param {int} [weekIndex=1] Numbered representation of a week where 0 is the most recent and 2 the oldest.
+   * @param {int} [weekIndex=1] Numbered representation of a week where 0 is the most recent and 3 the oldest.
    *
    * @return {void}
    */
@@ -192,7 +192,7 @@ const userHelper = function () {
   /**
    * This function will process the weeklySummaries array in the following way:
    *  1 ) Push a new (blank) summary at the beginning of the array.
-   *  2 ) Always maintains 3 items in the array where each item represents a summary for a given week.
+   *  2 ) Always maintains 4 items in the array where each item represents a summary for a given week.
    *
    * This function will also increment the weeklySummariesCount by 1 if the user had provided a valid summary.
    *
@@ -211,7 +211,7 @@ const userHelper = function () {
               },
             ],
             $position: 0,
-            $slice: 3,
+            $slice: 4,
           },
         },
       })


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/5071040/224442594-3509c621-ad20-43ac-bbc2-d710e8b869e9.png)
This PR is for URGENT bug #1 
This PR is **ONLY** for adding one more tab on weekly summaries dashboard, to show the weekly summary of "three weeks ago".
**This PR doesn't have any contribution on fixing the "total submitted".** 

## Related PRS (if any):
This PR is the backend of [#707](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/707)

## Mainly changes explained:
change all the places access 3 weeklysummaries into 4

## How to test:
check into current branch
do `npm install` and `...` to run this PR locally
log as any role user or a new created user
go to dashboard→ weekly summaries
verify adding summaries on the 4 tabs can work

## Screenshots or videos of changes:
![image](https://user-images.githubusercontent.com/5071040/224447306-5f57f363-d5ac-4b05-925b-2db6357068dd.png)

## Note:
1. I made some changes on the Dev database for testing this PR
From my frontend PR [#707](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/707), reviewers reported the problem after submitting a summary that page freezes and need refresh to get it back. I can reproduce that bug but due to the limited time, I couldn't get it fixed and it already got merged. When I tested it on Dev site today, it seems worked well.
Let me know if you still have this problem or know how to solve it. Thanks.