### PR TITLE
revert || new Date(req.body.endDate) on UserProfileController

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -309,7 +309,7 @@ const userProfileController = function (UserProfile) {
 
         if (hasPermission(req.body.requestor.role, 'putUserProfilePermissions')) { record.permissions = req.body.permissions; }
 
-        if (yearMonthDayDateValidator(req.body.endDate) || new Date(req.body.endDate)) {
+        if (yearMonthDayDateValidator(req.body.endDate)) {
           record.endDate = moment(req.body.endDate).toDate();
           if (isUserInCache) {
             userData.endDate = record.endDate.toISOString();


### PR DESCRIPTION
# Description
Revert line that might cause the End Date issue and deactivate accounts 
https://github.com/OneCommunityGlobal/HGNRest/pull/362

## Related PRS (if any):
[This frontend PR is related to the #XXX backend PR.
To test this backend PR you need to checkout the #XXX frontend PR.
…](https://github.com/OneCommunityGlobal/HGNRest/pull/362)

## Main changes explained:
delete " new Date(req.body.endDate) " on this is on the User Controller

 if (yearMonthDayDateValidator(req.body.endDate)) {
        if (yearMonthDayDateValidator(req.body.endDate) || new Date(req.body.endDate)) {
          record.endDate = moment(req.body.endDate).toDate();
          if (isUserInCache) {
            userData.endDate = record.endDate.toISOString();

## How to test:
1. check into current branch
2. do `npm run build` and `npm start` 


