### PR TITLE
Fix un-escaped regex

### DIFF
--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const UserProfile = require('../models/userProfile');
 const hasPermission = require('../utilities/permissions');
+const escapeRegex = require('../utilities/escapeRegex');
 
 const badgeController = function (Badge) {
   const getAllBadges = function (req, res) {
@@ -61,7 +62,7 @@ const badgeController = function (Badge) {
       return;
     }
 
-    Badge.find({ badgeName: { $regex: req.body.badgeName, $options: 'i' } })
+    Badge.find({ badgeName: { $regex: escapeRegex(req.body.badgeName), $options: 'i' } })
       .then((result) => {
         if (result.length > 0) {
           res.status(400).send({ error: `Another badge with name ${result[0].badgeName} already exists. Sorry, but badge names should be like snowflakes, no two should be the same. Please choose a different name for this badge so it can be proudly unique.` });

--- a/src/controllers/forgotPwdcontroller.js
+++ b/src/controllers/forgotPwdcontroller.js
@@ -1,6 +1,7 @@
 const uuidv4 = require('uuid/v4');
 const emailSender = require('../utilities/emailSender');
 const logger = require('../startup/logger');
+const escapeRegex = require('../utilities/escapeRegex');
 
 
 function getEmailMessageForForgotPassword(user, ranPwd) {
@@ -21,9 +22,9 @@ const forgotPwdController = function (userProfile) {
     const _lastName = (req.body.lastName);
 
     const user = await userProfile.findOne({
-      email: { $regex: _email, $options: 'i' },
-      firstName: { $regex: _firstName, $options: 'i' },
-      lastName: { $regex: _lastName, $options: 'i' },
+      email: { $regex: escapeRegex(_email), $options: 'i' },
+      firstName: { $regex: escapeRegex(_firstName), $options: 'i' },
+      lastName: { $regex: escapeRegex(_lastName), $options: 'i' },
     })
       .catch((error) => {
         res.status(500).send(error);

--- a/src/controllers/inventoryController.js
+++ b/src/controllers/inventoryController.js
@@ -3,6 +3,7 @@ const moment = require('moment');
 const projects = require('../models/project');
 const wbs = require('../models/wbs');
 const hasPermission = require('../utilities/permissions');
+const escapeRegex = require('../utilities/escapeRegex');
 
 const inventoryController = function (Item, ItemType) {
   const getAllInvInProjectWBS = function (req, res) {
@@ -539,7 +540,7 @@ const inventoryController = function (Item, ItemType) {
     if (!hasPermission(req.body.requestor.role, 'postInvType')) {
       return res.status(403).send('You are not authorized to save an inventory type.');
     }
-    return ItemType.find({ name: { $regex: req.body.name, $options: 'i' } })
+    return ItemType.find({ name: { $regex: escapeRegex(req.body.name), $options: 'i' } })
       .then((result) => {
         if (result.length > 0) {
           res.status(400).send({ error: `Another ItemType with name ${req.body.name} already exists. Sorry, but item names should be like snowflakes, no two should be the same.` });

--- a/src/controllers/logincontroller.js
+++ b/src/controllers/logincontroller.js
@@ -3,6 +3,7 @@ const jwt = require('jsonwebtoken');
 const moment = require('moment');
 const config = require('../config');
 const userprofile = require('../models/userProfile');
+const escapeRegex = require('../utilities/escapeRegex');
 
 const logincontroller = function () {
   const { JWT_SECRET,DEF_PWD } = config;
@@ -19,7 +20,7 @@ const logincontroller = function () {
     }
 
 
-    const user = await userprofile.findOne({ email: { $regex: _email, $options: 'i' } })
+    const user = await userprofile.findOne({ email: { $regex: escapeRegex(_email), $options: 'i' } })
       .catch(error => res.status(400).send(error));
 
     // returning 403 if the user not found or the found user is inactive.

--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -3,6 +3,7 @@ const timeentry = require('../models/timeentry');
 const userProfile = require('../models/userProfile');
 const userProject = require('../helpers/helperModels/userProjects');
 const hasPermission = require('../utilities/permissions');
+const escapeRegex = require('../utilities/escapeRegex');
 
 
 const projectController = function (Project) {
@@ -55,7 +56,7 @@ const projectController = function (Project) {
       return;
     }
 
-    Project.find({ projectName: { $regex: req.body.projectName, $options: 'i' } })
+    Project.find({ projectName: { $regex: escapeRegex(req.body.projectName), $options: 'i' } })
       .then((result) => {
         if (result.length > 0) {
           res.status(400).send({ error: `Project Name must be unique. Another project with name ${result.projectName} already exists. Please note that project names are case insensitive` });

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -12,6 +12,7 @@ const Badge = require('../models/badge');
 const yearMonthDayDateValidator = require('../utilities/yearMonthDayDateValidator');
 const cache = require('../utilities/nodeCache')();
 const hasPermission = require('../utilities/permissions');
+const escapeRegex = require('../utilities/escapeRegex');
 const config = require('../config');
 
 function ValidatePassword(req, res) {
@@ -112,7 +113,7 @@ const userProfileController = function (UserProfile) {
 
     const userByEmail = await UserProfile.findOne({
       email: {
-        $regex: req.body.email,
+        $regex: escapeRegex(req.body.email),
         $options: 'i',
       },
     });

--- a/src/utilities/escapeRegex.js
+++ b/src/utilities/escapeRegex.js
@@ -1,6 +1,6 @@
 
 const escapeRegex = function (text) {
-    return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+    return text.replace(/[[\]{}()*+?.\\^$|]/g, '\\$&');
 };
 
 module.exports = escapeRegex;

--- a/src/utilities/escapeRegex.js
+++ b/src/utilities/escapeRegex.js
@@ -1,0 +1,6 @@
+
+const escapeRegex = function (text) {
+    return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
+};
+
+module.exports = escapeRegex;

--- a/src/utilities/escapeRegexUnitTest.js
+++ b/src/utilities/escapeRegexUnitTest.js
@@ -1,0 +1,53 @@
+const assert = require('assert');
+const escapeRegex = require('./escapeRegex');
+
+
+let str = '.';
+let regex = new RegExp(escapeRegex(str));
+assert(regex.test(str) && !regex.test('a'), "'.' not escaped");
+
+str = 'a+';
+regex = new RegExp(escapeRegex(str));
+assert(regex.test(str) && !regex.test('a'), "'+' not escaped");
+
+str = 'a?a';
+regex = new RegExp(escapeRegex(str));
+assert(regex.test(str) && !regex.test('a'), "'?' not escaped");
+
+str = '(a)';
+regex = new RegExp(escapeRegex(str));
+assert(regex.test(str) && !regex.test('a'), "'()' not escaped");
+
+str = 'a{2,3}';
+regex = new RegExp(escapeRegex(str));
+assert(regex.test(str) && !regex.test('aa') && !regex.test('aaa'), "'{}' not escaped");
+
+str = '[a-c]';
+regex = new RegExp(escapeRegex(str));
+assert(regex.test(str) && !regex.test('b'), "'[]' not escaped");
+
+str = '^a';
+regex = new RegExp(escapeRegex(str));
+assert(regex.test(str) && !regex.test('a'), "'^' not escaped");
+
+str = 'a$';
+regex = new RegExp(escapeRegex(str));
+assert(regex.test(str) && !regex.test('a'), "'$' not escaped");
+
+str = 'a*';
+regex = new RegExp(escapeRegex(str));
+assert(regex.test(str) && !regex.test(''), "'*' not escaped");
+
+str = 'a|b';
+regex = new RegExp(escapeRegex(str));
+assert(regex.test(str) && !regex.test('a'), "'|' not escaped");
+
+str = '-';
+regex = new RegExp(escapeRegex(str));
+assert(regex.test(str), "'-' not escaped");
+
+str = ',';
+regex = new RegExp(escapeRegex(str));
+assert(regex.test(str), "',' not escaped");
+
+console.log('All escapeRegex unit tests have passed.');


### PR DESCRIPTION
# The Problem
Several checks for the uniqueness of new entries (profiles, badges, etc.) use regexes for case-insensitivity, however, the input was not escaped, so symbols with different meanings in regex were not being treated as text. This makes it so unique, valid emails (and other inputs) were not allowed or caused errors due to “duplication”. For example email@email.com == .....@email.com == e.+@email.com etc.

# Description
This fix escapes regex symbols to instead be treated as text.

There are 6 areas where this change affects. 4 are checking for the uniqueness of items as they are created (user emails for new profiles, badges, projects, and inventory items). The other two are matching email for login and email/name for the forgot password page.

# How to test
uniqueness: Create an item (user profile, badge, project, and inventory item), then attempt to create a separate item with a regex that should match (ex: '123' == '.+'). Order matters.
login: Once you create a new user profile using a regex, make sure you can log into it. 
forgot password: Make sure you can't trigger a password reset email from a regex that could match. 
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/23086054/fd421912-728a-4a60-82cf-78d727f8b70f)
vs
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/23086054/4e7fbdb7-3743-456c-bd3c-c14722c22bae)

