### PR TITLE
Oleksandr create invisibility hierarchy

### DIFF
--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -189,7 +189,7 @@ const dashboardhelper = function () {
       },
       {
         $match: {
-          // leaderboard tasks hierarchy
+          // leaderboard user roles hierarchy
           $or: [
             {
               role: 'Owner',

--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -199,7 +199,7 @@ const dashboardhelper = function () {
                 {
                   role: 'Administrator',
                 },
-                { 'persondata.0.role': { $nin: ['Owner'] } },
+                { 'persondata.0.role': { $nin: ['Owner', 'Administrator'] } },
               ]
             },
             {
@@ -207,7 +207,7 @@ const dashboardhelper = function () {
                 {
                   role: 'Core Team',
                 },
-                { 'persondata.0.role': { $nin: ['Owner', 'Administrator'] } },
+                { 'persondata.0.role': { $nin: ['Owner', 'Administrator', 'Core Team'] } },
               ],
             },
             {

--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -192,7 +192,7 @@ const dashboardhelper = function () {
           // leaderboard user roles hierarchy
           $or: [
             {
-              role: 'Owner',
+              role:  { $in: ['Owner', 'Core Team'] },
             },
             {
               $and: [
@@ -201,14 +201,6 @@ const dashboardhelper = function () {
                 },
                 { 'persondata.0.role': { $nin: ['Owner', 'Administrator'] } },
               ]
-            },
-            {
-              $and: [
-                {
-                  role: 'Core Team',
-                },
-                { 'persondata.0.role': { $nin: ['Owner', 'Administrator', 'Core Team'] } },
-              ],
             },
             {
               $and: [

--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -189,13 +189,40 @@ const dashboardhelper = function () {
       },
       {
         $match: {
+          // leaderboard tasks hierarchy
           $or: [
             {
-              role: {
-                $in: ['Core Team', 'Administrator', 'Owner'],
-              },
+              role: 'Owner',
             },
-            { 'persondata.0._id': userid },
+            {
+              $and: [
+                {
+                  role: 'Administrator',
+                },
+                { 'persondata.0.role': { $nin: ['Owner'] } },
+              ]
+            },
+            {
+              $and: [
+                {
+                  role: 'Core Team',
+                },
+                { 'persondata.0.role': { $nin: ['Owner', 'Administrator'] } },
+              ],
+            },
+            {
+              $and: [
+                {
+                  role: { $in: ['Manager', 'Mentor'] },
+                },
+                {
+                  'persondata.0.role': {
+                    $nin: ['Manager', 'Mentor', 'Core Team', 'Administrator', 'Owner'],
+                  },
+                },
+              ],
+            },
+            { 'persondata.0._id': userId },
             { 'persondata.0.role': 'Volunteer' },
             { 'persondata.0.isVisible': true },
           ],

--- a/src/helpers/taskHelper.js
+++ b/src/helpers/taskHelper.js
@@ -40,7 +40,7 @@ const taskHelper = function () {
       },
       {
         $match: {
-          // dashboard tasks hierarchy
+          // dashboard tasks user roles hierarchy
           $or: [
             {
               role: 'Owner',
@@ -86,10 +86,10 @@ const taskHelper = function () {
           weeklycommittedHours: {
             $sum: [
               {
-              $arrayElemAt: ['$persondata.weeklycommittedHours', 0],
+                $arrayElemAt: ['$persondata.weeklycommittedHours', 0],
               },
               {
-              $ifNull: [{ $arrayElemAt: ['$persondata.missedHours', 0] }, 0],
+                $ifNull: [{ $arrayElemAt: ['$persondata.missedHours', 0] }, 0],
               },
             ],
           },
@@ -142,7 +142,7 @@ const taskHelper = function () {
           totalSeconds: {
             $cond: [
               {
-              $gte: ['$timeEntryData.totalSeconds', 0],
+                $gte: ['$timeEntryData.totalSeconds', 0],
               },
               '$timeEntryData.totalSeconds',
               0,
@@ -151,7 +151,7 @@ const taskHelper = function () {
           isTangible: {
             $cond: [
               {
-              $gte: ['$timeEntryData.totalSeconds', 0],
+                $gte: ['$timeEntryData.totalSeconds', 0],
               },
               '$timeEntryData.isTangible',
               false,
@@ -165,7 +165,7 @@ const taskHelper = function () {
           tangibletime: {
             $cond: [
               {
-              $eq: ['$isTangible', true],
+                $eq: ['$isTangible', true],
               },
               '$totalSeconds',
               0,
@@ -324,9 +324,9 @@ const taskHelper = function () {
           role: '$role',
           name: {
             $concat: [
-            '$firstName',
-            ' ',
-            '$lastName',
+              '$firstName',
+              ' ',
+              '$lastName',
             ],
           },
           weeklycommittedHours: {
@@ -359,12 +359,12 @@ const taskHelper = function () {
               as: 'timeentry',
               cond: {
                 $and: [
-                {
-                  $gte: ['$$timeentry.dateOfWork', pdtstart],
-                },
-                {
-                  $lte: ['$$timeentry.dateOfWork', pdtend],
-                },
+                  {
+                    $gte: ['$$timeentry.dateOfWork', pdtstart],
+                  },
+                  {
+                    $lte: ['$$timeentry.dateOfWork', pdtend],
+                  },
                 ],
               },
             },
@@ -459,7 +459,7 @@ const taskHelper = function () {
         $project: {
           tasks: {
             resources: {
-            profilePic: 0,
+              profilePic: 0,
             },
           },
         },
@@ -482,9 +482,9 @@ const taskHelper = function () {
         $addFields: {
           'tasks.projectId': {
             $cond: [
-            { $ne: ['$projectId', []] },
-            { $arrayElemAt: ['$projectId', 0] },
-            '$tasks.projectId',
+              { $ne: ['$projectId', []] },
+              { $arrayElemAt: ['$projectId', 0] },
+              '$tasks.projectId',
             ],
           },
         },
@@ -494,12 +494,12 @@ const taskHelper = function () {
           projectId: 0,
           tasks: {
             projectId: {
-            _id: 0,
-            isActive: 0,
-            modifiedDatetime: 0,
-            wbsName: 0,
-            createdDatetime: 0,
-            __v: 0,
+              _id: 0,
+              isActive: 0,
+              modifiedDatetime: 0,
+              wbsName: 0,
+              createdDatetime: 0,
+              __v: 0,
             },
           },
         },
@@ -530,9 +530,9 @@ const taskHelper = function () {
         $addFields: {
           'data.tasks': {
             $filter: {
-            input: '$tasks',
-            as: 'task',
-            cond: { $ne: ['$$task', {}] },
+              input: '$tasks',
+              as: 'task',
+              cond: { $ne: ['$$task', {}] },
             },
           },
         },

--- a/src/helpers/taskHelper.js
+++ b/src/helpers/taskHelper.js
@@ -43,7 +43,7 @@ const taskHelper = function () {
           // dashboard tasks user roles hierarchy
           $or: [
             {
-              role: 'Owner',
+              role:  { $in: ['Owner', 'Core Team'] },
             },
             {
               $and: [
@@ -52,14 +52,6 @@ const taskHelper = function () {
                 },
                 { 'persondata.0.role': { $nin: ['Owner', 'Administrator'] } },
               ]
-            },
-            {
-              $and: [
-                {
-                  role: 'Core Team',
-                },
-                { 'persondata.0.role': { $nin: ['Owner', 'Administrator', 'Core Team'] } },
-              ],
             },
             {
               $and: [

--- a/src/helpers/taskHelper.js
+++ b/src/helpers/taskHelper.js
@@ -40,15 +40,38 @@ const taskHelper = function () {
       },
       {
         $match: {
+          // dashboard tasks hierarchy
           $or: [
             {
-              role: {
-                $in: [
-                  'Core Team',
-                  'Administrator',
-                  'Owner',
-                ],
-              },
+              role: 'Owner',
+            },
+            {
+              $and: [
+                {
+                  role: 'Administrator',
+                },
+                { 'persondata.0.role': { $nin: ['Owner'] } },
+              ]
+            },
+            {
+              $and: [
+                {
+                  role: 'Core Team',
+                },
+                { 'persondata.0.role': { $nin: ['Owner', 'Administrator'] } },
+              ],
+            },
+            {
+              $and: [
+                {
+                  role: { $in: ['Manager', 'Mentor'] },
+                },
+                {
+                  'persondata.0.role': {
+                    $nin: ['Manager', 'Mentor', 'Core Team', 'Administrator', 'Owner'],
+                  },
+                },
+              ],
             },
             { 'persondata.0._id': userId },
             { 'persondata.0.role': 'Volunteer' },

--- a/src/helpers/taskHelper.js
+++ b/src/helpers/taskHelper.js
@@ -50,7 +50,7 @@ const taskHelper = function () {
                 {
                   role: 'Administrator',
                 },
-                { 'persondata.0.role': { $nin: ['Owner'] } },
+                { 'persondata.0.role': { $nin: ['Owner', 'Administrator'] } },
               ]
             },
             {
@@ -58,7 +58,7 @@ const taskHelper = function () {
                 {
                   role: 'Core Team',
                 },
-                { 'persondata.0.role': { $nin: ['Owner', 'Administrator'] } },
+                { 'persondata.0.role': { $nin: ['Owner', 'Administrator', 'Core Team'] } },
               ],
             },
             {


### PR DESCRIPTION
# Description
![teams](https://github.com/OneCommunityGlobal/HGNRest/assets/108314277/48698fdb-1017-4f33-b3c4-1a777f3d480b)


## Main changes explained:
-Adding new filters to aggregating methods in getLeaderboard and getTasksForTeams


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. npm run build && npm start
4. log as owner or core user and check if user sees everyone,
5. log as admin and check if admin sees everyone but invisible owner or admin,
6. do the same for each role


## Note:
- owner and core see everyone,
- admin sees everyone but can't see invisible owner or admin,
- manager/mentor see everyone in their team lower by role or visible users
- volunteers see volunteers or visible users
- any other role is lower than manager/mentor but higher than volunteer. And they all equal to each other 
 (so they can't be seen by volunteers or equal roles if they are invisible but are seen by any higher role) 
- As for other roles I've created an Assistant Manager role.
 