### PR TITLE
Lucile T - add work confirmation improvements to people report

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -241,7 +241,6 @@ const userProfileController = function (UserProfile) {
       }
 
       const originalinfringements = record.infringements ? record.infringements : [];
-
       record.jobTitle = req.body.jobTitle;
       record.emailPubliclyAccessible = req.body.emailPubliclyAccessible;
       record.phoneNumberPubliclyAccessible = req.body.phoneNumberPubliclyAccessible;
@@ -264,6 +263,7 @@ const userProfileController = function (UserProfile) {
       record.hoursByCategory = req.body.hoursByCategory;
       record.totalTangibleHrs = req.body.totalTangibleHrs;
       record.isVisible = req.body.isVisible || false;
+      record.isRehireable = req.body.isRehireable || false;
       record.totalIntangibleHrs = req.body.totalIntangibleHrs;
       record.bioPosted = req.body.bioPosted || false;
 
@@ -281,6 +281,7 @@ const userProfileController = function (UserProfile) {
         hasPermission(req.body.requestor.role, 'putUserProfileImportantInfo')
       ) {
         record.role = req.body.role;
+        record.isRehireable = req.body.isRehireable;
         record.isActive = req.body.isActive;
         record.weeklycommittedHours = req.body.weeklycommittedHours;
         record.missedHours = req.body.role === 'Core Team' ? (req.body?.missedHours ?? 0) : 0;

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -308,7 +308,7 @@ const userProfileController = function (UserProfile) {
 
         if (hasPermission(req.body.requestor.role, 'putUserProfilePermissions')) { record.permissions = req.body.permissions; }
 
-        if (yearMonthDayDateValidator(req.body.endDate)) {
+        if (yearMonthDayDateValidator(req.body.endDate) || new Date(req.body.endDate)) {
           record.endDate = moment(req.body.endDate).toDate();
           if (isUserInCache) {
             userData.endDate = record.endDate.toISOString();

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -21,6 +21,7 @@ const userProfileSchema = new Schema({
     },
   },
   isActive: { type: Boolean, required: true, default: true },
+  isRehireable: { type: Boolean, default: false},
   isSet: { type: Boolean, required: true, default: false },
   role: {
     type: String,

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -21,7 +21,7 @@ const userProfileSchema = new Schema({
     },
   },
   isActive: { type: Boolean, required: true, default: true },
-  isRehireable: { type: Boolean, default: false},
+  isRehireable: { type: Boolean, default: false },
   isSet: { type: Boolean, required: true, default: false },
   role: {
     type: String,


### PR DESCRIPTION
###Description
9. (PRIORITY MEDIUM) Jae: Add work confirmation improvements to People Report (WIP Lucile)
Admin or Owner login → Reports → Reports → People → Choose
Remove “hours logged this week” section: If a user is INACTIVE (has an end date), then the “Hours Logged This Week” square should not show. Center the remaining ones.
Please also add the User’s Title under their name.
Please also add a “Rehireable” section under their name that can be clicked as Yes or No


###Related PR
To test this backend PR you need to checkout the #836 frontend PR.
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/836)

###Mainly changes explained:
1 - isRehireable was added to UserProfile Model
2 - isRehireable management and new Date(req.body.endDate) was added in userProfileController


###Before (sorry for my slow connexion)

https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/111132148/e92b0a4c-9f38-4129-963b-645cdada4b9d

###After (sorry for my slow connexion)



https://github.com/OneCommunityGlobal/HGNRest/assets/111132148/1587e394-e643-4f06-9c1c-9b6ade8e35f3



###How to test:
Git checkout Lucile_add_work_confirmation_improvements_to_people_report in the backend
do "npm install" and "npm run build" and "npm start" to run this PR locally

Git checkout Lucile_add_work_confirmation_improvements_to_people_report in the frontend
do "npm install" and "npm run start:local"

Admin or Owner login → Reports → Reports → People → Choose someone with an end date 
You should be able to checkout and checkout the rehireable check box on the right.
The chosen check should remain even if the page is refreshed.

Admin or Owner login → Reports → Reports → People → Choose someone without an end date 
You should not see the rehireable checkbox