### PR TITLE
Jinchao make new users show up immediately

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -193,16 +193,19 @@ const userProfileController = function (UserProfile) {
 
         // update backend cache
 
-        const userCache = `{"isActive":${true},"weeklyComittedHours":${up.weeklyComittedHours},
-                            "createdDate":"${up.createdDate.toISOString()}","_id":"${
-          up._id
-        }","role":"${up.role}",
-                            "firstName":"${up.firstName}","lastName":"${up.lastName}","email":"${
-          up.email
-        }"}`;
-        const userCacheJson = JSON.parse(userCache);
+        const userCache = {
+          permissions: up.permissions,
+          isActive: true,
+          weeklycommittedHours: up.weeklycommittedHours,
+          createdDate: up.createdDate.toISOString(),
+          _id: up._id,
+          role: up.role,
+          firstName: up.firstName,
+          lastName: up.lastName,
+          email: up.email,
+        };
         const allUserCache = JSON.parse(cache.getCache('allusers'));
-        allUserCache.push(userCacheJson);
+        allUserCache.push(userCache);
         cache.setCache('allusers', JSON.stringify(allUserCache));
       })
       .catch(error => res.status(501).send(error));


### PR DESCRIPTION
# Description
![image](https://user-images.githubusercontent.com/94319381/233766099-461df341-6228-4757-9508-56523cfb522b.png)
## Main Change Made:
The current creation of the new user cache has a dated var `weeklyComittedHours` and it is caused by merging an old PR.
This PR updates the variable and replaces the previous use of JSON.parse(string) with directly creating an object.
## How to test:
Log in as admin,
Other links->user management->create a new user
You will see an immediate change on the table.