### PR TITLE
DO NOT MERGE - Johny - WBS Categories Not Saving Correctly - still needs frontend

### DIFF
--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -733,6 +733,7 @@ const taskController = function (Task) {
     _task.startedDatetime = req.body.startedDatetime;
     _task.dueDatetime = req.body.dueDatetime;
     _task.links = req.body.links;
+    _task.category = req.body.category;
     _task.parentId1 = req.body.parentId1;
     _task.parentId2 = req.body.parentId2;
     _task.parentId3 = req.body.parentId3;


### PR DESCRIPTION
# Description
Fixes # (17 - PRIORITY High) WBS Categories Not Saving Correctly
When you create a new task, the category should save as the same as the category for the project within the task. It shows the correct category but doesn’t save… it saves to “Food” in my example video. 


## Related PRS (if any):
To test this backend PR you need to checkout the #XXX frontend PR.
…

## Mainly changes explained:
1 - Was added a new field  `_task.category = req.body.category;`  in the `newTask` object inside the function `postTask` 

## How to test:
check into current branch
do `npm install` and `npm run build` to run this PR locally

## Screenshots or videos of changes:
![Captura de Tela (345)](https://user-images.githubusercontent.com/39320057/233755796-3b4d194d-774a-45e6-9e0f-566f343125bf.png)
