### PR TITLE
Edwin - Fix logging authentication so partial match does not authenticate

### DIFF
--- a/src/controllers/logincontroller.js
+++ b/src/controllers/logincontroller.js
@@ -18,7 +18,7 @@ const logincontroller = function () {
     }
 
 
-    const user = await userprofile.findOne({ email: { $regex: escapeRegex(_email), $options: 'i' } })
+    const user = await userprofile.findOne({ email: { $regex: "^" + escapeRegex(_email) + "$", $options: 'i' } })
       .catch(error => res.status(400).send(error));
 
     // returning 403 if the user not found or the found user is inactive.


### PR DESCRIPTION
# Description

<img width="545" alt="Screen Shot 2023-06-19 at 3 46 39 AM" src="https://github.com/OneCommunityGlobal/HGNRest/assets/42288987/7b1d99f4-989b-4380-9080-521d010031b1">

## Main changes explained:
Added "^" to the start of the string and "$" to the end of the string so that it has to match exactly to the email

## How to test:
1. check into current branch
2. do `npm run build` && `npm run start`
3. Check for partial email matching. Partial email matching should not authenticate a user.

## Video/Screenshots

https://github.com/OneCommunityGlobal/HGNRest/assets/42288987/829b6cb3-63e5-4b7a-b157-8093c78088d4

