### PR TITLE
Jinchao apply missed hours to Core Team member

### DIFF
--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -1164,7 +1164,14 @@ const taskController = function (Task) {
             name: 1,
             role: 1,
             weeklycommittedHours: {
-              $arrayElemAt: ['$persondata.weeklycommittedHours', 0],
+              $sum: [
+                {
+                  $arrayElemAt: ['$persondata.weeklycommittedHours', 0],
+                },
+                {
+                  $ifNull: [{ $arrayElemAt: ['$persondata.missedHours', 0] }, 0],
+                },
+              ],
             },
           },
         },

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -270,7 +270,7 @@ const userProfileController = function (UserProfile) {
         record.role = req.body.role;
         record.isActive = req.body.isActive;
         record.weeklycommittedHours = req.body.weeklycommittedHours;
-        record.missedHours = req.body?.missedHours ?? 0;
+        record.missedHours = req.body.role === 'Core Team' ? (req.body?.missedHours ?? 0) : 0;
         record.adminLinks = req.body.adminLinks;
         record.teams = Array.from(new Set(req.body.teams));
         record.projects = Array.from(new Set(req.body.projects));

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -269,6 +269,7 @@ const userProfileController = function (UserProfile) {
         record.role = req.body.role;
         record.isActive = req.body.isActive;
         record.weeklycommittedHours = req.body.weeklycommittedHours;
+        record.missedHours = req.body?.missedHours ?? 0;
         record.adminLinks = req.body.adminLinks;
         record.teams = Array.from(new Set(req.body.teams));
         record.projects = Array.from(new Set(req.body.projects));

--- a/src/cronjobs/userProfileJobs.js
+++ b/src/cronjobs/userProfileJobs.js
@@ -11,6 +11,7 @@ const userProfileJobs = () => {
       const SUNDAY = 0;
       if (moment().tz('America/Los_Angeles').day() === SUNDAY) {
         await userhelper.assignBlueSquareForTimeNotMet();
+        await userhelper.applyMissedHourForCoreTeam();
         await userhelper.emailWeeklySummariesForAllUsers();
         await userhelper.deleteBlueSquareAfterYear();
         await userhelper.awardNewBadges();

--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -220,7 +220,14 @@ const dashboardhelper = function () {
           personId: 1,
           name: 1,
           weeklycommittedHours: {
-            $arrayElemAt: ['$persondata.weeklycommittedHours', 0],
+            $sum: [
+              {
+                $arrayElemAt: ['$persondata.weeklycommittedHours', 0],
+              },
+              {
+                $ifNull: [{ $arrayElemAt: ['$persondata.missedHours', 0] }, 0],
+              },
+            ],
           },
         },
       },

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -244,7 +244,7 @@ const userHelper = function () {
 
       const pdtEndOfLastWeek = moment().tz('America/Los_Angeles').endOf('week').subtract(1, 'week');
 
-      const users = await userProfile.find({ isActive: true }, '_id weeklySummaries');
+      const users = await userProfile.find({ isActive: true }, '_id weeklySummaries missedHours');
 
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
@@ -265,7 +265,9 @@ const userHelper = function () {
 
         const results = await dashboardHelper.laborthisweek(personId, pdtStartOfLastWeek, pdtEndOfLastWeek);
 
-        const { weeklycommittedHours, timeSpent_hrs: timeSpent } = results[0];
+        const { timeSpent_hrs: timeSpent } = results[0];
+
+        const weeklycommittedHours = user.weeklycommittedHours + (user.missedHours ?? 0);
 
         const timeNotMet = (timeSpent < weeklycommittedHours);
         let description;

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -244,7 +244,7 @@ const userHelper = function () {
 
       const pdtEndOfLastWeek = moment().tz('America/Los_Angeles').endOf('week').subtract(1, 'week');
 
-      const users = await userProfile.find({ isActive: true }, '_id weeklySummaries missedHours');
+      const users = await userProfile.find({ isActive: true }, '_id weeklycommittedHours weeklySummaries missedHours');
 
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
@@ -415,13 +415,21 @@ const userHelper = function () {
 
   const applyMissedHourForCoreTeam = async () => {
     try {
-      const currentDate = moment().tz('America/Los_Angeles');
+      const currentDate = moment().tz('America/Los_Angeles').format();
 
-      logger.logInfo(`Job for applying missed hours for Core Team members starting at ${currentDate.format()}`);
+      logger.logInfo(`Job for applying missed hours for Core Team members starting at ${currentDate}`);
 
-      const startOfLastWeek = currentDate.subtract(1, 'week').startOf('week').format('YYYY-MM-DD');
+      const startOfLastWeek = moment()
+      .tz('America/Los_Angeles')
+      .startOf('week')
+      .subtract(1, 'week')
+      .format('YYYY-MM-DD');
 
-      const endOfLastWeek = currentDate.subtract(1, 'week').endOf('week').format('YYYY-MM-DD');
+      const endOfLastWeek = moment()
+      .tz('America/Los_Angeles')
+      .endOf('week')
+      .subtract(1, 'week')
+      .format('YYYY-MM-DD');
 
       const missedHours = await userProfile.aggregate([
         {

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -51,6 +51,7 @@ const userProfileSchema = new Schema({
     ],
   },
   weeklycommittedHours: { type: Number, default: 10 },
+  missedHours: { type: Number, default: 0 },
   createdDate: { type: Date, required: true, default: Date.now() },
   lastModifiedDate: { type: Date, required: true, default: Date.now() },
   reactivationDate: { type: Date },


### PR DESCRIPTION
# Description
Back-end update for: a & b
![image](https://user-images.githubusercontent.com/94319381/230246489-e3d848b2-bf84-459d-88ba-b70a714342e6.png)
Frontend [PR757](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/757)

## Mainly changes explained:
Add `applyMissedHourForCoreTeam` function in userHelper.js to calculate missed hours for Core Team weekly.
Update `assignBlueSquareForTimeNotMet` function in userHelper.js to apply missed hours in the weekly blueSquare check.
Update `getTasksForTeamsByUser` function in taskController.js to send updated weeklycommittedHours for the tasks component.
Update `getLeaderboard` function in dashboard.js to send updated weeklycommittedHours for the leaderboard component.

## How to test:
This PR needs API testing using Postman, please first set up the Postman environment. 
1. If this is your first time using Postman, just start HGNRest and post to http://localhost:4500/api/login with the email and password in the body. You will get a token as a result if your setup is successful.
![image](https://user-images.githubusercontent.com/94319381/230522382-114d017c-acd8-4321-86ae-91f8c469ba3c.png)

2. Make the following adjustments to HGNRest then rebuild and restart the HGNRest:
**userProfileController.js: Add test function in userProfileController**
![image](https://user-images.githubusercontent.com/94319381/230523134-d4bde409-2ac1-4ee9-baf5-1ace6e0ae309.png)
**userProfileRouter.js: Add a new route to call the test function**
![image](https://user-images.githubusercontent.com/94319381/230523955-160c45de-6976-41cd-8722-d9a304e8b43f.png)
**userHelper.js: Add `role: 'Core Team'` to line 247 to let assignBlueSquareForTimeNotMet just apply for Core Team member.**
![image](https://user-images.githubusercontent.com/94319381/230525368-183a221b-cd06-43d6-be9c-343fdf4da006.png)

3. Use Postman and send a GET request to http://localhost:4500/api/userProfiletest. Make sure you input the correct address and method set to GET. **Set the authorization value to the token you get at step 1 in the header**. The request will return finished (this will take a few seconds.)
![image](https://user-images.githubusercontent.com/94319381/230546477-02993690-fbd0-449e-869e-35a8ef30e18b.png)

4. Open a 'Core Team' userProfile page and check the value of Additional Make-up Hours This Week. It should be (previous make-up hours + weeklycommittedHours - last week's total tangible time). Also, check the blue square to see if the blue square assignment is correct.
![image](https://user-images.githubusercontent.com/94319381/230543980-2d52268b-da77-4219-8be8-5778f75af579.png)

5. Use an admin user account to assign 'Core Team' user tangible time of last week. You can click the green/red dot of that user from the leaderboard and go to that user's dashboard, then assign a time log. Then repeat step 4 to see if the make-up hours and blue square assignment process is correct.
![image](https://user-images.githubusercontent.com/94319381/230544808-fc29de1f-c9b1-4d94-bd20-33f9b645829d.png)

## Note
In step 4 and 5, the make-up hours and blue square may not update since the cache of that user won't get updated. Try inactive/active the user to clean the cache. The applyMissedHourForCoreTeam function doesn't need to update the cache since it runs weekly and doesn't require immediate affection.



