### PR TITLE
add change bio announcement to permission management

### DIFF
--- a/src/utilities/createInitialPermissions.js
+++ b/src/utilities/createInitialPermissions.js
@@ -43,6 +43,7 @@ const permissionsRoles = [
       'dataIsTangibleTimelog',
       'toggleSubmitForm',
       'seePermissionsManagement',
+      'changeBioAnnouncement',
     ],
     permissionsBackEnd: [
       'seeBadges',
@@ -228,6 +229,7 @@ const permissionsRoles = [
       'toggleSubmitForm',
       'seePermissionsManagement',
       'putUserProfilePermissions',
+      'changeBioAnnouncement',
     ],
     permissionsBackEnd: [
       'seeBadges',


### PR DESCRIPTION
# Description
While many roles have the permission to view the weekly summaries report page, we expect only admin/owner can change/edit the bio announcement status with a toggle switch, and other roles just see the label. But outside of Owner/Admin, there will be people who will be granted editing ability. The users or classes can be granted special editing ability via the Other Links --> Permissions Management option.

## Related PRS (if any):
To test this backend PR you need to checkout the [frontend PR879](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/879).

## Main changes explained:
- add changeBioAnnouncement to the initial permissions of the Owner/Admin

## How to test:
1. check into current branch
2. `npm run build` and `npm start`
3. test using the frontend PR
