### PR TITLE
Fixed permissions promise bug

### DIFF
--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -4,8 +4,8 @@ const { hasPermission } = require('../utilities/permissions');
 const escapeRegex = require('../utilities/escapeRegex');
 
 const badgeController = function (Badge) {
-  const getAllBadges = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'seeBadges')) {
+  const getAllBadges = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'seeBadges')) {
       res.status(403).send('You are not authorized to view all badge data.');
       return;
     }
@@ -26,7 +26,7 @@ const badgeController = function (Badge) {
   };
 
   const assignBadges = async function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'assignBadges')) {
+    if (!await hasPermission(req.body.requestor.role, 'assignBadges')) {
       res.status(403).send('You are not authorized to assign badges.');
       return;
     }
@@ -56,8 +56,8 @@ const badgeController = function (Badge) {
     });
   };
 
-  const postBadge = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'createBadges')) {
+  const postBadge = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'createBadges')) {
       res.status(403).send({ error: 'You are not authorized to create new badges.' });
       return;
     }
@@ -90,8 +90,8 @@ const badgeController = function (Badge) {
       });
   };
 
-  const deleteBadge = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'deleteBadges')) {
+  const deleteBadge = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'deleteBadges')) {
       res.status(403).send({ error: 'You are not authorized to delete badges.' });
       return;
     }
@@ -111,8 +111,8 @@ const badgeController = function (Badge) {
       .catch((error) => { res.status(500).send(error); });
   };
 
-  const putBadge = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'updateBadges')) {
+  const putBadge = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'updateBadges')) {
       res.status(403).send({ error: 'You are not authorized to update badges.' });
       return;
     }

--- a/src/controllers/inventoryController.js
+++ b/src/controllers/inventoryController.js
@@ -6,8 +6,8 @@ const { hasPermission } = require('../utilities/permissions');
 const escapeRegex = require('../utilities/escapeRegex');
 
 const inventoryController = function (Item, ItemType) {
-  const getAllInvInProjectWBS = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'getAllInvInProjectWBS')) {
+  const getAllInvInProjectWBS = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'getAllInvInProjectWBS')) {
       return res.status(403).send('You are not authorized to view inventory data.');
     }
     // use req.params.projectId and wbsId
@@ -40,7 +40,7 @@ const inventoryController = function (Item, ItemType) {
   };
 
   const postInvInProjectWBS = async function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'postInvInProjectWBS')) {
+    if (!await hasPermission(req.body.requestor.role, 'postInvInProjectWBS')) {
       return res.status(403).send('You are not authorized to view inventory data.');
     }
     // use req.body.projectId and req.body.wbsId req.body.quantity,
@@ -107,8 +107,8 @@ const inventoryController = function (Item, ItemType) {
   };
 
 
-  const getAllInvInProject = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'getAllInvInProject')) {
+  const getAllInvInProject = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'getAllInvInProject')) {
       return res.status(403).send('You are not authorized to view inventory data.');
     }
     // same as getAllInvInProjectWBS but just using only the project to find the items of inventory
@@ -140,7 +140,7 @@ const inventoryController = function (Item, ItemType) {
   };
 
   const postInvInProject = async function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'postInvInProject')) {
+    if (!await hasPermission(req.body.requestor.role, 'postInvInProject')) {
       return res.status(403).send('You are not authorized to post new inventory data.');
     }
     // same as posting an item inProjectWBS but the WBS is uanassigned(i.e. null)
@@ -194,7 +194,7 @@ const inventoryController = function (Item, ItemType) {
   };
 
   const transferInvById = async function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'transferInvById')) {
+    if (!await hasPermission(req.body.requestor.role, 'transferInvById')) {
       return res.status(403).send('You are not authorized to transfer inventory data.');
     }
     // This function transfer inventory by id
@@ -283,7 +283,7 @@ const inventoryController = function (Item, ItemType) {
 
 
   const delInvById = async function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'delInvById')) {
+    if (!await hasPermission(req.body.requestor.role, 'delInvById')) {
       return res.status(403).send('You are not authorized to waste inventory.');
     }
     // send result just sending something now to have it work and not break anything
@@ -372,7 +372,7 @@ const inventoryController = function (Item, ItemType) {
   };
 
   const unWasteInvById = async function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'unWasteInvById')) {
+    if (!await hasPermission(req.body.requestor.role, 'unWasteInvById')) {
       return res.status(403).send('You are not authorized to unwaste inventory.');
     }
     const properUnWaste = await Item.findOne({ _id: req.params.invId, quantity: { $gte: req.body.quantity }, wasted: true }).select('_id').lean();
@@ -452,8 +452,8 @@ const inventoryController = function (Item, ItemType) {
     return res.status(400).send('Valid Project, Quantity and Type Id are necessary as well as valid wbs if sent in and not Unassigned');
   };
 
-  const getInvIdInfo = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'getInvIdInfo')) {
+  const getInvIdInfo = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'getInvIdInfo')) {
       return res.status(403).send('You are not authorized to get inventory by id.');
     }
     // req.params.invId
@@ -464,8 +464,8 @@ const inventoryController = function (Item, ItemType) {
       .catch(error => res.status(404).send(error));
   };
 
-  const putInvById = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'putInvById')) {
+  const putInvById = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'putInvById')) {
       return res.status(403).send('You are not authorized to edit inventory by id.');
     }
     // update the inv by id.
@@ -492,8 +492,8 @@ const inventoryController = function (Item, ItemType) {
     });
   };
 
-  const getInvTypeById = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'getInvTypeById')) {
+  const getInvTypeById = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'getInvTypeById')) {
       return res.status(403).send('You are not authorized to get inv type by id.');
     }
     // send result just sending something now to have it work and not break anything
@@ -503,8 +503,8 @@ const inventoryController = function (Item, ItemType) {
       .catch(error => res.status(404).send(error));
   };
 
-  const putInvType = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'putInvType')) {
+  const putInvType = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'putInvType')) {
       return res.status(403).send('You are not authorized to edit an inventory type.');
     }
     const { typeId } = req.params;
@@ -526,8 +526,8 @@ const inventoryController = function (Item, ItemType) {
     });
   };
 
-  const getAllInvType = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'getAllInvType')) {
+  const getAllInvType = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'getAllInvType')) {
       return res.status(403).send('You are not authorized to get all inventory.');
     }
     // send result just sending something now to have it work and not break anything
@@ -536,8 +536,8 @@ const inventoryController = function (Item, ItemType) {
       .catch(error => res.status(404).send(error));
   };
 
-  const postInvType = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'postInvType')) {
+  const postInvType = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'postInvType')) {
       return res.status(403).send('You are not authorized to save an inventory type.');
     }
     return ItemType.find({ name: { $regex: escapeRegex(req.body.name), $options: 'i' } })

--- a/src/controllers/popupEditorBackupController.js
+++ b/src/controllers/popupEditorBackupController.js
@@ -19,8 +19,8 @@ const popupEditorBackupController = function (PopupEditorBackups) {
   };
 
 
-  const createPopupEditorBackup = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'createPopup')) {
+  const createPopupEditorBackup = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'createPopup')) {
       res
         .status(403)
         .send({ error: 'You are not authorized to create new popup' });
@@ -45,8 +45,8 @@ const popupEditorBackupController = function (PopupEditorBackups) {
       .catch(error => res.status(500).send({ error }));
   };
 
-  const updatePopupEditorBackup = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'updatePopup')) {
+  const updatePopupEditorBackup = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'updatePopup')) {
       res
         .status(403)
         .send({ error: 'You are not authorized to create new popup' });

--- a/src/controllers/popupEditorController.js
+++ b/src/controllers/popupEditorController.js
@@ -14,8 +14,8 @@ const popupEditorController = function (PopupEditors) {
   };
 
 
-  const createPopupEditor = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'createPopup')) {
+  const createPopupEditor = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'createPopup')) {
       res
         .status(403)
         .send({ error: 'You are not authorized to create new popup' });
@@ -37,8 +37,8 @@ const popupEditorController = function (PopupEditors) {
       .catch(error => res.status(500).send({ error }));
   };
 
-  const updatePopupEditor = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'updatePopup')) {
+  const updatePopupEditor = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'updatePopup')) {
       res
         .status(403)
         .send({ error: 'You are not authorized to create new popup' });

--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -14,8 +14,8 @@ const projectController = function (Project) {
       .catch(error => res.status(404).send(error));
   };
 
-  const deleteProject = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'deleteProject')) {
+  const deleteProject = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'deleteProject')) {
       res.status(403).send({ error: 'You are  not authorized to delete projects.' });
       return;
     }
@@ -45,8 +45,8 @@ const projectController = function (Project) {
       .catch((errors) => { res.status(400).send(errors); });
   };
 
-  const postProject = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'postProject')) {
+  const postProject = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'postProject')) {
       res.status(403).send({ error: 'You are not authorized to create new projects.' });
       return;
     }
@@ -77,8 +77,8 @@ const projectController = function (Project) {
   };
 
 
-  const putProject = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'putProject')) {
+  const putProject = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'putProject')) {
       res.status(403).send('You are not authorized to make changes in the projects.');
       return;
     }
@@ -123,10 +123,10 @@ const projectController = function (Project) {
       });
   };
 
-  const assignProjectToUsers = function (req, res) {
+  const assignProjectToUsers = async function (req, res) {
     // verify requestor is administrator, projectId is passed in request params and is valid mongoose objectid, and request body contains  an array of users
 
-    if (!hasPermission(req.body.requestor.role, 'assignProjectToUsers')) {
+    if (!await hasPermission(req.body.requestor.role, 'assignProjectToUsers')) {
       res.status(403).send({ error: 'You are not authorized to perform this operation' });
       return;
     }

--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -2,8 +2,8 @@ const reporthelper = require('../helpers/reporthelper')();
 const { hasPermission } = require('../utilities/permissions');
 
 const reportsController = function () {
-  const getWeeklySummaries = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'getWeeklySummaries')) {
+  const getWeeklySummaries = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'getWeeklySummaries')) {
       res.status(403).send('You are not authorized to view all users');
       return;
     }

--- a/src/controllers/rolesController.js
+++ b/src/controllers/rolesController.js
@@ -9,8 +9,8 @@ const rolesController = function (Role) {
     .catch(error => res.status(404).send({ error }));
   };
 
-  const createNewRole = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'postRole')) {
+  const createNewRole = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'postRole')) {
       res.status(403).send('You are not authorized to create new roles.');
       return;
     }
@@ -38,8 +38,8 @@ const rolesController = function (Role) {
 };
 
 
-  const updateRoleById = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'putRole')) {
+  const updateRoleById = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'putRole')) {
       res.status(403).send('You are not authorized to make changes to roles.');
       return;
     }
@@ -66,8 +66,8 @@ const rolesController = function (Role) {
     });
   };
 
-  const deleteRoleById = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'deleteRole')) {
+  const deleteRoleById = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'deleteRole')) {
       res.status(403).send('You are not authorized to delete roles.');
       return;
     }

--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -389,8 +389,8 @@ const taskController = function (Task) {
     return tasksFromSameLevelArr.flat();
   };
 
-  const importTask = (req, res) => {
-    if (!hasPermission(req.body.requestor.role, 'importTask')) {
+  const importTask = async (req, res) => {
+    if (!await hasPermission(req.body.requestor.role, 'importTask')) {
       res
         .status(403)
         .send({ error: 'You are not authorized to create new Task.' });
@@ -419,8 +419,8 @@ const taskController = function (Task) {
     res.status(201).send('done');
   };
 
-  const postTask = (req, res) => {
-    if (!hasPermission(req.body.requestor.role, 'postTask')) {
+  const postTask = async (req, res) => {
+    if (!await hasPermission(req.body.requestor.role, 'postTask')) {
       res
         .status(403)
         .send({ error: 'You are not authorized to create new Task.' });
@@ -455,8 +455,8 @@ const taskController = function (Task) {
       });
   };
 
-  const updateNum = (req, res) => {
-    if (!hasPermission(req.body.requestor.role, 'updateNum')) {
+  const updateNum = async (req, res) => {
+    if (!await hasPermission(req.body.requestor.role, 'updateNum')) {
       res
         .status(403)
         .send({ error: 'You are not authorized to create new projects.' });
@@ -592,8 +592,8 @@ const taskController = function (Task) {
     });
   };
 
-  const deleteTask = (req, res) => {
-    if (!hasPermission(req.body.requestor.role, 'deleteTask')) {
+  const deleteTask = async (req, res) => {
+    if (!await hasPermission(req.body.requestor.role, 'deleteTask')) {
       res
         .status(403)
         .send({ error: 'You are not authorized to deleteTasks.' });
@@ -641,8 +641,8 @@ const taskController = function (Task) {
     .catch(errors => res.status(400).send(errors));
   };
 
-  const deleteTaskByWBS = (req, res) => {
-    if (!hasPermission(req.body.requestor.role, 'deleteTask')) {
+  const deleteTaskByWBS = async (req, res) => {
+    if (!await hasPermission(req.body.requestor.role, 'deleteTask')) {
       res
         .status(403)
         .send({ error: 'You are not authorized to deleteTasks.' });
@@ -672,8 +672,8 @@ const taskController = function (Task) {
     });
   };
 
-  const updateTask = (req, res) => {
-    if (!hasPermission(req.body.requestor.role, 'updateTask')) {
+  const updateTask = async (req, res) => {
+    if (!await hasPermission(req.body.requestor.role, 'updateTask')) {
       res.status(403).send({ error: 'You are not authorized to update Task.' });
       return;
     }
@@ -688,8 +688,8 @@ const taskController = function (Task) {
       .catch(error => res.status(404).send(error));
   };
 
-  const swap = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'swapTask')) {
+  const swap = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'swapTask')) {
       res
         .status(403)
         .send({ error: 'You are not authorized to create new projects.' });

--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -16,8 +16,8 @@ const teamcontroller = function (Team) {
       .then(results => res.send(results).status(200))
       .catch(error => res.send(error).status(404));
   };
-  const postTeam = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'postTeam')) {
+  const postTeam = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'postTeam')) {
       res.status(403).send({ error: 'You are not authorized to create teams.' });
       return;
     }
@@ -33,8 +33,8 @@ const teamcontroller = function (Team) {
       .then(results => res.send(results).status(200))
       .catch(error => res.send(error).status(404));
   };
-  const deleteTeam = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'deleteTeam')) {
+  const deleteTeam = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'deleteTeam')) {
       res.status(403).send({ error: 'You are not authorized to delete teams.' });
       return;
     }
@@ -56,8 +56,8 @@ const teamcontroller = function (Team) {
       res.status(400).send(error);
     });
   };
-  const putTeam = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'putTeam')) {
+  const putTeam = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'putTeam')) {
       res.status(403).send('You are not authorized to make changes in the teams.');
       return;
     }
@@ -81,10 +81,10 @@ const teamcontroller = function (Team) {
     });
   };
 
-  const assignTeamToUsers = function (req, res) {
+  const assignTeamToUsers = async function (req, res) {
     // verify requestor is administrator, teamId is passed in request params and is valid mongoose objectid, and request body contains  an array of users
 
-    if (!hasPermission(req.body.requestor.role, 'assignTeamToUsers')) {
+    if (!await hasPermission(req.body.requestor.role, 'assignTeamToUsers')) {
       res.status(403).send({ error: 'You are not authorized to perform this operation' });
       return;
     }

--- a/src/controllers/timeZoneAPIController.js
+++ b/src/controllers/timeZoneAPIController.js
@@ -1,7 +1,7 @@
 const { hasPermission } = require('../utilities/permissions');
 
 const timeZoneAPIController = function () {
-  const getTimeZoneAPIKey = (req, res) => {
+  const getTimeZoneAPIKey = async (req, res) => {
     const requestorRole = req.body.requestor.role;
     const premiumKey = process.env.TIMEZONE_PREMIUM_KEY;
     const commonKey = process.env.TIMEZONE_COMMON_KEY;
@@ -9,7 +9,7 @@ const timeZoneAPIController = function () {
       res.status(403).send('Unauthorized Request');
       return;
     }
-    if (hasPermission(requestorRole, 'getTimeZoneAPIKey')) {
+    if (await hasPermission(requestorRole, 'getTimeZoneAPIKey')) {
       res.status(200).send({ userAPIKey: premiumKey });
       return;
     }

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -16,7 +16,7 @@ const { hasPermission, canRequestorUpdateUser } = require('../utilities/permissi
 const escapeRegex = require('../utilities/escapeRegex');
 const config = require('../config');
 
-function ValidatePassword(req, res) {
+async function ValidatePassword(req, res) {
   const { userId } = req.params;
   const { requestor } = req.body;
 
@@ -35,7 +35,7 @@ function ValidatePassword(req, res) {
     return;
   }
   // Verify request is authorized by self or adminsitrator
-  if (!userId === requestor.requestorId && !hasPermission(requestor.role, 'updatePassword')) {
+  if (!userId === requestor.requestorId && !await hasPermission(requestor.role, 'updatePassword')) {
     res.status(403).send({
       error: "You are unauthorized to update this user's password",
     });
@@ -51,8 +51,8 @@ function ValidatePassword(req, res) {
 }
 
 const userProfileController = function (UserProfile) {
-  const getUserProfiles = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'getUserProfiles')) {
+  const getUserProfiles = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'getUserProfiles')) {
       res.status(403).send('You are not authorized to view all users');
       return;
     }
@@ -81,8 +81,8 @@ const userProfileController = function (UserProfile) {
       .catch(error => res.status(404).send(error));
   };
 
-  const getProjectMembers = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'getProjectMembers')) {
+  const getProjectMembers = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'getProjectMembers')) {
       res.status(403).send('You are not authorized to view all users');
       return;
     }
@@ -104,12 +104,12 @@ const userProfileController = function (UserProfile) {
   };
 
   const postUserProfile = async function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'postUserProfile')) {
+    if (!await hasPermission(req.body.requestor.role, 'postUserProfile')) {
       res.status(403).send('You are not authorized to create new users');
       return;
     }
 
-    if (req.body.role === 'Owner' && !hasPermission(req.body.requestor.role, 'addDeleteEditOwners')) {
+    if (req.body.role === 'Owner' && !await hasPermission(req.body.requestor.role, 'addDeleteEditOwners')) {
       res.status(403).send('You are not authorized to create new owners');
       return;
     }
@@ -221,11 +221,11 @@ const userProfileController = function (UserProfile) {
       .catch(error => res.status(501).send(error));
   };
 
-  const putUserProfile = function (req, res) {
+  const putUserProfile = async function (req, res) {
     const userid = req.params.userId;
     const isRequestorAuthorized = !!(
       canRequestorUpdateUser(req.body.requestor.requestorId, userid) && (
-        hasPermission(req.body.requestor.role, 'putUserProfile')
+        await hasPermission(req.body.requestor.role, 'putUserProfile')
       || req.body.requestor.requestorId === userid
       )
     );
@@ -235,13 +235,13 @@ const userProfileController = function (UserProfile) {
       return;
     }
 
-    if (req.body.role === 'Owner' && !hasPermission(req.body.requestor.role, 'addDeleteEditOwners')) {
+    if (req.body.role === 'Owner' && !await hasPermission(req.body.requestor.role, 'addDeleteEditOwners')) {
       res.status(403).send('You are not authorized to update this user');
       return;
     }
 
     cache.removeCache(`user-${userid}`);
-    UserProfile.findById(userid, (err, record) => {
+    UserProfile.findById(userid, async (err, record) => {
       if (err || !record) {
         res.status(404).send('No valid records found');
         return;
@@ -295,7 +295,7 @@ const userProfileController = function (UserProfile) {
         userIdx = allUserData.findIndex(users => users._id === userid);
         userData = allUserData[userIdx];
       }
-      if (hasPermission(req.body.requestor.role, 'putUserProfileImportantInfo')) {
+      if (await hasPermission(req.body.requestor.role, 'putUserProfileImportantInfo')) {
         record.role = req.body.role;
         record.isRehireable = req.body.isRehireable;
         record.isActive = req.body.isActive;
@@ -352,7 +352,7 @@ const userProfileController = function (UserProfile) {
 
         record.bioPosted = req.body.bioPosted || 'default';
 
-        if (hasPermission(req.body.requestor.role, 'putUserProfilePermissions')) {
+        if (await hasPermission(req.body.requestor.role, 'putUserProfilePermissions')) {
           record.permissions = req.body.permissions;
         }
 
@@ -372,7 +372,7 @@ const userProfileController = function (UserProfile) {
           userData.createdDate = record.createdDate.toISOString();
         }
       }
-      if (hasPermission(req.body.requestor.role, 'infringementAuthorizer')) {
+      if (await hasPermission(req.body.requestor.role, 'infringementAuthorizer')) {
         record.infringements = req.body.infringements;
       }
 
@@ -402,12 +402,12 @@ const userProfileController = function (UserProfile) {
 
   const deleteUserProfile = async function (req, res) {
     const { option, userId } = req.body;
-    if (!hasPermission(req.body.requestor.role, 'deleteUserProfile')) {
+    if (!await hasPermission(req.body.requestor.role, 'deleteUserProfile')) {
       res.status(403).send('You are not authorized to delete users');
       return;
     }
 
-    if (req.body.role === 'Owner' && !hasPermission(req.body.requestor.role, 'addDeleteEditOwners')) {
+    if (req.body.role === 'Owner' && !await hasPermission(req.body.requestor.role, 'addDeleteEditOwners')) {
       res.status(403).send('You are not authorized to delete this user');
       return;
     }
@@ -562,7 +562,7 @@ const userProfileController = function (UserProfile) {
       .catch(error => res.status(500).send(error));
   };
 
-  const updatepassword = function (req, res) {
+  const updatepassword = async function (req, res) {
     const { userId } = req.params;
     const { requestor } = req.body;
     if (!mongoose.Types.ObjectId.isValid(userId)) {
@@ -578,7 +578,7 @@ const userProfileController = function (UserProfile) {
       });
     }
     // Verify request is authorized by self or adminsitrator
-    if (!userId === requestor.requestorId && !hasPermission(requestor.role, 'updatePassword')) {
+    if (!userId === requestor.requestorId && !await hasPermission(requestor.role, 'updatePassword')) {
       return res.status(403).send({
         error: "You are unauthorized to update this user's password",
       });
@@ -630,7 +630,7 @@ const userProfileController = function (UserProfile) {
       .catch(error => res.status(500).send(error));
   };
 
-  const getreportees = function (req, res) {
+  const getreportees = async function (req, res) {
     if (!mongoose.Types.ObjectId.isValid(req.params.userId)) {
       res.status(400).send({
         error: 'Bad request',
@@ -643,7 +643,7 @@ const userProfileController = function (UserProfile) {
 
     let validroles = ['Volunteer', 'Manager', 'Administrator', 'Core Team', 'Owner', 'Mentor'];
 
-    if (hasPermission(role, 'getReporteesLimitRoles')) {
+    if (await hasPermission(role, 'getReporteesLimitRoles')) {
       validroles = ['Volunteer', 'Manager'];
     }
 
@@ -701,7 +701,7 @@ const userProfileController = function (UserProfile) {
     }
   };
 
-  const changeUserStatus = function (req, res) {
+  const changeUserStatus = async function (req, res) {
     const { userId } = req.params;
     const status = req.body.status === 'Active';
     const activationDate = req.body.reactivationDate;
@@ -714,7 +714,7 @@ const userProfileController = function (UserProfile) {
       });
       return;
     }
-    if (!hasPermission(req.body.requestor.role, 'changeUserStatus')) {
+    if (!await hasPermission(req.body.requestor.role, 'changeUserStatus')) {
       res.status(403).send('You are not authorized to change user status');
       return;
     }

--- a/src/controllers/wbsController.js
+++ b/src/controllers/wbsController.js
@@ -10,8 +10,8 @@ const wbsController = function (WBS) {
       .catch(error => res.status(404).send(error));
   };
 
-  const postWBS = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'postWbs')) {
+  const postWBS = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'postWbs')) {
       res.status(403).send({ error: 'You are not authorized to create new projects.' });
       return;
     }
@@ -33,8 +33,8 @@ const wbsController = function (WBS) {
       .catch(error => res.status(500).send({ error }));
   };
 
-  const deleteWBS = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'deleteWbs')) {
+  const deleteWBS = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'deleteWbs')) {
       res.status(403).send({ error: 'You are  not authorized to delete projects.' });
       return;
     }

--- a/src/utilities/permissions.js
+++ b/src/utilities/permissions.js
@@ -1,19 +1,9 @@
 const Role = require('../models/role');
 
-const hasPermission = async (role, action) => {
-  // Permissions depending on the back-end of the
-  let isAllowed;
-  const allPermissions = await Role.find({});
+const hasPermission = async (role, action) => Role.findOne({ roleName: role })
+    .exec()
+    .then(({ permissions }) => permissions.includes(action));
 
-  const { permissions } = allPermissions.find(({ roleName }) => roleName === role);
-
-  if (permissions.includes(action)) {
-    isAllowed = true;
-  } else {
-    isAllowed = false;
-  }
-  return isAllowed;
-};
 
 const canRequestorUpdateUser = (requestorId, userId) => {
   const allowedIds = ['63feae337186de1898fa8f51', // dev jae@onecommunityglobal.org


### PR DESCRIPTION
# Description
Fixes permissions evaluating promises as true.

## Main changes explained:
- Added `await` before every `hasPermission()` call
- Added `async` to every function with an async call
- Simplified `hasPermission()` method

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. log as admin user
4. open app in other incognito window and log into a volunteer user
5. as both users, view the volunteer account
6. As the admin, make a change to team or role of the volunteer account and save.
7. As the volunteer, do not refresh, verify changes have **not** been updated, and make a separate change (easiest is name or role)
8. save changes
9. refresh
10. verify that team/role changes made as admin were not overwritten

## Screenshots or videos of changes:
[video.webm](https://github.com/OneCommunityGlobal/HGNRest/assets/23086054/6c952da9-b86e-4cbc-8e9c-204153690577)

