### PR TITLE
Tim add bmdashboard login route

### DIFF
--- a/src/controllers/bmdashboard/bmLoginController.js
+++ b/src/controllers/bmdashboard/bmLoginController.js
@@ -1,0 +1,44 @@
+const jwt = require('jsonwebtoken');
+const bcrypt = require('bcryptjs');
+
+const config = require('../../config');
+
+const userprofile = require('../../models/userProfile');
+
+const bmLoginController = function () {
+  const { JWT_SECRET } = config;
+  const bmLogin = async function _login(req, res) {
+    const { email: _email, password: _password } = req.body;
+    const currentToken = req.headers.authorization;
+    try {
+    const decode = jwt.verify(currentToken, JWT_SECRET);
+    const user = await userprofile.findOne({ _id: decode.userid });
+
+    // check email
+    if (user.email !== _email) {
+      res.status(422);
+      return res.json({ label: 'email', message: 'Email must match current login. Please try again.' });
+    }
+    // check password
+    const check = await bcrypt.compare(_password, user.password);
+    if (!check) {
+      res.status(422);
+      return res.json({ label: 'password', message: 'Password must match current login. Please try again.' });
+    }
+    // create new token
+    const jwtPayload = {
+      ...decode,
+      access: {
+        canAccessBMPortal: true,
+      },
+    };
+    const newToken = jwt.sign(jwtPayload, JWT_SECRET);
+    return res.json({ token: newToken });
+    } catch (err) {
+      res.json(err);
+    }
+  };
+  return { bmLogin };
+};
+
+module.exports = bmLoginController;

--- a/src/controllers/logincontroller.js
+++ b/src/controllers/logincontroller.js
@@ -49,6 +49,9 @@ const logincontroller = function () {
           userid: user._id,
           role: user.role,
           permissions: user.permissions,
+          access: {
+            canAccessBMPortal: false,
+          },
           expiryTimestamp: moment().add(config.TOKEN.Lifetime, config.TOKEN.Units),
         };
 

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -808,6 +808,9 @@ const userProfileController = function (UserProfile) {
       userid: user._id,
       role: user.role,
       permissions: user.permissions,
+      access: {
+        canAccessBMPortal: false,
+      },
       expiryTimestamp: moment_().add(config.TOKEN.Lifetime, config.TOKEN.Units),
     };
     const currentRefreshToken = jwt.sign(jwtPayload, JWT_SECRET);

--- a/src/routes/bmdashboard/bmLoginRouter.js
+++ b/src/routes/bmdashboard/bmLoginRouter.js
@@ -1,0 +1,13 @@
+const express = require('express');
+
+const routes = function () {
+  const loginrouter = express.Router();
+  const controller = require('../../controllers/bmdashboard/bmLoginController')();
+
+  loginrouter.route('/login')
+    .post(controller.bmLogin);
+
+  return loginrouter;
+};
+
+module.exports = routes;

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -53,6 +53,9 @@ const ownerStandardMessageRouter = require('../routes/ownerStandardMessageRouter
 const reasonRouter = require('../routes/reasonRouter')(reason, userProfile);
 const mouseoverTextRouter = require('../routes/mouseoverTextRouter')(mouseoverText);
 
+// bm dashboard
+const bmLoginRouter = require('../routes/bmdashboard/bmLoginRouter')();
+
 
 module.exports = function (app) {
   app.use('/api', forgotPwdRouter);
@@ -79,8 +82,10 @@ module.exports = function (app) {
   app.use('/api', roleRouter);
   app.use('/api', ownerMessageRouter);
   app.use('/api', ownerStandardMessageRouter);
-  app.use('/api', profileInitialSetupRouter)
+  app.use('/api', profileInitialSetupRouter);
   app.use('/api', reasonRouter);
   app.use('/api', informationRouter);
   app.use('/api', mouseoverTextRouter);
+  // bm dashboard
+  app.use('/api/bm', bmLoginRouter);
 };


### PR DESCRIPTION
# Description
Backend updates to support the new Building Management Dashboard (ie Phase 2) entry point and login screen. 

## Related PRS (if any):
[Frontend PR 1325](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1325)

## Main changes explained:
- New API route, router, and controller function for users to verify their current login credentials to access the BM Dashboard.
   - Note: Currently any user role can access the BM Dashboard.
- Adds a new access object to JWT tokens with a Boolean value controlling access to the BM Dashboard.
- The controller function accepts the user’s credentials and matches them against the submitted token. Mismatches result in an error with status code 422. If the credentials are verified, the response is a new token with `access.canAccessBMPortal=true`
   - Note: token expiration is not refreshed

## How to test:
- `git checkout Tim_add_bmdashboard_login_route`
- `npm install`
- `npm run build`
- `npm start`
