### PR TITLE
Olga_enforce_email_input_on_login

### DIFF
--- a/src/controllers/logincontroller.js
+++ b/src/controllers/logincontroller.js
@@ -3,7 +3,6 @@ const jwt = require('jsonwebtoken');
 const moment = require('moment');
 const config = require('../config');
 const userprofile = require('../models/userProfile');
-const escapeRegex = require('../utilities/escapeRegex');
 
 const logincontroller = function () {
   const { JWT_SECRET } = config;
@@ -17,9 +16,8 @@ const logincontroller = function () {
       return;
     }
 
-
     try {
-      const user = await userprofile.findOne({ email: { $regex: escapeRegex(_email), $options: 'i' } });
+      const user = await userprofile.findOne({ email: _email });
 
       // returning 403 if the user not found or the found user is inactive.
       if (!user) {


### PR DESCRIPTION
# Description

(PRIORITY MEDIUM) Gary/Jae: (WIP Olga) Enforce email input when logging in so a user has to input their entire email address.
1.Start on the login page.
2.Enter any valid email address you’ve used in the past to login but enter only one character after the @ symbol in your email. I’m assuming this will work with any number of characters after the @ symbol.
3.Type in the correct password and you will be able to login.


## Main changes explained:
Removed regex from findOne query in loginController to enforce strict search

## How to test:
1. check into current branch
2. do `npm run build` and `npm start` to run this PR locally
3. check into development branch on the front end and run it
4. log in as any user
5.  verify that you are only able to log in when a complete email address is typed and are not able to log in otherwise

## Screenshots or videos of changes:

BEFORE:
https://www.loom.com/share/a2aafa6d99f44cf5abc8e33199951bbb

AFTER:
<img width="719" alt="Loggin_in_AFTER" src="https://github.com/OneCommunityGlobal/HGNRest/assets/107726913/26d1c97b-0641-45ee-beda-0818c29461b9">

