### PR TITLE
Jinchao fix error when editing time logs

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -132,40 +132,21 @@ const timeEntrycontroller = function (TimeEntry) {
 
       // Update the hoursLogged field of related tasks based on before and after timeEntries
       // initialIsTangible is a bealoon value, req.body.isTangible is a string
-      if (initialIsTangible === true && req.body.isTangible === 'true') {
-        // Before timeEntry is tangible, after timeEntry is also tangible
-        try {
+      // initialProjectId may be a task id or project id, so do not throw error.
+      try {
+        if (initialIsTangible === true) {
           const initialTask = await task.findById(initialProjectId);
           initialTask.hoursLogged -= (initialSeconds / 3600);
           await initialTask.save();
-        } catch (error) {
-          throw new Error('Failed to find the initial task by id');
         }
-        try {
+
+        if (req.body.isTangible === true) {
           const editedTask = await task.findById(req.body.projectId);
           editedTask.hoursLogged += (totalSeconds / 3600);
           await editedTask.save();
-        } catch (error) {
-          throw new Error('Failed to find the edited task by id');
         }
-      } else if (initialIsTangible === true && req.body.isTangible === 'false') {
-        // Before timeEntry is tangible, after timeEntry is in-tangible
-        try {
-          const initialTask = await task.findById(initialProjectId);
-          initialTask.hoursLogged -= (initialSeconds / 3600);
-          await initialTask.save();
-        } catch (error) {
-          throw new Error('Failed to find the initial task by id');
-        }
-      } else if (initialIsTangible === false && req.body.isTangible === 'true') {
-        // Before timeEntry is in-tangible, after timeEntry is tangible
-        try {
-          const editedTask = await task.findById(req.body.projectId);
-          editedTask.hoursLogged += (totalSeconds / 3600);
-          await editedTask.save();
-        } catch (error) {
-          throw new Error('Failed to find the edited task by id');
-        }
+      } catch (error) {
+        console.log('Failed to find task by id');
       }
 
       // Update edit history


### PR DESCRIPTION
# Description
Fixed bug:
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/94319381/3d5b90b2-96db-4741-b9db-20af3c294599)

## Main changes explained:
Currently, a time entry can be logged under either a task or a project, and they share a same field in time entry class: projectId
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/94319381/ca30454f-8bf0-4925-9d47-8c8be36de7ce)
The bug is caused by a `throw error` when trying to do `task,findById` with a project id. This PR change it back to a `console.log` and improve the logic of increasing/decreasing timelogged.

## How to test:
1. check into current branch, do build and start.
2. log as admin user
3. Edit the time Entry logged under project or task to see if it can be correctly save now
4. Check if the logged time under a task change correctly when editing a relative time entry.

## Note
We need to refresh the page to load the latest logged time, may need another PR to address that issue.
