### PR TITLE
Lucas fix users own tasks

### DIFF
--- a/src/helpers/taskHelper.js
+++ b/src/helpers/taskHelper.js
@@ -298,6 +298,7 @@ const taskHelper = function () {
       {
         $project: {
           personId: '$_id',
+          role: '$role',
           name: {
             $concat: [
             '$firstName',
@@ -328,6 +329,7 @@ const taskHelper = function () {
           personId: 1,
           name: 1,
           weeklycommittedHours: 1,
+          role:1,
           timeEntryData: {
             $filter: {
               input: '$timeEntryData',
@@ -357,6 +359,7 @@ const taskHelper = function () {
           personId: 1,
           name: 1,
           weeklycommittedHours: 1,
+          role:1,
           totalSeconds: {
             $cond: [
               {
@@ -396,6 +399,7 @@ const taskHelper = function () {
             personId: '$personId',
             weeklycommittedHours: '$weeklycommittedHours',
             name: '$name',
+            role: '$role'
           },
           totalSeconds: {
             $sum: '$totalSeconds',
@@ -411,6 +415,7 @@ const taskHelper = function () {
           personId: '$_id.personId',
           name: '$_id.name',
           weeklycommittedHours: '$_id.weeklycommittedHours',
+          role: '$_id.role',
           totaltime_hrs: {
             $divide: ['$totalSeconds', 3600],
           },


### PR DESCRIPTION
# Description
Users that didn't have the permission to see all the dashboard needed to be in a team to see their own tasks.

## Main changes explained:
When a user is not on a team, only the user's data is fetched, but it didn't include the **role** field, and the role field is necessary so the render function can work, so the **role** property was added when fetching a single user's data.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Loggin as roles that can't see the full dashboard information, make sure that the user is not on a team
4. check if the user can see itself under the tasks tab
