### PR TITLE
Navneeth create see project management tab custom permission

### DIFF
--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const timeentry = require('../models/timeentry');
 const userProfile = require('../models/userProfile');
 const userProject = require('../helpers/helperModels/userProjects');
-const { hasPermission } = require('../utilities/permissions');
+const { hasPermission, hasIndividualPermission } = require('../utilities/permissions');
 const escapeRegex = require('../utilities/escapeRegex');
 
 
@@ -15,7 +15,8 @@ const projectController = function (Project) {
   };
 
   const deleteProject = function (req, res) {
-    if (!hasPermission(req.body.requestor.role, 'deleteProject')) {
+    if (!hasPermission(req.body.requestor.role, 'deleteProject')
+    && !hasIndividualPermission(req.body.requestor.requestorId, 'seeProjectManagement')) { 
       res.status(403).send({ error: 'You are not authorized to delete projects.' });
       return;
     }
@@ -46,7 +47,8 @@ const projectController = function (Project) {
   };
 
   const postProject = async function (req, res) {
-    if (!await hasPermission(req.body.requestor.role, 'postProject')) {
+    if (!await hasPermission(req.body.requestor.role, 'postProject') 
+    && !await hasIndividualPermission(req.body.requestor.requestorId, 'seeProjectManagement')) { 
       res.status(403).send({ error: 'You are not authorized to create new projects.' });
       return;
     }
@@ -77,7 +79,8 @@ const projectController = function (Project) {
 
 
   const putProject = async function (req, res) {
-    if (!await hasPermission(req.body.requestor.role, 'putProject')) {
+    if (!await hasPermission(req.body.requestor.role, 'putProject')
+    && !await hasIndividualPermission(req.body.requestor.requestorId, 'seeProjectManagement')) { 
       res.status(403).send('You are not authorized to make changes in the projects.');
       return;
     }
@@ -125,8 +128,11 @@ const projectController = function (Project) {
     // verify requestor is administrator, projectId is passed in request params and is valid mongoose objectid, and request body contains  an array of users
 
     if (!await hasPermission(req.body.requestor.role, 'assignProjectToUsers')) {
+      if (!await hasIndividualPermission(req.body.requestor.requestorId, 'seeProjectManagement') 
+        && !await hasIndividualPermission(req.body.requestor.requestorId, 'seeProjectManagementTab')) {
       res.status(403).send({ error: 'You are not authorized to perform this operation' });
       return;
+        }
     }
 
     if (!req.params.projectId || !mongoose.Types.ObjectId.isValid(req.params.projectId) || !req.body.users || (req.body.users.length === 0)) {

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -12,7 +12,7 @@ const Badge = require('../models/badge');
 const userProfile = require('../models/userProfile');
 const yearMonthDayDateValidator = require('../utilities/yearMonthDayDateValidator');
 const cache = require('../utilities/nodeCache')();
-const { hasPermission, canRequestorUpdateUser } = require('../utilities/permissions');
+const { hasPermission, hasIndividualPermission, canRequestorUpdateUser } = require('../utilities/permissions');
 const escapeRegex = require('../utilities/escapeRegex');
 const config = require('../config');
 
@@ -53,8 +53,11 @@ async function ValidatePassword(req, res) {
 const userProfileController = function (UserProfile) {
   const getUserProfiles = async function (req, res) {
     if (!await hasPermission(req.body.requestor.role, 'getUserProfiles')) {
+      if (!await hasIndividualPermission(req.body.requestor.requestorId, 'seeProjectManagement') 
+        && !await hasIndividualPermission(req.body.requestor.requestorId, 'seeProjectManagementTab')) {
       res.status(403).send('You are not authorized to view all users');
       return;
+      }
     }
 
     if (cache.getCache('allusers')) {

--- a/src/controllers/wbsController.js
+++ b/src/controllers/wbsController.js
@@ -1,4 +1,4 @@
-const { hasPermission } = require('../utilities/permissions');
+const { hasPermission, hasIndividualPermission } = require('../utilities/permissions');
 
 const wbsController = function (WBS) {
   const getAllWBS = function (req, res) {
@@ -11,7 +11,9 @@ const wbsController = function (WBS) {
   };
 
   const postWBS = async function (req, res) {
-    if (!await hasPermission(req.body.requestor.role, 'postWbs')) {
+    if (!await hasPermission(req.body.requestor.role, 'postWbs')
+    && !await hasIndividualPermission(req.body.requestor.requestorId, 'seeProjectManagement')
+    && !await hasIndividualPermission(req.body.requestor.requestorId, 'seeProjectManagementTab')) { 
       res.status(403).send({ error: 'You are not authorized to create new projects.' });
       return;
     }
@@ -34,7 +36,8 @@ const wbsController = function (WBS) {
   };
 
   const deleteWBS = async function (req, res) {
-    if (!await hasPermission(req.body.requestor.role, 'deleteWbs')) {
+    if (!await hasPermission(req.body.requestor.role, 'deleteWbs')
+    && !await hasIndividualPermission(req.body.requestor.requestorId, 'seeProjectManagement')) {
       res.status(403).send({ error: 'You are  not authorized to delete projects.' });
       return;
     }


### PR DESCRIPTION
# Description
![bug description](https://github.com/OneCommunityGlobal/HGNRest/assets/44264834/a88845c4-6d40-4db1-a0bc-409359fb4a99)


## Related PRs:
This PR is linked to the FE PR [#1336](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1336).

## Main changes explained:
- Updated the permission checks for not allowing creating/updating/deleting of projects if the user also does not have individual permission 'seeProjectManagement'.
- Updated the permission checks for not allowing listing users (used while adding members) and assigning projects to users if the user also does not have either  'seeProjectManagement' or 'seeProjectManagementTab' permissions.

## How to test:
1. check into current branch
2. do `npm install` and `npm run build` and `npm run start` successively to run this PR locally

