### PR TITLE
Jinchao fix “Current Week” hours at top of Dashboard Page

### DIFF
--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -235,6 +235,7 @@ const dashboardhelper = function () {
                 ],
               },
             },
+            { 'persondata.0._id': userid },
             { 'persondata.0.role': 'Volunteer' },
             { 'persondata.0.isVisible': true },
           ],


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/94319381/232260059-1493ef1d-4ec8-45b9-8081-8c3af1eecfdc.png)
same change as #322 since that one was reverted.
## Main change
In the current dev branch, if a manager or mentor set their visibility to invisible which is the default setting (update from #300 and #[731](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/731)), the leaderboard data they get from HGNRest won't include their own record, which leads to the bug. This PR adds one line in `getLeaderboard` function to let these users always get their own record whatever their visibility is.
## How to test
In the current branch, log in as a manager or mentor. Go to userProfile->Teams->set visibility to 'invisible'->go back to the basic information tab to save the change. In this case, you won't see yourself in the leaderboard and you won't see your logged hour through the summary bar:
![image](https://user-images.githubusercontent.com/94319381/232678479-3f890f26-1871-4be4-9be2-3c6ff99e9d6d.png)
Now if you go back and change your visibility to 'visible', everything will look good as usual.
Pull this branch then rebuild and restart the HGNRest. Log in as a manager or mentor, and check if the leaderboard and summary bar looks good whatever the visibility is. (Users should be able to see themselves on the leaderboard)