### PR TITLE
Jinchao fix “Current Week” hours at top of Dashboard Page

### DIFF
--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -235,6 +235,7 @@ const dashboardhelper = function () {
                 ],
               },
             },
+            { 'persondata.0._id': userid },
             { 'persondata.0.role': 'Volunteer' },
             { 'persondata.0.isVisible': true },
           ],


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/94319381/232260059-1493ef1d-4ec8-45b9-8081-8c3af1eecfdc.png)
This bug occurs when users with certain roles, such as managers, have their visibility set to invisible and are not able to view their own leaderboard data. This one-line change will fix the bug.