### PR TITLE
Nathan permission presets

### DIFF
--- a/src/controllers/rolePresetsController.js
+++ b/src/controllers/rolePresetsController.js
@@ -29,7 +29,7 @@ const rolePresetsController = function (Preset) {
     preset.presetName = req.body.presetName;
     preset.permissions = req.body.permissions;
     preset.save()
-      .then(res.status(200).send({ message: 'New preset created' }))
+      .then(result => res.status(201).send({ newPreset: result, message: 'New preset created' }))
       .catch(error => res.status(400).send({ error }));
   };
 
@@ -46,7 +46,7 @@ const rolePresetsController = function (Preset) {
         record.presetName = req.body.presetName;
         record.permissions = req.body.permissions;
         record.save()
-        .then(results => res.status(201).send(results))
+        .then(results => res.status(200).send(results))
         .catch(errors => res.status(400).send(errors));
       })
       .catch(error => res.status(400).send({ error }));

--- a/src/controllers/rolePresetsController.js
+++ b/src/controllers/rolePresetsController.js
@@ -1,0 +1,79 @@
+const { hasPermission } = require('../utilities/permissions');
+
+const rolePresetsController = function (Preset) {
+  const getPresetsByRole = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'putRole')) {
+      res.status(403).send('You are not authorized to make changes to roles.');
+      return;
+    }
+
+    const { roleName } = req.params;
+    Preset.find({ roleName })
+      .then((results) => { res.status(200).send(results); })
+      .catch((error) => { res.status(400).send(error); });
+  };
+
+  const createNewPreset = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'putRole')) {
+      res.status(403).send('You are not authorized to make changes to roles.');
+      return;
+    }
+
+    if (!req.body.roleName || !req.body.presetName || !req.body.permissions) {
+      res.status(400).send({ error: 'roleName, presetName, and permissions are mandatory fields.' });
+      return;
+    }
+
+    const preset = new Preset();
+    preset.roleName = req.body.roleName;
+    preset.presetName = req.body.presetName;
+    preset.permissions = req.body.permissions;
+    preset.save()
+      .then(res.status(200).send({ message: 'New preset created' }))
+      .catch(error => res.status(400).send({ error }));
+  };
+
+  const updatePresetById = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'putRole')) {
+      res.status(403).send('You are not authorized to make changes to roles.');
+      return;
+    }
+
+    const { presetId } = req.params;
+    Preset.findById(presetId)
+      .then((record) => {
+        record.roleName = req.body.roleName;
+        record.presetName = req.body.presetName;
+        record.permissions = req.body.permissions;
+        record.save()
+        .then(results => res.status(201).send(results))
+        .catch(errors => res.status(400).send(errors));
+      })
+      .catch(error => res.status(400).send({ error }));
+  };
+
+  const deletePresetById = async function (req, res) {
+    if (!await hasPermission(req.body.requestor.role, 'putRole')) {
+      res.status(403).send('You are not authorized to make changes to roles.');
+      return;
+    }
+
+    const { presetId } = req.params;
+    Preset.findById(presetId)
+      .then((result) => {
+        result.remove()
+          .then(res.status(200).send({ message: 'Deleted preset' }))
+          .catch(error => res.status(400).send({ error }));
+      })
+      .catch(error => res.status(400).send({ error }));
+  };
+
+  return {
+    getPresetsByRole,
+    createNewPreset,
+    updatePresetById,
+    deletePresetById,
+  };
+};
+
+module.exports = rolePresetsController;

--- a/src/models/rolePreset.js
+++ b/src/models/rolePreset.js
@@ -1,0 +1,14 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+
+const RolePermissionPresets = new Schema({
+  roleName: { type: String, required: true },
+  presetName: { type: String, required: true },
+  permissions: [String],
+});
+
+// RolePermissionPresets.createIndex({ roleName: 1, presetName: 1 }, { unique: true });
+
+module.exports = mongoose.model('rolePermissionPresets', RolePermissionPresets, 'rolePermissionPresets');

--- a/src/routes/rolePresetRouter.js
+++ b/src/routes/rolePresetRouter.js
@@ -1,0 +1,20 @@
+const express = require('express');
+
+const routes = function (rolePreset) {
+  const controller = require('../controllers/rolePresetsController')(rolePreset);
+  const PresetsRouter = express.Router();
+
+  PresetsRouter.route('/rolePreset')
+  .post(controller.createNewPreset);
+
+  PresetsRouter.route('/rolePreset/:roleName')
+  .get(controller.getPresetsByRole);
+
+  PresetsRouter.route('/rolePreset/:presetId')
+  .put(controller.updatePresetById)
+  .delete(controller.deletePresetById);
+
+return PresetsRouter;
+};
+
+module.exports = routes;

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -15,6 +15,7 @@ const badge = require('../models/badge');
 const inventoryItem = require('../models/inventoryItem');
 const inventoryItemType = require('../models/inventoryItemType');
 const role = require('../models/role');
+const rolePreset = require('../models/rolePreset');
 const ownerMessage = require('../models/ownerMessage');
 const ownerStandardMessage = require('../models/ownerStandardMessage');
 const profileInitialSetuptoken = require('../models/profileInitialSetupToken');
@@ -47,6 +48,7 @@ const profileInitialSetupRouter = require('../routes/profileInitialSetupRouter')
 const taskEditSuggestion = require('../models/taskEditSuggestion');
 const taskEditSuggestionRouter = require('../routes/taskEditSuggestionRouter')(taskEditSuggestion);
 const roleRouter = require('../routes/roleRouter')(role);
+const rolePresetRouter = require('../routes/rolePresetRouter')(rolePreset);
 const ownerMessageRouter = require('../routes/ownerMessageRouter')(ownerMessage);
 const ownerStandardMessageRouter = require('../routes/ownerStandardMessageRouter')(ownerStandardMessage);
 
@@ -77,9 +79,10 @@ module.exports = function (app) {
   app.use('/api', timeZoneAPIRouter);
   app.use('/api', taskEditSuggestionRouter);
   app.use('/api', roleRouter);
+  app.use('/api', rolePresetRouter);
   app.use('/api', ownerMessageRouter);
   app.use('/api', ownerStandardMessageRouter);
-  app.use('/api', profileInitialSetupRouter)
+  app.use('/api', profileInitialSetupRouter);
   app.use('/api', reasonRouter);
   app.use('/api', informationRouter);
   app.use('/api', mouseoverTextRouter);

--- a/src/utilities/createInitialPermissions.js
+++ b/src/utilities/createInitialPermissions.js
@@ -1,4 +1,5 @@
 const Role = require('../models/role');
+const RolePreset = require('../models/rolePreset');
 const User = require('../models/userProfile');
 
 const permissionsRoles = [
@@ -222,6 +223,7 @@ const createInitialPermissions = async () => {
 
   // Get Roles From DB
   const allRoles = await Role.find();
+  const allPresets = await RolePreset.find();
   const onlyUpdateOwner = false;
 
   const promises = [];
@@ -248,6 +250,27 @@ const createInitialPermissions = async () => {
           record.save();
         }));
       }
+    }
+
+    // Update Default presets
+    const presetDataBase = allPresets.find(preset => preset.roleName === roleName && preset.presetName === 'default');
+
+    // If role does not exist in db, create it
+    if (!presetDataBase) {
+      const defaultPreset = new RolePreset();
+      defaultPreset.roleName = roleName;
+      defaultPreset.presetName = 'default';
+      defaultPreset.permissions = permissions;
+      defaultPreset.save();
+
+    // If role exists in db and is not updated, update default
+    } else if (!presetDataBase.permissions.every(perm => permissions.includes(perm)) || !permissions.every(perm => presetDataBase.permissions.includes(perm))) {
+      const roleId = presetDataBase._id;
+
+      promises.push(Role.findById(roleId, (_, record) => {
+        record.permissions = permissions;
+        record.save();
+      }));
     }
   }
   await Promise.all(promises);


### PR DESCRIPTION
# Description
This PR addresses `Create a “Restore To Default” functionality that restores the user permissions to the default configurations`.

## Related PRS (if any):
This backend PR is related to frontend PR #1374.
To test this backend PR you may need to checkout the frontend PR unless testing with Postman.
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1374

## Main changes explained:
- created `rolePresetsController`, `rolePreset` model, and `rolePresetRouter`
- added creation of `default` presets for the hard-coded permissions in `createInitialPermissions.js`. These will be updated every time the server starts.

## How to test:
Follow instructions on frontend PR. Can also test new APIs with Postman if desired.
