### PR TITLE
Angelina - Add GDoc Link to Weekly Summaries Reports (backend)

### DIFF
--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -22,68 +22,83 @@ const reporthelper = function () {
    * @param {integer} endWeekIndex The end week index, eg. 1 for last week.
    */
   const weeklySummaries = async (startWeekIndex, endWeekIndex) => {
-    const pstStart = moment().tz('America/Los_Angeles').startOf('week').subtract(startWeekIndex, 'week')
+    const pstStart = moment()
+      .tz('America/Los_Angeles')
+      .startOf('week')
+      .subtract(startWeekIndex, 'week')
       .toDate();
-    const pstEnd = moment().tz('America/Los_Angeles').endOf('week').subtract(endWeekIndex, 'week')
+    const pstEnd = moment()
+      .tz('America/Los_Angeles')
+      .endOf('week')
+      .subtract(endWeekIndex, 'week')
       .toDate();
 
-    const results = await userProfile.aggregate([{
-      $match: {
-        isActive: true,
+    const results = await userProfile.aggregate([
+      {
+        $match: {
+          isActive: true,
+        },
       },
-    },
-    {
-      $lookup: {
-        from: 'timeEntries',
-        localField: '_id',
-        foreignField: 'personId',
-        as: 'timeEntries',
+      {
+        $lookup: {
+          from: 'timeEntries',
+          localField: '_id',
+          foreignField: 'personId',
+          as: 'timeEntries',
+        },
       },
-    },
-    {
-      $project: {
-        timeEntries: {
-          $filter: {
-            input: '$timeEntries',
-            as: 'timeEntry',
-            cond: {
-              $and: [
-                {
-                  $gte: ['$$timeEntry.dateOfWork', moment(pstStart).format('YYYY-MM-DD')],
-                },
-                {
-                  $lte: ['$$timeEntry.dateOfWork', moment(pstEnd).format('YYYY-MM-DD')],
-                },
-              ],
+      {
+        $project: {
+          timeEntries: {
+            $filter: {
+              input: '$timeEntries',
+              as: 'timeEntry',
+              cond: {
+                $and: [
+                  {
+                    $gte: [
+                      '$$timeEntry.dateOfWork',
+                      moment(pstStart).format('YYYY-MM-DD'),
+                    ],
+                  },
+                  {
+                    $lte: [
+                      '$$timeEntry.dateOfWork',
+                      moment(pstEnd).format('YYYY-MM-DD'),
+                    ],
+                  },
+                ],
+              },
             },
           },
-        },
-        firstName: 1,
-        lastName: 1,
-        email: 1,
-        mediaUrl: 1,
-        weeklycommittedHours: 1,
-        weeklySummaryNotReq: 1,
-        weeklySummaryOption: 1,
-        weeklySummaries: {
-          $filter: {
-            input: '$weeklySummaries',
-            as: 'ws',
-            cond: {
-              $and: [
-                {
-                  $gte: ['$$ws.dueDate', pstStart],
-                }, {
-                  $lte: ['$$ws.dueDate', pstEnd],
-                },
-              ],
+          firstName: 1,
+          lastName: 1,
+          email: 1,
+          mediaUrl: 1,
+          weeklycommittedHours: 1,
+          weeklySummaryNotReq: 1,
+          weeklySummaryOption: 1,
+          adminLinks: 1,
+          weeklySummaries: {
+            $filter: {
+              input: '$weeklySummaries',
+              as: 'ws',
+              cond: {
+                $and: [
+                  {
+                    $gte: ['$$ws.dueDate', pstStart],
+                  },
+                  {
+                    $lte: ['$$ws.dueDate', pstEnd],
+                  },
+                ],
+              },
             },
           },
+          weeklySummariesCount: 1,
+          isTangible: 1,
         },
-        weeklySummariesCount: 1,
-        isTangible: 1,
       },
-    },
     ]);
 
     // Logic too difficult to do using aggregation.
@@ -93,7 +108,10 @@ const reporthelper = function () {
       result.timeEntries.forEach((entry) => {
         const index = absoluteDifferenceInWeeks(entry.dateOfWork, pstEnd);
 
-        if (result.totalSeconds[index] === undefined || result.totalSeconds[index] === null) {
+        if (
+          result.totalSeconds[index] === undefined ||
+          result.totalSeconds[index] === null
+        ) {
           result.totalSeconds[index] = 0;
         }
 
@@ -108,7 +126,6 @@ const reporthelper = function () {
     return results;
   };
 
-
   /**
    * Checks whether a date belongs to a specific week based on week index.
    *
@@ -118,8 +135,14 @@ const reporthelper = function () {
    * @return {boolean} True if match, false otherwise.
    */
   const doesDateBelongToWeek = function (dueDate, weekIndex) {
-    const pstStartOfWeek = moment().tz('America/Los_Angeles').startOf('week').subtract(weekIndex, 'week');
-    const pstEndOfWeek = moment().tz('America/Los_Angeles').endOf('week').subtract(weekIndex, 'week');
+    const pstStartOfWeek = moment()
+      .tz('America/Los_Angeles')
+      .startOf('week')
+      .subtract(weekIndex, 'week');
+    const pstEndOfWeek = moment()
+      .tz('America/Los_Angeles')
+      .endOf('week')
+      .subtract(weekIndex, 'week');
     const fromDate = moment(pstStartOfWeek).toDate();
     const toDate = moment(pstEndOfWeek).toDate();
     return moment(dueDate).isBetween(fromDate, toDate, undefined, '[]');
@@ -153,7 +176,7 @@ const reporthelper = function () {
    * @return {Object} An array of user objects with properly sorted weeklySummaries by due date.
    */
   const formatSummaries = function (results) {
-    return (results.map((user) => {
+    return results.map((user) => {
       const { weeklySummaries: wS } = user;
       const wSummaries = [];
 
@@ -166,20 +189,21 @@ const reporthelper = function () {
         }
         // When single entry.
         if (wS.length === 1) {
-        // Special case when first entry belongs to week before last.
+          // Special case when first entry belongs to week before last.
           if (getTheWeek(wS[0].dueDate) === 2) {
             wSummaries[0] = null;
             wSummaries[1] = null;
             wSummaries[2] = { ...wS[0] };
           }
-        } else { // When two entries.
+        } else {
+          // When two entries.
           if (getTheWeek(wS[1].dueDate) === 1) wSummaries[1] = { ...wS[1] };
           if (getTheWeek(wS[1].dueDate) === 2) wSummaries[2] = { ...wS[1] };
         }
         user = { ...user, weeklySummaries: wSummaries };
       }
       return user;
-    }));
+    });
   };
 
   return {


### PR DESCRIPTION
1. [this icon](https://www.uplabs.com/posts/google-go-android-icon) and a link to that Google Doc for each person who has one
2. Put the icon/link to the right of their name Navigate as an Admin to Reports → Weekly Summaries Reports: I’d like the app to check for a Google Doc link on their profile (one is added for almost every person when they are added to the system) and insert 
3. On that icon, please also be sure that I can command (mac)/control (PC) + Click to open that in a new tab. It should happen automatically if it is a linked icon, but please double-check to be sure.
4. If no Google Doc is present for the user, it should instead cause a popup that says: “Uh oh, no Google Doc is present for this user! Please contact an Admin to find out why.”

### **Main Changes Explained:**
add adminLinks  to the reporthelper function. 

### **How to Test:**

1. check out this branch and the frontend branch that is related to this PR as well. (see link below)
2. Navigate as an Admin to Reports → Weekly Summaries Reports
3. Select the google doc icon located next to each user profile name. 
4. If they have a google doc link then a new window will open and the google doc link will appear. 
5. If they do not have a google doc link then a pop-up will appear. 

### **Additional Notes:**
This branch needs the front end branch:
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/786

