### PR TITLE
changed the return object within getUserLaborData

### DIFF
--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -452,6 +452,8 @@ const dashboardhelper = function () {
       return [
         {
           personId: userId,
+          role: user.role,
+          weeklycommittedHours: user.weeklycommittedHours,
           name: `${user.firstName} ${user.lastName}`,
           totaltime_hrs: (tangibleSeconds + intangibleSeconds) / 3600,
           totaltangibletime_hrs: tangibleSeconds / 3600,


### PR DESCRIPTION
This PR is due: (PRIORITY URGENT) JAE:  Fix “Current Week” hours at top of Dashboard Page (WIP Jinchao/Lucas)
Previous work on this that was reverted but didn’t need to be [PR #322](https://github.com/OneCommunityGlobal/HGNRest/pull/322)
Volunteers are seeing zero for their hours on their Dashboard like the pic below. They also don’t show on the leaderboard on the right
Adding a person to a team fixes this
After Yiyun’s account role was changed from “Manager” to “Volunteer” on Main, her current hours showed back correctly as well as hours on the Timelog page. And also she is back on the Leaderboard. She suspected that change related to “Visibility” on her profile page Teams tab.

### Main changes

Now, if an user is not on a team, it can see itself on the Leaderboard and is now able to log hours

<hr>

### How to test

- Check the current branch
- Enter on various users that are not on a team with various roles
- Check if those users can see themselves on the Leaderboard
- Check if those users can log time and if the "Current Week" bar is working properly