### PR TITLE
add bio requested status to report page

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -264,6 +264,7 @@ const userProfileController = function (UserProfile) {
       record.totalTangibleHrs = req.body.totalTangibleHrs;
       record.isVisible = req.body.isVisible || false;
       record.totalIntangibleHrs = req.body.totalIntangibleHrs;
+      record.bioPosted = req.body.bioPosted || false;
 
       // find userData in cache
       const isUserInCache = cache.hasCache('allusers');

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -142,6 +142,7 @@ const userProfileSchema = new Schema({
   timeZone: { type: String, required: true, default: 'America/Los_Angeles' },
   isVisible: { type: Boolean, default: false },
   weeklySummaryOption: { type: String },
+  bioPosted: { type: Boolean, default: false },
 });
 
 userProfileSchema.pre('save', function (next) {


### PR DESCRIPTION
### Description
Add a “Bio Posted/Requested” selection to the Reports page
1. This is so anyone looking at the reports page knows if a person’s bio announcement is in the process of being created or already created.  
2. Changing this should auto-save (show saving notification like saving an intangible time log) but not refresh the page 
3. It should be editable by Owner/Admin class only

### Mainly changes explained:
add a new attribute `bioPosted` to the userProfile to store the status.

### How to test:
**Please test with the [front end PR](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/807).**
checkout this branch
for the server:
`npm run build`
`npm start`
for the front end:
`npm run start:local`
run the front end and test
