### PR TITLE
Jianjun - Fix the permission of changing user status

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -642,6 +642,10 @@ const userProfileController = function (UserProfile) {
       });
       return;
     }
+    if (!hasPermission(req.body.requestor.role, 'changeUserStatus')) {
+      res.status(403).send('You are not authorized to change user status');
+      return;
+    }
     cache.removeCache(`user-${userId}`);
     UserProfile.findById(userId, 'isActive')
       .then((user) => {

--- a/src/utilities/createInitialPermissions.js
+++ b/src/utilities/createInitialPermissions.js
@@ -44,6 +44,8 @@ const permissionsRoles = [
       'toggleSubmitForm',
       'seePermissionsManagement',
       'changeBioAnnouncement',
+      'changeUserStatus',
+      'submitWeeklySummaryForOthers',
     ],
     permissionsBackEnd: [
       'seeBadges',
@@ -230,6 +232,8 @@ const permissionsRoles = [
       'seePermissionsManagement',
       'putUserProfilePermissions',
       'changeBioAnnouncement',
+      'changeUserStatus',
+      'submitWeeklySummaryForOthers',
     ],
     permissionsBackEnd: [
       'seeBadges',


### PR DESCRIPTION
# Description
Fixes 5. (PRIORITY MEDIUM) Vitor/Jae: Fix the "Change User Status” permission
ADMIN LOGIN → Other Links → Permissions Management
When adding this permission it should give access on another person’s profile to edit the green button beside the name of the user profile you are viewing

## Related PRS (if any):
To test this backend PR you need to checkout [the frontend PR904](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/904).

## Main changes explained:
- add 'changeUserStatus' and 'submitWeeklySummaryForOthers' as the initial permissions of the Owner and Admin role.

## How to test:
1. check into current branch
2. do `npm run build` and `npm start` to run this PR locally

## Note:
The bug fix is mainly about the 'changeUserStatus', while the 'submitWeeklySummaryForOthers' is just added because it has not been included in the previous merged PR that introduces this permission (just make changes in the front end code).