### PR TITLE
XiaoW fix getOrgData logic

### DIFF
--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -22,6 +22,15 @@ const dashboardhelper = function () {
       .endOf('week')
       .format('YYYY-MM-DD');
 
+    /**
+     * Previous aggregate pipeline had two issues:
+     *  1. personId is not in the userProfile field, it is from timeEntries
+     *  2. '$unwind' stage creates some documents for the same user, but later when using '$group' to get the user number and totalcommitedhours,
+     *    it didn't account for this. I think that is why it used `USERS = await userProfile.find()` to get the actual users number,
+     *    but this USER object is Huge, which is causing minutes to process.
+     *
+     * This update resolves these issues.
+     */
     const output = await userProfile.aggregate([
       {
         $match: {
@@ -44,7 +53,7 @@ const dashboardhelper = function () {
       },
       {
         $project: {
-          personId: 1,
+          personId: '$_id',
           name: 1,
           weeklycommittedHours: 1,
           role: 1,
@@ -85,34 +94,21 @@ const dashboardhelper = function () {
               0,
             ],
           },
-          isTangible: {
-            $cond: [
-              {
-                $gte: ['$timeEntryData.totalSeconds', 0],
-              },
-              '$timeEntryData.isTangible',
-              false,
-            ],
-          },
-        },
-      },
-      {
-        $addFields: {
           tangibletime: {
             $cond: [
               {
-                $eq: ['$isTangible', true],
+                $eq: ['$timeEntryData.isTangible', true],
               },
-              '$totalSeconds',
+              '$timeEntryData.totalSeconds',
               0,
             ],
           },
           intangibletime: {
             $cond: [
               {
-                $eq: ['$isTangible', false],
+                $eq: ['$timeEntryData.isTangible', false],
               },
-              '$totalSeconds',
+              '$timeEntryData.totalSeconds',
               0,
             ],
           },
@@ -120,70 +116,38 @@ const dashboardhelper = function () {
       },
       {
         $group: {
-          _id: 0,
-          member_count: {
-            $sum: 1,
+          _id: {
+            personId: '$personId',
+            weeklycommittedHours: '$weeklycommittedHours',
           },
-          totalSeconds: {
-            $sum: '$totalSeconds',
+          time_hrs: {
+            $sum: { $divide: ['$totalSeconds', 3600] },
           },
-          tangibletime: {
-            $sum: '$tangibletime',
+          tangibletime_hrs: {
+            $sum: { $divide: ['$tangibletime', 3600] },
           },
-          intangibletime: {
-            $sum: '$intangibletime',
-          },
-          totalweeklycommittedHours: {
-            $sum: '$weeklycommittedHours',
+          intangibletime_hrs: {
+            $sum: { $divide: ['$intangibletime', 3600] },
           },
         },
       },
       {
-        $project: {
+        $group: {
           _id: 0,
-          memberCount: '$member_count',
-          totalweeklycommittedHours: '$totalweeklycommittedHours',
+          memberCount: { $sum: 1 },
+          totalweeklycommittedHours: { $sum: '$_id.weeklycommittedHours' },
           totaltime_hrs: {
-            $divide: ['$totalSeconds', 3600],
+            $sum: '$time_hrs',
           },
           totaltangibletime_hrs: {
-            $divide: ['$tangibletime', 3600],
+            $sum: '$tangibletime_hrs',
           },
           totalintangibletime_hrs: {
-            $divide: ['$intangibletime', 3600],
-          },
-          percentagespentintangible: {
-            $cond: [
-              {
-                $eq: ['$totalSeconds', 0],
-              },
-              0,
-              {
-                $multiply: [
-                  {
-                    $divide: ['$tangibletime', '$totalSeconds'],
-                  },
-                  100,
-                ],
-              },
-            ],
+            $sum: '$intangibletime_hrs',
           },
         },
       },
     ]);
-
-    // This is a temporary band aid. I can't figure out why, but intangible time entries
-    // somehow increment the total weekly committted hours across all users. ???
-    const USERS = await userProfile.find({ isActive: true, role: { $ne: 'Mentor' }, weeklycommittedHours: { $gt: 0 } });
-    let totalCommittedHours = 0;
-    let MEMBER_COUNT = 0;
-    USERS.forEach((user) => {
-      totalCommittedHours += user.weeklycommittedHours;
-      MEMBER_COUNT += 1;
-    });
-
-    output[0].totalweeklycommittedHours = totalCommittedHours;
-    output[0].memberCount = MEMBER_COUNT;
 
     return output;
   };
@@ -228,11 +192,7 @@ const dashboardhelper = function () {
           $or: [
             {
               role: {
-                $in: [
-                  'Core Team',
-                  'Administrator',
-                  'Owner',
-                ],
+                $in: ['Core Team', 'Administrator', 'Owner'],
               },
             },
             { 'persondata.0._id': userid },


### PR DESCRIPTION
# Description
Dashboard will send a get request to '.../dashboard/leaderboard/org/data' and it will takes several seconds to get response for React main, and for React dev it will even take minutes to resolve (more test users). The response for this request is only for the first item on leaderboard (the 'HGN Totals' one).
![Screenshot 2023-06-08 191222](https://github.com/OneCommunityGlobal/HGNRest/assets/77769556/b205f9eb-3ec4-463d-b950-7a55b6ff680c)

Also The backend logic for this type of request is incorrect, and fixing this will resolve this whole issue.

(Priority low) Fixes LEADERBOARD COMPONENT 4 

## Main changes explained:
- Fix the aggregate pipeline logic (details see comments in file) 
- remove the second time consuming DB query and integrate it in the above pipeline
…

## How to test:
1. check into dev, run `npm i` `npm run build` and `npm start`, then run frontend in a new incognito browser, and on dashboard, check the first item on leaderboard to see how long it takes to update(usually minutes). Or you can open chrome developer tools and search network tab for the request sending to '.../dashboard/leaderboard/org/data' and see how long it takes for its status to change from pending to 200
2. check into this branch, run `npm i` `npm run build` and `npm start`, and repeat the same process in step 1
3. compare the times.

## Note:
I am still learning Mongdb, and if you notice anything I could improve please let me know as well.
