### PR TITLE
Aaron hotfix remove "400 error" for invalid team code

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -314,11 +314,6 @@ const userProfileController = function (UserProfile) {
         return;
       }
 
-      const teamcodeRegex = /^([a-zA-Z]-[a-zA-Z]{3}|[a-zA-Z]{5})$/;
-      if (!teamcodeRegex.test(req.body.teamCode)) {
-        res.status(400).send("The team code is invalid");
-        return;
-      };
       record.teamCode = req.body.teamCode;
 
       // find userData in cache
@@ -608,17 +603,12 @@ const userProfileController = function (UserProfile) {
     if (key === "teamCode") {
       const canEditTeamCode = req.body.requestor.role === "Owner" ||
         req.body.requestor.permissions?.frontPermissions.includes("editTeamCode");
-      const teamcodeRegex = /^([a-zA-Z]-[a-zA-Z]{3}|[a-zA-Z]{5})$/;
 
       if(!canEditTeamCode){
         res.status(403).send("You are not authorized to edit team code.");
         return;
       }
   
-      if (!teamcodeRegex.test(value)) {
-        res.status(400).send("The team code is invalid");
-        return;
-      };
     }
 
     // remove user from cache, it should be loaded next time


### PR DESCRIPTION
# Description
Whenever you try to update a user's profile information and their team code is invalid/nonexistent, the information doesn't update and an undescriptive popup is given "An error occurred while attempting to save this profile." I have removed the error checker for invalid team codes.

## Related PRS (if any):
- I am working on a frontend PR <TBA> that will have a more descriptive save message when the user's team code is invalid

## Main changes explained:
- remove 400 error for invalid team code in `putUserProfile`
- remove 400 error for invalid team code in `updateOneProperty`

## How to test:
1. check into current branch
2. do `npm run build` and `npm start` to run this PR locally
3. log as admin/owner user
4. go to a user's profile who either doesn't have a team code or has an invalid one 
  (you can create a new user if you can't find one)
6. make sure you can edit ANY of their profile information successfully
