### PR TITLE
Lucile reusable user change 

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -493,9 +493,9 @@ const userProfileController = function (UserProfile) {
     const { userId } = req.params;
     const { key, value } = req.body;
 
-    //remove user from cache, it should be loaded next time
+    // remove user from cache, it should be loaded next time
     cache.removeCache(`user-${userId}`);
-    if (!key || value == undefined) return res.status(400).send({error:'Missing property or value'})
+    if (!key || value === undefined) return res.status(400).send({error:'Missing property or value'})
 
     return UserProfile.findById(userId)
       .then((user) => {

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -488,6 +488,31 @@ const userProfileController = function (UserProfile) {
       .catch(error => res.status(404).send(error));
   };
 
+
+  const updateOneProperty = function (req, res) {
+    const { userId } = req.params;
+    const { key, value } = req.body;
+
+    //remove user from cache, it should be loaded next time
+    cache.removeCache(`user-${userId}`);
+    if (!key || value == undefined) return res.status(400).send({error:'Missing property or value'})
+
+    return UserProfile.findById(userId)
+      .then((user) => {
+        user.set({
+          [key] : value
+        });
+
+        return user
+              .save()
+              .then(() =>{
+                res.status(200).send({ message: 'updated property' })
+              })
+              .catch(error => res.status(500).send(error));
+      })
+      .catch(error => res.status(500).send(error));
+  }
+
   const updatepassword = function (req, res) {
     const { userId } = req.params;
     const { requestor } = req.body;
@@ -741,6 +766,7 @@ const userProfileController = function (UserProfile) {
     deleteUserProfile,
     getUserById,
     getreportees,
+    updateOneProperty,
     updatepassword,
     getUserName,
     getTeamMembersofUser,

--- a/src/routes/userProfileRouter.js
+++ b/src/routes/userProfileRouter.js
@@ -28,6 +28,9 @@ const routes = function (userProfile) {
   userProfileRouter.route('/userProfile/teammembers/:userId')
     .get(controller.getTeamMembersofUser);
 
+    userProfileRouter.route('/userProfile/:userId/property')
+    .patch(controller.updateOneProperty);
+
   userProfileRouter.route('/userProfile/:userId/updatePassword')
     .patch(controller.updatepassword);
 


### PR DESCRIPTION
###Description
After a concerning bug, this PR has been made in order to change only a part of the User Profile without the use of putUserProfile function
In this PR this new code is used for isRehireable and Bio Status on the report page. 

###Related PR
To test this backend PR you need to checkout the #921 backend PR.
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/921

###Mainly changes explained:
1 - putUserProfile replaced by updateOneProperty

###Before 

https://github.com/OneCommunityGlobal/HGNRest/assets/111132148/78cd8ce5-fd98-4d84-8cb3-f738ae8ad811



###After 


https://github.com/OneCommunityGlobal/HGNRest/assets/111132148/6b44e983-7a0a-4c74-a86e-90b51f4b615b



###How to test:
Git checkout Lucile-reusable-user-change in the backend
do "npm pull" and "npm install" and "npm run build" and "npm start" to run this PR locally

Git checkout Lucile-reusable-user-change in the frontend
do "npm install" and "npm run start:local"

Admin or Owner login → Reports → Reports → People → Choose someone with an end date 
You should be able to check and checkout the rehireable check box and the bio status on the right.
The chosen check should remain even if the page is refreshed.

Admin or Owner login → Reports → Reports → People → Choose someone without an end date 
You should not see the rehireable checkbox
