### PR TITLE
Aaron moving time entry to another task does not reflect the change correctly in Team Member Tasks

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -140,7 +140,7 @@ const timeEntrycontroller = function (TimeEntry) {
           await initialTask.save();
         }
 
-        if (req.body.isTangible === true) {
+        if (req.body.isTangible === "true") {
           const editedTask = await task.findById(req.body.projectId);
           editedTask.hoursLogged += (totalSeconds / 3600);
           await editedTask.save();


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/10265513/3b94a28c-41ea-4524-ab0b-9e39adbb72c0)

This PR also fixes the issue of whenever you edit a time entry, it removes that time from the task's `hoursLogged` (see before video).

## Related PRS (if any):
N/A

## Main changes explained:
- edited if statement in `editTimeEntry` to check for string value instead of boolean
- editing a time entry by moving it to another displays the hours correctly in "Team Member Tasks"
- editing a time entry in any other way does not remove this time from the hours logged

## How to test:
1. check into current branch
2. do `npm run build` and `npm start` to run this PR locally
3. log as any user that has multiple tasks with time logged to at least one of them
  a. if you don't have any users with tasks, login as admin/owner and create at least 2 tasks and assign them to a user
  b. if you don't have any time entries associated with the tasks, you can manually log time or log intangible time and then 
      convert it (only can be done on admin/owner)
5. go to dashboard→ Tasks and Timelogs → Current Week Timelog
6. edit the timelog and move it to another task
7. refresh the page, go to Tasks and make sure the hours successfully moved to the other task

## Screenshots or videos of changes:

<b>Before</b>

https://github.com/OneCommunityGlobal/HGNRest/assets/10265513/a7cb110d-a422-468f-a04f-2d0020987d72

<b>After</b>

https://github.com/OneCommunityGlobal/HGNRest/assets/10265513/724086c9-83c8-491a-a7cf-ec3ccba082e5