### PR TITLE
Roberto fix removing user from profile

### DIFF
--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const userProfile = require('../models/userProfile');
 const { hasPermission } = require('../utilities/permissions');
+const cache = require('../utilities/nodeCache')();
 
 const teamcontroller = function (Team) {
   const getAllTeams = function (req, res) {
@@ -113,6 +114,8 @@ const teamcontroller = function (Team) {
 
         users.forEach((element) => {
           const { userId, operation } = element;
+          // if user's profile is stored in cache, clear it so when you visit their profile page it will be up to date
+          if(cache.hasCache(`user-${userId}`)) cache.removeCache(`user-${userId}`);
 
           if (operation === 'Assign') {
             assignlist.push(userId);


### PR DESCRIPTION
# Description
When you visit a Team member's list and remove a member, then visit that user's profile you'll notice that their teams section is not updated immediately. The update can take up to a few minutes to finally show.
<img width="820" alt="Screenshot 2023-09-28 at 5 14 05 PM" src="https://github.com/OneCommunityGlobal/HGNRest/assets/117053202/7276e0d4-de35-409a-801b-f9a9b0b14ded">


## Related PRS (if any):
To test this backend PR you need to checkout the [#1350](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1350) frontend PR.
…

## Main changes explained:
- Added an if statement to teamController.js, clears the user cache if any to get the most up to date user profile
…

## How to test:
1. check into current branch
2. do `npm install`, `npm run build`, and`npm start` to run this PR locally
3. check frontend instructions
