### PR TITLE
XiaoW - optimize the request for user tasks to one post request (backend)

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -352,24 +352,11 @@ const timeEntrycontroller = function (TimeEntry) {
   };
 
   const getTimeEntriesForUsersList = function (req, res) {
-    const { members } = req.query;
-    const membersArr = members.split(',');
-
-    const fromDate = moment()
-      .tz('America/Los_Angeles')
-      .startOf('week')
-      .subtract(0, 'weeks')
-      .format('YYYY-MM-DD');
-
-    const toDate = moment()
-      .tz('America/Los_Angeles')
-      .endOf('week')
-      .subtract(0, 'weeks')
-      .format('YYYY-MM-DD');
+    const { users, fromDate, toDate } = req.body;
 
     TimeEntry.find(
       {
-        personId: { $in: membersArr },
+        personId: { $in: users },
         dateOfWork: { $gte: fromDate, $lte: toDate },
       },
       ' -createdDateTime',
@@ -395,7 +382,7 @@ const timeEntrycontroller = function (TimeEntry) {
         });
         res.status(200).send(data);
       })
-      .catch(error => res.status(400).send(error));
+      .catch((error) => res.status(400).send(error));
   };
 
   const getTimeEntriesForSpecifiedProject = function (req, res) {

--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -22,6 +22,15 @@ const dashboardhelper = function () {
       .endOf('week')
       .format('YYYY-MM-DD');
 
+    /**
+     * Previous aggregate pipeline had two issues:
+     *  1. personId is not in the userProfile field, it is from timeEntries
+     *  2. '$unwind' stage creates some documents for the same user, but later when using '$group' to get the user number and totalcommitedhours,
+     *    it didn't account for this. I think that is why it used `USERS = await userProfile.find()` to get the actual users number,
+     *    but this USER object is Huge, which is causing minutes to process.
+     *
+     * This update resolves these issues.
+     */
     const output = await userProfile.aggregate([
       {
         $match: {
@@ -44,7 +53,7 @@ const dashboardhelper = function () {
       },
       {
         $project: {
-          personId: 1,
+          personId: '$_id',
           name: 1,
           weeklycommittedHours: 1,
           role: 1,
@@ -85,34 +94,21 @@ const dashboardhelper = function () {
               0,
             ],
           },
-          isTangible: {
-            $cond: [
-              {
-                $gte: ['$timeEntryData.totalSeconds', 0],
-              },
-              '$timeEntryData.isTangible',
-              false,
-            ],
-          },
-        },
-      },
-      {
-        $addFields: {
           tangibletime: {
             $cond: [
               {
-                $eq: ['$isTangible', true],
+                $eq: ['$timeEntryData.isTangible', true],
               },
-              '$totalSeconds',
+              '$timeEntryData.totalSeconds',
               0,
             ],
           },
           intangibletime: {
             $cond: [
               {
-                $eq: ['$isTangible', false],
+                $eq: ['$timeEntryData.isTangible', false],
               },
-              '$totalSeconds',
+              '$timeEntryData.totalSeconds',
               0,
             ],
           },
@@ -120,70 +116,38 @@ const dashboardhelper = function () {
       },
       {
         $group: {
-          _id: 0,
-          member_count: {
-            $sum: 1,
+          _id: {
+            personId: '$personId',
+            weeklycommittedHours: '$weeklycommittedHours',
           },
-          totalSeconds: {
-            $sum: '$totalSeconds',
+          time_hrs: {
+            $sum: { $divide: ['$totalSeconds', 3600] },
           },
-          tangibletime: {
-            $sum: '$tangibletime',
+          tangibletime_hrs: {
+            $sum: { $divide: ['$tangibletime', 3600] },
           },
-          intangibletime: {
-            $sum: '$intangibletime',
-          },
-          totalweeklycommittedHours: {
-            $sum: '$weeklycommittedHours',
+          intangibletime_hrs: {
+            $sum: { $divide: ['$intangibletime', 3600] },
           },
         },
       },
       {
-        $project: {
+        $group: {
           _id: 0,
-          memberCount: '$member_count',
-          totalweeklycommittedHours: '$totalweeklycommittedHours',
+          memberCount: { $sum: 1 },
+          totalweeklycommittedHours: { $sum: '$_id.weeklycommittedHours' },
           totaltime_hrs: {
-            $divide: ['$totalSeconds', 3600],
+            $sum: '$time_hrs',
           },
           totaltangibletime_hrs: {
-            $divide: ['$tangibletime', 3600],
+            $sum: '$tangibletime_hrs',
           },
           totalintangibletime_hrs: {
-            $divide: ['$intangibletime', 3600],
-          },
-          percentagespentintangible: {
-            $cond: [
-              {
-                $eq: ['$totalSeconds', 0],
-              },
-              0,
-              {
-                $multiply: [
-                  {
-                    $divide: ['$tangibletime', '$totalSeconds'],
-                  },
-                  100,
-                ],
-              },
-            ],
+            $sum: '$intangibletime_hrs',
           },
         },
       },
     ]);
-
-    // This is a temporary band aid. I can't figure out why, but intangible time entries
-    // somehow increment the total weekly committted hours across all users. ???
-    const USERS = await userProfile.find({ isActive: true, role: { $ne: 'Mentor' }, weeklycommittedHours: { $gt: 0 } });
-    let totalCommittedHours = 0;
-    let MEMBER_COUNT = 0;
-    USERS.forEach((user) => {
-      totalCommittedHours += user.weeklycommittedHours;
-      MEMBER_COUNT += 1;
-    });
-
-    output[0].totalweeklycommittedHours = totalCommittedHours;
-    output[0].memberCount = MEMBER_COUNT;
 
     return output;
   };
@@ -228,11 +192,7 @@ const dashboardhelper = function () {
           $or: [
             {
               role: {
-                $in: [
-                  'Core Team',
-                  'Administrator',
-                  'Owner',
-                ],
+                $in: ['Core Team', 'Administrator', 'Owner'],
               },
             },
             { 'persondata.0._id': userid },

--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -174,11 +174,7 @@ const dashboardhelper = function () {
 
     // This is a temporary band aid. I can't figure out why, but intangible time entries
     // somehow increment the total weekly committted hours across all users. ???
-    const USERS = await userProfile.find({
-      isActive: true,
-      role: { $ne: 'Mentor' },
-      weeklycommittedHours: { $gt: 0 },
-    });
+    const USERS = await userProfile.find({ isActive: true, role: { $ne: 'Mentor' }, weeklycommittedHours: { $gt: 0 } });
     let totalCommittedHours = 0;
     let MEMBER_COUNT = 0;
     USERS.forEach((user) => {
@@ -232,7 +228,11 @@ const dashboardhelper = function () {
           $or: [
             {
               role: {
-                $in: ['Core Team', 'Administrator', 'Owner'],
+                $in: [
+                  'Core Team',
+                  'Administrator',
+                  'Owner',
+                ],
               },
             },
             { 'persondata.0._id': userid },

--- a/src/routes/timeentryRouter.js
+++ b/src/routes/timeentryRouter.js
@@ -5,11 +5,9 @@ const routes = function (TimeEntry) {
 
   const controller = require('../controllers/timeEntryController')(TimeEntry);
 
-
   TimeEntryRouter.route('/TimeEntry')
     .get(controller.getAllTimeEnteries)
     .post(controller.postTimeEntry);
-
 
   TimeEntryRouter.route('/TimeEntry/:timeEntryId')
     .put(controller.editTimeEntry)
@@ -19,11 +17,10 @@ const routes = function (TimeEntry) {
     .get(controller.getTimeEntriesForSpecifiedPeriod);
 
   TimeEntryRouter.route('/TimeEntry/users')
-    .get(controller.getTimeEntriesForUsersList);
+    .post(controller.getTimeEntriesForUsersList);
 
   TimeEntryRouter.route('/TimeEntry/projects/:projectId/:fromDate/:toDate')
     .get(controller.getTimeEntriesForSpecifiedProject);
-
 
   return TimeEntryRouter;
 };


### PR DESCRIPTION
# Description
When loading dashboard, app will send a get request for each user for its task and for admin there will be hundreds of requests. This PR integrates all the request into one post request.

## Related PRS (if any):
This backend PR is related to the [#905](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/905#issue-1751170104) frontend PR.
To test this backend PR you need to checkout the [#905](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/905#issue-1751170104) frontend PR.
…

## Main changes explained:
- change request method of `/TimeEntry/users` to post
- modify getTimeEntriesForUsersList for handling tasks for userIds
…

## How to test:
1. check into current branch
2. do `npm install`, `npm run build`, and `npm start` to run this PR locally
3. check [#905](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/905#issue-1751170104) for more details
