### PR TITLE
Jinchao update weeklysummaryrequired

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -178,6 +178,7 @@ const userProfileController = function (UserProfile) {
     up.email = req.body.email;
     up.weeklySummaries = req.body.weeklySummaries || [{ summary: "" }];
     up.weeklySummariesCount = req.body.weeklySummariesCount || 0;
+    up.weeklySummaryOption = req.body.weeklySummaryOption;
     up.mediaUrl = req.body.mediaUrl || "";
     up.collaborationPreference = req.body.collaborationPreference || "";
     up.timeZone = req.body.timeZone || "America/Los_Angeles";
@@ -291,6 +292,7 @@ const userProfileController = function (UserProfile) {
         record.weeklySummaryNotReq = req.body.weeklySummaryNotReq
           ? req.body.weeklySummaryNotReq
           : record.weeklySummaryNotReq;
+        record.weeklySummaryOption = req.body.weeklySummaryOption;
         record.categoryTangibleHrs = req.body.categoryTangibleHrs
           ? req.body.categoryTangibleHrs
           : record.categoryTangibleHrs;

--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -64,6 +64,7 @@ const reporthelper = function () {
         mediaUrl: 1,
         weeklycommittedHours: 1,
         weeklySummaryNotReq: 1,
+        weeklySummaryOption: 1,
         weeklySummaries: {
           $filter: {
             input: '$weeklySummaries',

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -108,7 +108,7 @@ const userHelper = function () {
 
       const weeklySummaryNotProvidedMessage = '<div><b>Weekly Summary:</b> <span style="color: red;"> Not provided! </span> </div>';
 
-      const weeklySummaryNotRequiredMessage = '<div><b>Weekly Summary:</b> <span style="color: magenta;"> Not required for this user </span></div>';
+      const weeklySummaryNotRequiredMessage = '<div><b>Weekly Summary:</b> <span style="color: green;"> Not required for this user </span></div>';
 
       results.sort((a, b) => `${a.firstName} ${a.lastName}`.localeCompare(
           `${b.firstName} ${b.lastname}`,

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -142,7 +142,18 @@ const userHelper = function () {
           : 'Not provided!';
 
         let weeklySummaryMessage = weeklySummaryNotProvidedMessage;
-
+        const colorStyle = (() => {
+          switch (weeklySummaryOption) {
+            case 'Team':
+              return 'style="color: magenta;"';
+            case 'Not Required':
+              return 'style="color: green"';
+            case 'Required':
+              return '';
+            default:
+              return result.weeklySummaryNotReq ? 'style="color: green"' : '';
+          }
+        })();
         // weeklySummaries array should only have one item if any, hence weeklySummaries[0] needs be used to access it.
         if (Array.isArray(weeklySummaries) && weeklySummaries[0]) {
           const { dueDate, summary } = weeklySummaries[0];
@@ -154,11 +165,11 @@ const userHelper = function () {
                   .tz('America/Los_Angeles')
                   .format('YYYY-MMM-DD')}</b>):
               </div>
-              <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}" ${weeklySummaryOption === 'Team' ? 'style="color: magenta;"' : ''}>
+              <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}" ${colorStyle}>
                 ${summary}
               </div>
             `;
-          } else if (weeklySummaryOption === 'Not Required' || result.weeklySummaryNotReq === true) {
+          } else if (weeklySummaryOption === 'Not Required' || (!weeklySummaryOption && result.weeklySummaryNotReq)) {
             weeklySummaryMessage = weeklySummaryNotRequiredMessage;
           }
         }

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -125,6 +125,7 @@ const userHelper = function () {
           mediaUrl,
           weeklySummariesCount,
           weeklycommittedHours,
+          weeklySummaryOption,
         } = result;
 
         if (email !== undefined && email !== null) {
@@ -153,11 +154,11 @@ const userHelper = function () {
                   .tz('America/Los_Angeles')
                   .format('YYYY-MMM-DD')}</b>):
               </div>
-              <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}">
+              <div data-pdfmake="{&quot;margin&quot;:[20,0,20,0]}" ${weeklySummaryOption === 'Team' ? 'style="color: magenta;"' : ''}>
                 ${summary}
               </div>
             `;
-          } else if (result.weeklySummaryNotReq === true) {
+          } else if (weeklySummaryOption === 'Not Required' || result.weeklySummaryNotReq === true) {
             weeklySummaryMessage = weeklySummaryNotRequiredMessage;
           }
         }
@@ -338,7 +339,7 @@ const userHelper = function () {
           { new: true },
         );
 
-        if (updateResult?.weeklySummaryNotReq) {
+        if (updateResult?.weeklySummaryOption === 'Not Required' || updateResult?.weeklySummaryNotReq) {
           hasWeeklySummary = true;
         }
 

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -140,6 +140,7 @@ const userProfileSchema = new Schema({
   ],
   weeklySummaryNotReq: { type: Boolean, default: false },
   timeZone: { type: String, required: true, default: 'America/Los_Angeles' },
+  weeklySummaryOption: { type: String },
 });
 
 userProfileSchema.pre('save', function (next) {


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/94319381/231906373-9bd0d506-05db-49d7-a092-11a148c3602e.png)
Backend update for [#764](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/764).
## Mainly changes explained:
Add `weeklySummaryOption` attribute to `userProfile` model. Update `postUserProfile` and `putUserProfile` functions in `userProfileController`
Update `emailWeeklySummariesForAllUsers` to show the correct summary text color in the email. 
## How to test:
Please first finished the test in frontend [#764](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/764) to have the big picture of the function. In this testing, we are using **POSTMAN** to do api test for `emailWeeklySummariesForAllUsers` function. Please refer to #313 if you are not familiar with **POSTMAN**.

- Make the following adjustments to HGNRest then rebuild and start the HGNRest:

1. userHelper.js: Add `return emailBody;` at line 227 of `emailWeeklySummariesForAllUsers`
![image](https://user-images.githubusercontent.com/94319381/231911242-0b175a89-9624-44a7-b71c-b9acfa24d35a.png)
2. userProfileController.js: Add test function in userProfileController
`const test = async (req, res) => {
    const emailBody = await userHelper.emailWeeklySummariesForAllUsers(0);
    res.status(200).send(emailBody);
  };`
![image](https://user-images.githubusercontent.com/94319381/231934639-19cd729b-b5ad-4268-9447-4df000669315.png)
3. userProfileRouter.js: Add a new route to call the test function in userProfileRouter
`userProfileRouter.route('/userProfiletest')
    .get(controller.test);`
![image](https://user-images.githubusercontent.com/94319381/231911542-2b201a7a-0261-4afc-a2d8-4adf2c0c8f37.png)

- Use Postman and send a GET request to http://localhost:4500/api/userProfiletest. 
![image](https://user-images.githubusercontent.com/94319381/231934408-574de3e8-511f-43e2-bb23-182963350158.png)
Check if the email output is the correct text color for users in different summary options. The content of reports should be the same as the report in the front end.
## Notes
We use `emailWeeklySummariesForAllUsers(0)` rather than `emailWeeklySummariesForAllUsers()` in `userProfileJobs` because the weekly summaries data in the dev database may not have last week's records due to multiple calls of `processWeeklySummariesByUserId` in `assignBlueSquareForTimeNotMet`
![image](https://user-images.githubusercontent.com/94319381/231935184-8461434b-a8b9-4364-bb75-53434ded012a.png)

