### PR TITLE
fixed taskHelper so it returns the roles when fetched

### DIFF
--- a/src/helpers/taskHelper.js
+++ b/src/helpers/taskHelper.js
@@ -70,6 +70,7 @@ const taskHelper = function () {
               },
             ],
           },
+          role:1
         },
       },
       {
@@ -101,6 +102,7 @@ const taskHelper = function () {
               },
             },
           },
+          role:1
         },
       },
       {
@@ -132,6 +134,7 @@ const taskHelper = function () {
               false,
             ],
           },
+          role:1
         },
       },
       {
@@ -153,6 +156,7 @@ const taskHelper = function () {
             personId: '$personId',
             weeklycommittedHours: '$weeklycommittedHours',
             name: '$name',
+            role: '$role'
           },
           totalSeconds: {
             $sum: '$totalSeconds',
@@ -174,6 +178,7 @@ const taskHelper = function () {
           totaltangibletime_hrs: {
             $divide: ['$tangibletime', 3600],
           },
+          role: '$_id.role'
         },
       },
       {


### PR DESCRIPTION
# Description

### HOTFIX ###
The tasks were not showing for members other than owners/administrators due some mistakes made while aggregating them

## Main changes explained:

Tasks are now being showed for all members normally on the tasks tab

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as various user's roles
4. go to dashboard→ Tasks
5. see if tasks are being showed

