### PR TITLE
Shrey Fix castError issue and stop unecessary api call when task id is undefined

### DIFF
--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -746,58 +746,39 @@ const taskController = function (Task) {
     });
   };
 
-  const getTaskById = function (req, res) {
-    const taskId = req.params.id;
-    Task.findById(taskId, '-__v  -createdDatetime -modifiedDatetime')
-      .then((results) => {
-        if (!results) {
-          res.status(400).send({ error: 'This is not a valid task' });
-          return;
+  const getTaskById = async (req, res) => {
+    try {
+        const taskId = req.params.id;
+
+        // Ensure the task ID is provided
+        if (!taskId || taskId === 'undefined') {
+            return res.status(400).send({ error: 'Task ID is missing' });
         }
-        timeEntryHelper
-          .getAllHoursLoggedForSpecifiedProject(taskId)
-          .then((hours) => {
-            results.set('hoursLogged', hours, { strict: false });
-          })
-          .catch(error => res.status(404).send(error))
-          .then(() => {
-            // Retrieve and update resource names for task
-            const resources = results?.resources;
-            const resourcesLength = resources.length;
-            const promiseArray = [];
-            for (let i = 0; i < resourcesLength; i += 1) {
-              promiseArray.push(
-                  taskHelper.getUserProfileFirstAndLastName(resources[i].userID),
-                );
-            }
-            Promise.all(promiseArray)
-              .then((resourceNames) => {
-                // Create a deep copy of resources
-                const editedResources = [];
-                for (let i = 0; i < resourcesLength; i += 1) {
-                  editedResources[i] = {};
-                  editedResources[i].completedTask = results.resources[i].completedTask;
-                  editedResources[i]._id = results.resources[i]._id;
-                  editedResources[i].userID = results.resources[i].userID;
-                  editedResources[i].name = results.resources[i].name;
-                }
-                // Update deep copy array's resource names
-                for (let i = 0; i < resourcesLength; i += 1) {
-                  // taskHelper.getUserProfileFirstAndLastName() will return an empty string if the results are null
-                  // If that's the case, do not update the resource's name
-                  editedResources[i].name = resourceNames[i] !== ' ' ? resourceNames[i] : editedResources[i].name;
-                }
-                results.resources = editedResources;
-              })
-              .finally(() => {
-                res.status(200).send(results);
-              });
-          })
-          .catch(() => {
-            // If there's an error, send potentially outdated resource names
-            res.status(200).send(results);
-          });
-      });
+
+        const task = await Task.findById(taskId, '-__v  -createdDatetime -modifiedDatetime');
+
+        if (!task) {
+            return res.status(400).send({ error: 'This is not a valid task' });
+        }
+
+        const hoursLogged = await timeEntryHelper.getAllHoursLoggedForSpecifiedProject(taskId);
+        task.set('hoursLogged', hoursLogged, { strict: false });
+
+        // Fetch the resource names for all resources
+        const resourceNamesPromises = task.resources.map(resource => taskHelper.getUserProfileFirstAndLastName(resource.userID));
+        const resourceNames = await Promise.all(resourceNamesPromises);
+
+        // Update the task's resources with the fetched names
+        task.resources.forEach((resource, index) => {
+            resource.name = resourceNames[index] !== ' ' ? resourceNames[index] : resource.name;
+        });
+
+        res.status(200).send(task);
+
+    } catch (error) {
+        // Generic error message, you can adjust as needed
+        res.status(500).send({ error: 'Internal Server Error', details: error.message });
+    }
   };
 
   const updateAllParents = (req, res) => {


### PR DESCRIPTION
# Description
Fix sentry logging issue when accessing a task from dashboard page logged in as any type of user.
Log in to HGN app in development branch for frontend and backend under any type of user i.e. Admin, Manager, Volunteer, etc.
On the Dashboard page select a task by clicking the name of the task.
You will be redirected to the task page but you will notice the CastError that gets logged to the console on the server side.

## Related PRS (if any):
This backend PR is related to the [#1279](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1279) frontend PR.
To test this backend PR you need to checkout the [#1279](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1279) frontend PR.
…

## Main changes explained:
- Delete file A for removing unused components …
- Update file B for including new pattern …
- Create file C for introducing new components …
…

## How to test:
1. check into current branch and [1279](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1279) in the frontend branch
2. do `npm install` and `...` to run this PR locally
3. log as admin/owner/volunteer all of the users or any user 
4. go to dashboard→ Tasks→ eam Member Tasks→ Click on task name
5. verify on the backend console that you do not see castError. 
6. Verify on the console that you do not see 500 or 400 for undefined taskId

## Screenshots or videos of changes:
Before:
<img width="1476" alt="Screenshot 2023-09-07 at 5 57 40 PM" src="https://github.com/OneCommunityGlobal/HGNRest/assets/118795427/fe484924-a7aa-4d23-afa8-5a414001875a">

https://github.com/OneCommunityGlobal/HGNRest/assets/118795427/e759d481-1637-47ee-9498-e191655e66ba


After:

https://github.com/OneCommunityGlobal/HGNRest/assets/118795427/85aebcf7-631b-40c5-8cd0-01850d37bf2b

