### PR TITLE
XiaoW_hotfix_of_weekly_summaries_reports_page

### DIFF
--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -1,9 +1,9 @@
 const reporthelper = require('../helpers/reporthelper')();
-const { hasPermission } = require('../utilities/permissions');
+const { hasPermission, hasIndividualPermission } = require('../utilities/permissions');
 
 const reportsController = function () {
   const getWeeklySummaries = async function (req, res) {
-    if (!await hasPermission(req.body.requestor.role, 'getWeeklySummaries')) {
+    if (!await hasPermission(req.body.requestor.role, 'getWeeklySummaries') && !await hasIndividualPermission(req.body.requestor.requestorId, 'getWeeklySummaries')) {
       res.status(403).send('You are not authorized to view all users');
       return;
     }

--- a/src/utilities/permissions.js
+++ b/src/utilities/permissions.js
@@ -1,9 +1,14 @@
 const Role = require('../models/role');
+const UserProfile =  require('../models/userProfile');
 
 const hasPermission = async (role, action) => Role.findOne({ roleName: role })
     .exec()
     .then(({ permissions }) => permissions.includes(action));
 
+const hasIndividualPermission = async (userId, action) => UserProfile.findById(userId)
+  .select('permissions')
+  .exec()
+  .then(({ permissions }) => permissions.frontPermissions.includes(action));
 
 const canRequestorUpdateUser = (requestorId, userId) => {
   const allowedIds = ['63feae337186de1898fa8f51', // dev jae@onecommunityglobal.org
@@ -24,4 +29,4 @@ const canRequestorUpdateUser = (requestorId, userId) => {
   return !(protectedIds.includes(userId) && !allowedIds.includes(requestorId));
 };
 
-module.exports = { hasPermission, canRequestorUpdateUser };
+module.exports = { hasPermission, hasIndividualPermission, canRequestorUpdateUser };


### PR DESCRIPTION
# Description
This is a hot fix for volunteer account couldn't fully load the WeeklySummariesReport page.

## Related PRS (if any):
This PR is related to the [#1223](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1223#issue-1878399593) frontend PR.

## Main changes explained:
Add one additional `hasIndividualPermission` in the permission check for get route `/reports/weeklysummaries`.
