### PR TITLE
date for each badge earned

### DIFF
--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -25,6 +25,20 @@ const userHelper = function () {
     });
   };
 
+  const earnedDateBadge = () =>{
+    const today = new Date();
+    const yyyy = today.getFullYear();
+    // Add 1 beacuse the month start at zero
+    let mm = today.getMonth() + 1; 
+    let dd = today.getDate()
+     
+    mm < 10  ?  mm = '0' + mm : mm;
+    dd < 10  ?  dd = '0' + dd : dd;
+    const formatedDate = yyyy + '-' + mm + '-' + dd;
+
+    return formatedDate;
+  }
+
   const getUserName = async function (userId) {
     const userid = mongoose.Types.ObjectId(userId);
     return userProfile.findById(userid, 'firstName lastName');
@@ -531,12 +545,12 @@ const userHelper = function () {
   const increaseBadgeCount = async function (personId, badgeId) {
     console.log('Increase Badge Count', personId, badgeId);
     userProfile.updateOne({ _id: personId, 'badgeCollection.badge': badgeId },
-      { $inc: { 'badgeCollection.$.count': 1 }, $set: { 'badgeCollection.$.lastModified': Date.now().toString() } },
-      (err) => {
-        if (err) {
-          console.log(err);
-        }
-      });
+    { $inc: { 'badgeCollection.$.count': 1 }, $set: { 'badgeCollection.$.lastModified': Date.now().toString() } , $push:{'badgeCollection.$.earnedDate':earnedDateBadge() }},
+    (err) => {
+      if (err) {
+        console.log(err);
+      }
+    });
   };
 
   const addBadge = async function (personId, badgeId, count = 1, featured = false) {
@@ -546,7 +560,7 @@ const userHelper = function () {
         $push:
         {
           badgeCollection: {
-            badge: badgeId, count, featured, lastModified: Date.now().toString(),
+            badge: badgeId, count, earnedDate:[earnedDateBadge()], featured, lastModified: Date.now().toString(),
           },
         },
       }, (err) => {

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -60,6 +60,7 @@ const userProfileSchema = new Schema({
     {
       badge: { type: mongoose.SchemaTypes.ObjectId, ref: 'badge' },
       count: { type: Number, default: 0 },
+      earnedDate:{type: Array, default:[]},
       lastModified: { type: Date, required: true, default: Date.now() },
       featured: {
         type: Boolean,


### PR DESCRIPTION
DASHBOARD COMPONENT
1 - (PRIORITY MEDIUM)  Need a “Details” button or other way to see when specific badges were earned. Some badges are earned multiple times, so the button needs to show all dates when they were earned.
Dashboard → Badges Section → Badges Report

## Related PRS (if any):
This frontend PR is related to the #XXX backend PR.
To test this backend PR you need to checkout the [#756](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/755) frontend PR.
…

## Mainly changes explained:
1 -  Added a  new field named as `earnedDate ` of type `Array  i`n the userProfile Schema, to store all the date when a specif badge is earned.
2 -  in the userHelper file where the badges are assigned Automatically, was added a function named as `earnedDateBadge` that  is responsible to format de dates when a badge is earned. 
3 -  then  this new function  was invoked inside the `addBadge ` and `increaseBadgeCount ` functions.
4 -   the changes 2 and 3 is necessary because the badges are assigned automatically too  

## How to test:
check into current branch
do `npm install` and ` npm run build` to run this PR locally
`npm start`
to verify if the earned dates are being saved when the badge is assigned automatically it is necessary to put the `awardNewBadges` function outside the ` CronJob` in the `userProfileJob` file.
`
![Captura de Tela (318)](https://user-images.githubusercontent.com/39320057/230230147-1e71c921-85ce-4be8-8166-97eb574693ff.png)


