### PR TITLE
Fix collection name

### DIFF
--- a/src/utilities/createInitialPermissions.js
+++ b/src/utilities/createInitialPermissions.js
@@ -265,9 +265,9 @@ const createInitialPermissions = async () => {
 
     // If role exists in db and is not updated, update default
     } else if (!presetDataBase.permissions.every(perm => permissions.includes(perm)) || !permissions.every(perm => presetDataBase.permissions.includes(perm))) {
-      const roleId = presetDataBase._id;
+      const presetId = presetDataBase._id;
 
-      promises.push(Role.findById(roleId, (_, record) => {
+      promises.push(RolePreset.findById(presetId, (_, record) => {
         record.permissions = permissions;
         record.save();
       }));


### PR DESCRIPTION
# Description
This fixes crashing bug when permissions are changed in `createInitialPermissions.js`

## Related PRS (if any):
https://github.com/OneCommunityGlobal/HGNRest/pull/559

## Main changes explained:
Changed collection for updating rolePresets to be RolePreset instead of Role.

## How to test:
1. checkout PR.
2. run backend
3. verify it doesn't crash
4. change some permission in `createInitialPermissions.js`
5. restart backend
6. verify it doesn't crash again


![image](https://github.com/OneCommunityGlobal/HGNRest/assets/23086054/7d199de6-7fde-4717-8ef3-8ed0a36d70ed)

