### PR TITLE
Nathan - New perms and no removing PMP perms on startup

### DIFF
--- a/src/utilities/createInitialPermissions.js
+++ b/src/utilities/createInitialPermissions.js
@@ -72,7 +72,10 @@ const permissionsRoles = [
   },
   {
     roleName: 'Volunteer',
-    permissions: ['getReporteesLimitRoles'],
+    permissions: [
+      'getReporteesLimitRoles',
+      'suggestTask',
+    ],
   },
   {
     roleName: 'Core Team',
@@ -105,7 +108,8 @@ const permissionsRoles = [
       'putUserProfile',
       'infringementAuthorizer',
       'getReporteesLimitRoles',
-      'suggestTask',
+      'updateTask',
+      'putTeam',
       'getAllInvInProjectWBS',
       'postInvInProjectWBS',
       'getAllInvInProject',
@@ -239,12 +243,16 @@ const createInitialPermissions = async () => {
         role.permissions = permissions;
         role.save();
 
-      // If role exists in db and is not updated, update it
-      } else if (!roleDataBase.permissions.every(perm => permissions.includes(perm)) || !permissions.every(perm => roleDataBase.permissions.includes(perm))) {
+      // If role exists in db and does not have every permission, add the missing permissions
+      } else if (!permissions.every(perm => roleDataBase.permissions.includes(perm))) {
         const roleId = roleDataBase._id;
 
         promises.push(Role.findById(roleId, (_, record) => {
-          record.permissions = permissions;
+          permissions.forEach((perm) => {
+            if (!record.permissions.includes(perm)) {
+              record.permissions.push(perm);
+            }
+          });
           record.save();
         }));
       }


### PR DESCRIPTION
# Description
`createInitialPermissions.js` will no longer remove permissions added through the Permissions Management Page. It will only add any permissions in the file which are not in the database.

## Related PRS (if any):
This reverts commit 97f97b6639348dabb6993c8226cf4bfee669b8a1 to re-apply PR[#481](https://github.com/OneCommunityGlobal/HGNRest/pull/481).


## Main changes explained:
- Removed check that every permission in database has to exists in `createInitialPermissions.js`
- Modified updating permissions to only push new permissions and not overwrite the whole array
- Added permissions to update tasks and teams to managers
- Added Permission to suggest tasks to volunteers


## How to test:
1. Check into current branch
2. Do `npm install` and `...` to run this PR locally
3. log in as Owner user
5. Go to dashboard→ Other Links→ Permissions Management
6. Give any role a permission they didn't have before, remove a permission listed under that role in `createInitialPermissions.js`, and save changes.
7. Restart server
8. Verify that the added permission is still there and the removed permission has been re-added.

Also, check that you don't get this error 503 or a 404 on the dashboard:
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/23086054/ff12223d-77fe-452a-9350-e4d0d14b37d9)

## Notes
Make sure to have the updated .env file. If you do not have TIME_ARCHIVE data, it will appear to work, but will not actually be running.


