### PR TITLE
remove the increment by 1 of weeklysummary

### DIFF
--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -194,12 +194,9 @@ const userHelper = function () {
    *  1 ) Push a new (blank) summary at the beginning of the array.
    *  2 ) Always maintains 4 items in the array where each item represents a summary for a given week.
    *
-   * This function will also increment the weeklySummariesCount by 1 if the user had provided a valid summary.
-   *
    * @param {ObjectId} personId This is mongoose.Types.ObjectId object.
-   * @param {boolean} hasWeeklySummary Whether the user with personId has submitted a valid weekly summary.
    */
-  const processWeeklySummariesByUserId = function (personId, hasWeeklySummary) {
+  const processWeeklySummariesByUserId = function (personId) {
     userProfile
       .findByIdAndUpdate(personId, {
         $push: {
@@ -215,15 +212,6 @@ const userHelper = function () {
           },
         },
       })
-      .then(() => {
-        if (hasWeeklySummary) {
-          userProfile
-            .findByIdAndUpdate(personId, {
-              $inc: { weeklySummariesCount: 1 },
-            }, { new: true })
-            .catch(error => logger.logException(error));
-        }
-      })
       .catch(error => logger.logException(error));
   };
 
@@ -231,8 +219,7 @@ const userHelper = function () {
    * This function is called by a cron job to do 3 things to all active users:
    *  1 ) Determine whether there's been an infringement for the weekly summary for last week.
    *  2 ) Determine whether there's been an infringement for the time not met for last week.
-   *  3 ) Call the processWeeklySummariesByUserId(personId) to process the weeklySummaries array
-   *      and increment the weeklySummariesCount for valud submissions.
+   *  3 ) Call the processWeeklySummariesByUserId(personId) to process the weeklySummaries array.
    */
   const assignBlueSquareForTimeNotMet = async () => {
     try {
@@ -261,7 +248,7 @@ const userHelper = function () {
         }
 
         //  This needs to run AFTER the check for weekly summary above because the summaries array will be updated/shifted after this function runs.
-        await processWeeklySummariesByUserId(personId, hasWeeklySummary);
+        await processWeeklySummariesByUserId(personId);
 
         const results = await dashboardHelper.laborthisweek(personId, pdtStartOfLastWeek, pdtEndOfLastWeek);
 


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/5071040/224442594-3509c621-ad20-43ac-bbc2-d710e8b869e9.png)
This PR is for URGENT bug #1 
This PR is **ONLY** for fixing the "total submitted" number of weekly summaries

## Related PRS (if any):
related frontend [741](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/741)

## Mainly changes explained:
The logic of counting the total submitted of weeklySummaries has already been implemented in the above frontend PR.
This PR only removes all the previous implementation.

## How to test:
Actually you cannot test this PR since the incrementing weeklySummariesCount by 1 logic only call by the `assignBlueSquareForTimeNotMet` every Sunday the first second.

## Screenshots or videos of changes:
see video from its frontend PR 741[PR demo video](https://www.dropbox.com/s/1e96vqry2fn6r71/PR%20demo%20showing.mp4?dl=0)