### PR TITLE
lawrence - fix change of name resources bug when adding a task

### DIFF
--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -1007,10 +1007,46 @@ const taskController = function (Task) {
           .getAllHoursLoggedForSpecifiedProject(taskId)
           .then((hours) => {
             results.set('hoursLogged', hours, { strict: false });
+          })
+          .catch(error => res.status(404).send(error))
+          .then(() => {
+            // Retrieve and update resource names for task
+            const resources = results?.resources;
+            const resourcesLength = resources.length;
+            const promiseArray = [];
+            for (let i = 0; i < resourcesLength; i += 1) {
+              promiseArray.push(
+                  taskHelper.getUserProfileFirstAndLastName(resources[i].userID),
+                );
+            }
+            Promise.all(promiseArray)
+              .then((resourceNames) => {
+                // Create a deep copy of resources
+                const editedResources = [];
+                for (let i = 0; i < resourcesLength; i += 1) {
+                  editedResources[i] = {};
+                  editedResources[i].completedTask = results.resources[i].completedTask;
+                  editedResources[i]._id = results.resources[i]._id;
+                  editedResources[i].userID = results.resources[i].userID;
+                  editedResources[i].name = results.resources[i].name;
+                }
+                // Update deep copy array's resource names
+                for (let i = 0; i < resourcesLength; i += 1) {
+                  // taskHelper.getUserProfileFirstAndLastName() will return an empty string if the results are null
+                  // If that's the case, do not update the resource's name
+                  editedResources[i].name = resourceNames[i] !== ' ' ? resourceNames[i] : editedResources[i].name;
+                }
+                results.resources = editedResources;
+              })
+              .finally(() => {
+                res.status(200).send(results);
+              });
+          })
+          .catch(() => {
+            // If there's an error, send potentially outdated resource names
             res.status(200).send(results);
           });
-      })
-      .catch(error => res.status(404).send(error));
+      });
   };
 
   const updateAllParents = (req, res) => {

--- a/src/helpers/taskHelper.js
+++ b/src/helpers/taskHelper.js
@@ -521,9 +521,18 @@ const taskHelper = function () {
       },
     ]);
   };
+  const getUserProfileFirstAndLastName = function (userId) {
+    return userProfile.findById(userId).then((results) => {
+      if (!results) {
+        return ' ';
+      }
+      return `${results.firstName} ${results.lastName}`;
+    });
+  };
   return {
     getTasksForTeams,
     getTasksForSingleUser,
+    getUserProfileFirstAndLastName,
   };
 };
 


### PR DESCRIPTION
# Description

![task](https://github.com/OneCommunityGlobal/HGNRest/assets/46981223/7782e733-9fd9-403d-ba2f-e9000dd3502e)

## Main changes explained:
- Update taskController.js to be able to make a series of Promises from taskHelper.js to retrieve resources' names
- Update taskHelper.js to be able to query for resources' names instead of using the potentially outdated names stored inside the task model

## How to test:
1. check into current branch
2. do `npm run build` and `npm start` to run this PR locally
3. click path on admin account: Dashboard → task → Edit/Suggest → Resources,
4. on assignor account: Dashboard → View Profile → Change Name → Save Changes Name → Save Changes
5. on admin account again: Dashboard → task → Edit/Suggest → Resources
6. check assignor’s name update or not.

## Screenshots or videos of changes:

![Demo gif](https://github.com/OneCommunityGlobal/HGNRest/assets/46981223/35f5e5f1-5401-41d8-8720-92d2c126acee)

## Note:
If you did what I did in the gif, refresh the tasks page because the back button will store the task data in a state therefore, it will not make an API call with the updated resources' names.

If you find the cast error logged on the backend console when you click on the "Edit" button, that was there before this update.
