### PR TITLE
Nida - Save/Edit chatGPT Prompt by owner

### DIFF
--- a/src/controllers/dashBoardController.js
+++ b/src/controllers/dashBoardController.js
@@ -1,9 +1,42 @@
 const mongoose = require('mongoose');
 const dashboardhelper = require('../helpers/dashboardhelper')();
 const emailSender = require('../utilities/emailSender');
+const DashboardData = require('../models/dashboardData');
 
 const dashboardcontroller = function () {
-  const dashboarddata = function (req, res) {
+
+  const getDashBoardData = function (req, res) {
+    DashboardData.findOne({dataId: "ai-prompt"})
+      .then(results => {
+        console.log("GETTTTTTTTT")
+        res.status(200).send(results)
+      })
+      .catch(error => res.status(404).send(error));
+  };
+  
+
+  const updateDashboardData = function (req, res) {
+    const userId = mongoose.Types.ObjectId(req.params.userId);
+
+    const snapshot = dashboardhelper.personaldetails(userId);
+
+    snapshot.then((userData) => { 
+      if (userData.role === 'Owner') {
+        const dashboardDataModel = new DashboardData();
+        dashboardDataModel.dataId = 'ai-prompt';
+        dashboardDataModel.aIPromptText = 'test';
+        dashboardDataModel.save().then(() => {
+          console.log("dashboard", dashboardDataModel)
+          console.log('SAVED!!!');
+          res.status(200).send({
+            aIPromptText: 'test' 
+          });
+        })
+      }
+     });
+  };
+
+  const dashboarduserdata = function (req, res) {
     const userId = mongoose.Types.ObjectId(req.params.userId);
 
     const snapshot = dashboardhelper.personaldetails(userId);
@@ -100,7 +133,9 @@ const dashboardcontroller = function () {
 
 
   return {
-    dashboarddata,
+    getDashBoardData,
+    updateDashboardData,
+    dashboarduserdata,
     monthlydata,
     weeklydata,
     leaderboarddata,

--- a/src/controllers/dashBoardController.js
+++ b/src/controllers/dashBoardController.js
@@ -4,36 +4,21 @@ const emailSender = require('../utilities/emailSender');
 const DashboardData = require('../models/dashboardData');
 
 const dashboardcontroller = function () {
+  const updateDashboardData = function (req, res) {
+      if (req.body.requestor.role === 'Owner') {
+         DashboardData.findOneAndUpdate({ _id: 'ai-prompt' }, { ...req.body, aIPromptText: req.body.aIPromptText })
+        .then(() => {
+          res.status(200).send();
+        }).catch(error => res.status(404).send(error));
+      }
+  };
 
   const getDashBoardData = function (req, res) {
-    DashboardData.findOne({dataId: "ai-prompt"})
-      .then(results => {
-        console.log("GETTTTTTTTT")
-        res.status(200).send(results)
+    DashboardData.findById({ _id: 'ai-prompt' })
+      .then((results) => {
+        res.status(200).send(results);
       })
       .catch(error => res.status(404).send(error));
-  };
-  
-
-  const updateDashboardData = function (req, res) {
-    const userId = mongoose.Types.ObjectId(req.params.userId);
-
-    const snapshot = dashboardhelper.personaldetails(userId);
-
-    snapshot.then((userData) => { 
-      if (userData.role === 'Owner') {
-        const dashboardDataModel = new DashboardData();
-        dashboardDataModel.dataId = 'ai-prompt';
-        dashboardDataModel.aIPromptText = 'test';
-        dashboardDataModel.save().then(() => {
-          console.log("dashboard", dashboardDataModel)
-          console.log('SAVED!!!');
-          res.status(200).send({
-            aIPromptText: 'test' 
-          });
-        })
-      }
-     });
   };
 
   const dashboarduserdata = function (req, res) {
@@ -133,8 +118,8 @@ const dashboardcontroller = function () {
 
 
   return {
-    getDashBoardData,
     updateDashboardData,
+    getDashBoardData,
     dashboarduserdata,
     monthlydata,
     weeklydata,

--- a/src/models/dashboardData.js
+++ b/src/models/dashboardData.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+
+const DashboardData = new Schema({
+    dataId: {type: String},
+    aIPromptText: { type: String, required: true},
+});
+
+module.exports = mongoose.model('dashboardData', DashboardData, 'dashboard');

--- a/src/models/dashboardData.js
+++ b/src/models/dashboardData.js
@@ -4,8 +4,8 @@ const { Schema } = mongoose;
 
 
 const DashboardData = new Schema({
-    dataId: {type: String},
-    aIPromptText: { type: String, required: true},
+    _id: { type: mongoose.Schema.Types.String },
+    aIPromptText: { type: String },
 });
 
 module.exports = mongoose.model('dashboardData', DashboardData, 'dashboard');

--- a/src/routes/dashboardRouter.js
+++ b/src/routes/dashboardRouter.js
@@ -6,8 +6,14 @@ const route = function () {
 
   const Dashboardrouter = express.Router();
 
+  Dashboardrouter.route('/dashboard')
+    .get(controller.getDashBoardData);
+
   Dashboardrouter.route('/dashboard/:userId')
-    .get(controller.dashboarddata);
+    .put(controller.updateDashboardData);
+
+  Dashboardrouter.route('/dashboard/:userId')
+    .get(controller.dashboarduserdata);
 
   Dashboardrouter.route('/dashboard/monthlydata/:userId/:fromDate/:toDate')
     .get(controller.monthlydata);

--- a/src/routes/dashboardRouter.js
+++ b/src/routes/dashboardRouter.js
@@ -2,14 +2,10 @@ const express = require('express');
 
 const route = function () {
   const controller = require('../controllers/dashBoardController')();
-
-
   const Dashboardrouter = express.Router();
 
-  Dashboardrouter.route('/dashboard')
-    .get(controller.getDashBoardData);
-
-  Dashboardrouter.route('/dashboard/:userId')
+  Dashboardrouter.route('/dashboard/aiPrompt')
+    .get(controller.getDashBoardData)
     .put(controller.updateDashboardData);
 
   Dashboardrouter.route('/dashboard/:userId')

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -16,10 +16,11 @@ const inventoryItemType = require('../models/inventoryItemType');
 const role = require('../models/role');
 const ownerMessage = require('../models/ownerMessage');
 const ownerStandardMessage = require('../models/ownerStandardMessage');
+const dashboardData = require('../models/dashboardData');
 
 const userProfileRouter = require('../routes/userProfileRouter')(userProfile);
 const badgeRouter = require('../routes/badgeRouter')(badge);
-const dashboardRouter = require('../routes/dashboardRouter')();
+const dashboardRouter = require('../routes/dashboardRouter')(dashboardData);
 const timeEntryRouter = require('../routes/timeentryRouter')(timeEntry);
 const projectRouter = require('../routes/projectRouter')(project);
 const teamRouter = require('../routes/teamRouter')(team);


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/32549172/4c683905-279b-4629-9430-5fc6bacf9b2f)

### Fixes (priority medium)
Currently, the chatGPT Prompt is not editable by owner

## Related PRS:
To test this backend PR you need to checkout the [#1024](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1024) frontend PR.

## Main changes explained:
- Created a `dashboardData` model containing the `aIPromptText` field holding the current prompt.
- Implemented `getDashBoardData()` which is used to get/retrieve the prompt and  `updateDashboardData()` which is used to update the changes made from the front-end by the owner. Both these functions are being implemented in `dashboardController`.
- Set up the API connections in `dashboardRouter` for both GET and PUT call to fetch and save the changes.

## How to test:
1. Check into current branch
2. Log as owner user
3. On the dashboard → Open Weekly Summary → Click on 'View and Copy Current AI Prompt'
4. Verify that the owner is able to edit the chatGPT prompt and the changes are saved.

## Note:
Please pull down the frontend [PR#1024](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1024) to test this backend PR.
