### PR TITLE
Johny fix badges i earned for x_hrs_x_week

### DIFF
--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -969,7 +969,7 @@ const userHelper = function () {
     const badgesOfType = badgeCollection.filter(badge => badge.badge?.type === 'X Hours for X Week Streak').map(badge => badge.badge);
      // Here is assigning the badges for 1 week streak
    const oneWeekBadges = await badge.find({ type: 'X Hours for X Week Streak', weeks: 1 }).sort({ totalHrs: -1 });
-   
+
     const arrayBadges = [];
    //  Here it is been saving the badges that is sastifying a condition for the hours the user worked.
    // for example if the user worked 50 hours in all week the badge to be assigned is just the badge of 50 hours in 1 week
@@ -1007,7 +1007,7 @@ const userHelper = function () {
    const workedWeeks = user.savedTangibleHrs.length;
    const greatStreakBadges = await badge.find({ type: 'X Hours for X Week Streak', weeks: { $lte: workedWeeks, $gt: 1 } }).sort({ totalHrs: -1 });
    // for the badge be assigned have to fulfill the requirement  totalHrs < user.lastWeekTangibleHrs;
-   
+
    const badgesThatMatch = [];
    // this array is storing all the badges that fullfil the totalHrs < lastWeekTangibleHrs
    greatStreakBadges.forEach((item) => {
@@ -1017,7 +1017,7 @@ const userHelper = function () {
    });
    const matchBadge = [];
    const weeksArray = [];
-   
+
    badgeCollection.filter(bdg => bdg.badge?.type === 'X Hours for X Week Streak').map((badge) => {
      for (let i = 0; i < badgesThatMatch.length; i++) {
        if (badge.badge?.totalHrs === badgesThatMatch[i].totalHrs) {
@@ -1037,8 +1037,8 @@ const userHelper = function () {
              removeDupBadge(personId, item.badge._id);
          }
        });
-   
-   
+
+
        for (let i = 0; i < badgesOfType.length; i++) {
          if (badgesOfType[i]._id.toString() === bdg._id.toString()) {
              badgeId = badgesOfType[i]._id;

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -984,7 +984,9 @@ const userHelper = function () {
       });
    // Here it is verifying the maximun  hour in the array of badges for the first condition
    // if the user worked 45 hours in a week just make sense assign badges where the total hours are lower then or equal 45 hours
-   const maxHourBadge = Math.max(...arrayTotalHrs);
+    let maxHourBadge = 0;
+    if(arrayTotalHrs.length > 0) { maxHourBadge = Math.max(...arrayTotalHrs)} 
+    ;
    // now here will assign the especific badge
    arrayBadges.map((badge) => {
      if (badge.totalHrs === maxHourBadge) {
@@ -1027,7 +1029,10 @@ const userHelper = function () {
      }
    });
    // calculate the max week number to assign the badge;
-   const maxWeek = Math.max(...weeksArray);
+   let maxWeek = 0;
+if (weeksArray.length > 0) {
+  maxWeek = Math.max(...weeksArray);
+}
    matchBadge.forEach((bdg) => {
      let badgeId;
      if (bdg.weeks === maxWeek) {


### PR DESCRIPTION
# Description
Fixes Bug from the badge bug list 4 - (PRIORITY MEDIUM) : Below are the badges I’ve earned. This should represent 1 time I got three 30-hr weeks in a row and 2 times I got two 30-hr weeks in a row.
![Captura de Tela (330)](https://user-images.githubusercontent.com/39320057/232641759-41b1f682-eef2-4740-9ecb-8ef7b27975ca.png)



## Mainly changes explained:
1 - The function `checkxHrsforXWeeks` was rebuild.
2 -  Now thw badges are being assigned properly.
3 - Badges of lower streak now are being delete when a badge of greate streak is earned.

## How to test:
check into current branch
do `npm install` and `npm run build` to run this PR locally
:arrow_right: go to the `useProfileJobs.js ` file and it is necessary to set the cronjob to run  in a short interval of time
:white_check_mark: for example to run the cronjob every 30 seconds use :  `'*/30 * * * * *'`.
:arrow_right:  to assign badges for 1 week or weeks greater than 1 it is necessary the user had worked for a entire week,  because the badges is assigned based on last week tangible hours.
:arrow_right: assign tangible hours for the user in any project.

![Captura de Tela (331)](https://user-images.githubusercontent.com/39320057/232643907-e8460812-0dd3-4841-94cb-56f2c71445c0.png)

:warning: :warning:
## it is not a easy PR to test

