### PR TITLE
Fix timeZoneAPIController multiple headers sent

### DIFF
--- a/src/controllers/timeZoneAPIController.js
+++ b/src/controllers/timeZoneAPIController.js
@@ -11,6 +11,7 @@ const timeZoneAPIController = function () {
     }
     if (hasPermission(requestorRole, 'getTimeZoneAPIKey')) {
       res.status(200).send({ userAPIKey: premiumKey });
+      return;
     }
     res.status(200).send({ userAPIKey: commonKey });
   };


### PR DESCRIPTION
# Description
This PR fixes the following error when loading the dashboard (and wherever else timeZoneAPIController is used).
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client

## Main changes explained:
Adds a return to stop res.status().send from running twice. Could be replaced by an else block instead.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log in as admin user
4. go to dashboard
5. Confirm that you don't get a ERR_HTTP_HEADERS_SENT error in the HGNRest terminal.
