### PR TITLE
Update timerController and re-add oldTimer model

### DIFF
--- a/src/controllers/REAL_TIME_timerController.js
+++ b/src/controllers/REAL_TIME_timerController.js
@@ -1,6 +1,6 @@
 
 const logger = require('../startup/logger');
-const OldTimer = require('../models/timer');
+const OldTimer = require('../models/oldTimer');
 
 const timerController = function (Timer) {
   const getTimerFromDatabase = async ({ userId }) => {

--- a/src/models/oldTimer.js
+++ b/src/models/oldTimer.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const timerSchema = new Schema({
+    userId: { type: Schema.Types.ObjectId, required: true, ref: 'userProfile' },
+    pausedAt: { type: Number, default: 0 },
+    isWorking: { type: Boolean, default: false },
+    started: { type: Date },
+    lastAccess: { type: Date },
+  });
+
+
+module.exports = mongoose.model('timer', timerSchema, 'timers');


### PR DESCRIPTION
# Description

In current dev and prod, the timer will automatically pause every minutes and won't save the status after refreshing the page. 
This PR will fix the current timer in both dev and prod.

The bug is caused by an incomplete revert of the new Timer. When we are currently using the old timer, the controller is trying to store and update data with the `newTimers` doc in the database, which is supposed to be used by the new timer. The incompatible between the frontend and backed causes this bug.

## Main changes explained:
Re-add `oldTimer` in models to connect with `timers` doc in mongodb.
Change the model import in timerController.

## How to test:
1. check into current branch, rebuild and start the HGNRest
2. Test if now the timer is fixed: start/pause/stop/refresh the page, make sure everything is working correctly and the timer won't automatically stop after 1 min.
