### PR TITLE
Bada - include user field isActive in getprojectMembership response

### DIFF
--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -175,7 +175,7 @@ const projectController = function (Project) {
       res.status(400).send({ error: 'Invalid request' });
       return;
     }
-    userProfile.find({ projects: projectId }, '_id firstName lastName profilePic')
+    userProfile.find({ projects: projectId }, '_id firstName lastName isActive profilePic')
       .sort({ firstName: 1, lastName: 1 })
       .then((results) => { res.status(200).send(results); })
       .catch((error) => { res.status(500).send(error); });


### PR DESCRIPTION
Needed for the [FE PR #852](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/852).

Include the `isActive` user field in the `getprojectMembership` response.