### PR TITLE
Ramya teams limit see all 

### DIFF
--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -21,7 +21,6 @@ const teamcontroller = function (Team) {
       .catch(error => res.send(error).status(404));
   };
   const postTeam = async function (req, res) {
-    console.log("==============>   3 ");
 
     if (!await hasPermission(req.body.requestor.role, 'postTeam')) {
       res.status(403).send({ error: 'You are not authorized to create teams.' });
@@ -196,6 +195,8 @@ const teamcontroller = function (Team) {
 
   
   const updateTeamVisibility = async (req, res) => {
+    console.log("==============>   9 ");
+
     const { visibility, teamId, userId } = req.body;
   
     try {
@@ -215,9 +216,7 @@ const teamcontroller = function (Team) {
         team.modifiedDatetime = Date.now();
   
         team.save()
-          .then(updatedTeam => {
-            console.log('Team updated successfully:');
-  
+          .then(updatedTeam => {  
             // Additional operations after team.save() 
             const assignlist = [];
             const unassignlist = [];
@@ -256,70 +255,9 @@ const teamcontroller = function (Team) {
   
       });
     } catch (error) {
-      console.log('Exception');
       res.status(500).send('Error updating team visibility: ' + error.message);
     }
   };
-          
-  //  const updateTeamVisibility = async (req, res) => {
-  //     const { visibility, teamId, userId } = req.body;
-    
-  //     try {
-  //       Team.findById(teamId, (error, team) => {
-  //         if (error || team === null) {
-  //           res.status(400).send('No valid records found');
-  //           return;
-  //         }
-    
-  //         const memberIndex = team.members.findIndex(member => member.userId.toString() === userId);
-  //         if (memberIndex === -1) {
-  //           res.status(400).send('Member not found in the team.');
-  //           return;
-  //         }
-    
-  //         team.members[memberIndex].visible = visibility;
-  //         team.modifiedDatetime = Date.now();
-    
-  //         team.save()
-  //           .then(updatedTeam => {
-  //             console.log('Team updated successfully:');
-    
-  //             // Additional operations after team.save() if needed
-  //         if (!visibility) {
-  //           const otherUserIds = team.members
-  //             .filter(member => member.userId.toString() !== userId)
-  //             .map(member => member.userId);
-
-  //           // Remove the other user IDs from the myteam array
-  //           const removeMember = myTeam.updateOne({ _id: teamId }, { $pull: { myteam: { _id: { $in: otherUserIds } } } }).exec();
-
-  //           // Wait for the removal to complete using Promise.all
-  //           Promise.all([removeMember])
-  //             .then(() => {
-  //               res.status(200).send({ result: 'Done' });
-  //             })
-  //             .catch(error => {
-  //               console.error('Error removing users from myteam:', error);
-  //               res.status(500).send('Error removing users from myteam: ' + error.message);
-  //             });
-  //         } else {
-  //           res.status(200).send({ result: 'Done' });
-  //         }
-  //       })
-  //       .catch(error => {
-  //         console.error('Error saving team:', error);
-  //         res.status(400).send('Error saving team: ' + error.message);
-  //       });
-  //   });}
-  //      catch (error) {
-  //       console.log('Exception');
-  //       res.status(500).send('Error updating team visibility: ' + error.message);
-  //     };
-  //   };
-  
-  // // };
-  
-
   return {
     getAllTeams,
     getTeamById,

--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -1,9 +1,11 @@
 const mongoose = require('mongoose');
 const userProfile = require('../models/userProfile');
-const teamDetails=require('../models/team');
+// const teamDetails=require('../models/team');
 const { hasPermission } = require('../utilities/permissions');
+const myTeam = require('../helpers/helperModels/myTeam');
 
 const teamcontroller = function (Team) {
+  console.log("Coming inside team Controller");
   const getAllTeams = function (req, res) {
     Team.find({})
       .sort({ teamName: 1 })
@@ -11,6 +13,7 @@ const teamcontroller = function (Team) {
       .catch(error => res.send(error).status(404));
   };
   const getTeamById = function (req, res) {
+
     const { teamId } = req.params;
 
     Team.findById(teamId)
@@ -18,6 +21,8 @@ const teamcontroller = function (Team) {
       .catch(error => res.send(error).status(404));
   };
   const postTeam = async function (req, res) {
+    console.log("==============>   3 ");
+
     if (!await hasPermission(req.body.requestor.role, 'postTeam')) {
       res.status(403).send({ error: 'You are not authorized to create teams.' });
       return;
@@ -35,6 +40,7 @@ const teamcontroller = function (Team) {
       .catch(error => res.send(error).status(404));
   };
   const deleteTeam = async function (req, res) {
+
     if (!await hasPermission(req.body.requestor.role, 'deleteTeam')) {
       res.status(403).send({ error: 'You are not authorized to delete teams.' });
       return;
@@ -58,6 +64,7 @@ const teamcontroller = function (Team) {
     });
   };
   const putTeam = async function (req, res) {
+
     if (!await hasPermission(req.body.requestor.role, 'putTeam')) {
       res.status(403).send('You are not authorized to make changes in the teams.');
       return;
@@ -83,6 +90,7 @@ const teamcontroller = function (Team) {
   };
 
   const assignTeamToUsers = async function (req, res) {
+
     // verify requestor is administrator, teamId is passed in request params and is valid mongoose objectid, and request body contains  an array of users
 
     if (!await hasPermission(req.body.requestor.role, 'assignTeamToUsers')) {
@@ -121,7 +129,6 @@ const teamcontroller = function (Team) {
           } else {
             unassignlist.push(userId);
           }
-          if(oper)
         });
 
         const addTeamToUserProfile = userProfile
@@ -136,6 +143,7 @@ const teamcontroller = function (Team) {
         ).exec();
 
         const removeUserFromTeam = Team.updateOne(
+
           { _id: team._id },
           { $pull: { members: { userId: { $in: unassignlist } } } },
         ).exec();
@@ -154,6 +162,7 @@ const teamcontroller = function (Team) {
   };
 
   const getTeamMembership = function (req, res) {
+
     const { teamId } = req.params;
     if (!mongoose.Types.ObjectId.isValid(teamId)) {
       res.status(400).send({ error: 'Invalid request' });
@@ -185,37 +194,131 @@ const teamcontroller = function (Team) {
       .catch(error => res.status(500).send(error));
   };
 
-  const updateTeamVisiblity= async function(req,res){
-      if (!await hasPermission(req.body.requestor.role, 'updateTeamVisiblity')) {
-        res.status(403).send('You are not authorized to make changes in the teams.');
-        return;
-      }
   
-      const { teamId } = req.params;
-      const { userId, visibility } = req.body;
-
+  const updateTeamVisibility = async (req, res) => {
+    const { visibility, teamId, userId } = req.body;
   
-      Team.findById(teamId, (error, record) => {
-        if (error || record === null) {
+    try {
+      Team.findById(teamId, (error, team) => {
+        if (error || team === null) {
           res.status(400).send('No valid records found');
           return;
         }
-        
-        const memberToUpdate = record.members.find(member => member.userId.toString() === userId);
-        
-        if (!memberToUpdate) {
-          res.status(404).send('Member not found in the team.');
+  
+        const memberIndex = team.members.findIndex(member => member.userId.toString() === userId);
+        if (memberIndex === -1) {
+          res.status(400).send('Member not found in the team.');
           return;
         }
-    
-        memberToUpdate.visibility = visibility;
   
-        record
-          .save()
-          .then(results => res.status(201).send(results._id))
-          .catch(errors => res.status(400).send(errors));
-      }); 
-  }
+        team.members[memberIndex].visible = visibility;
+        team.modifiedDatetime = Date.now();
+  
+        team.save()
+          .then(updatedTeam => {
+            console.log('Team updated successfully:');
+  
+            // Additional operations after team.save() 
+            const assignlist = [];
+            const unassignlist = [];
+            team.members.forEach(member => {
+              if (member.userId.toString() === userId) {
+                // Current user, no need to process further
+                return;
+              }
+            
+              if (visibility) {
+                assignlist.push(member.userId);
+              } else {
+                unassignlist.push(member.userId);
+              }
+            });
+  
+            const addTeamToUserProfile = userProfile
+              .updateMany({ _id: { $in: assignlist } }, { $addToSet: { teams: teamId } })
+              .exec();
+            const removeTeamFromUserProfile = userProfile
+              .updateMany({ _id: { $in: unassignlist } }, { $pull: { teams: teamId } })
+              .exec();
+  
+            Promise.all([addTeamToUserProfile, removeTeamFromUserProfile])
+              .then(() => {
+                res.status(200).send({ result: 'Done' });
+              })
+              .catch((error) => {
+                res.status(500).send({ error });
+              });
+          })
+          .catch(errors => {
+            console.error('Error saving team:', errors);
+            res.status(400).send(errors);
+          });
+  
+      });
+    } catch (error) {
+      console.log('Exception');
+      res.status(500).send('Error updating team visibility: ' + error.message);
+    }
+  };
+          
+  //  const updateTeamVisibility = async (req, res) => {
+  //     const { visibility, teamId, userId } = req.body;
+    
+  //     try {
+  //       Team.findById(teamId, (error, team) => {
+  //         if (error || team === null) {
+  //           res.status(400).send('No valid records found');
+  //           return;
+  //         }
+    
+  //         const memberIndex = team.members.findIndex(member => member.userId.toString() === userId);
+  //         if (memberIndex === -1) {
+  //           res.status(400).send('Member not found in the team.');
+  //           return;
+  //         }
+    
+  //         team.members[memberIndex].visible = visibility;
+  //         team.modifiedDatetime = Date.now();
+    
+  //         team.save()
+  //           .then(updatedTeam => {
+  //             console.log('Team updated successfully:');
+    
+  //             // Additional operations after team.save() if needed
+  //         if (!visibility) {
+  //           const otherUserIds = team.members
+  //             .filter(member => member.userId.toString() !== userId)
+  //             .map(member => member.userId);
+
+  //           // Remove the other user IDs from the myteam array
+  //           const removeMember = myTeam.updateOne({ _id: teamId }, { $pull: { myteam: { _id: { $in: otherUserIds } } } }).exec();
+
+  //           // Wait for the removal to complete using Promise.all
+  //           Promise.all([removeMember])
+  //             .then(() => {
+  //               res.status(200).send({ result: 'Done' });
+  //             })
+  //             .catch(error => {
+  //               console.error('Error removing users from myteam:', error);
+  //               res.status(500).send('Error removing users from myteam: ' + error.message);
+  //             });
+  //         } else {
+  //           res.status(200).send({ result: 'Done' });
+  //         }
+  //       })
+  //       .catch(error => {
+  //         console.error('Error saving team:', error);
+  //         res.status(400).send('Error saving team: ' + error.message);
+  //       });
+  //   });}
+  //      catch (error) {
+  //       console.log('Exception');
+  //       res.status(500).send('Error updating team visibility: ' + error.message);
+  //     };
+  //   };
+  
+  // // };
+  
 
   return {
     getAllTeams,
@@ -225,7 +328,7 @@ const teamcontroller = function (Team) {
     putTeam,
     assignTeamToUsers,
     getTeamMembership,
-    updateTeamVisiblity,
+    updateTeamVisibility,
   };
 };
 

--- a/src/models/team.js
+++ b/src/models/team.js
@@ -11,6 +11,7 @@ const team = new Schema({
     {
       userId: { type: mongoose.SchemaTypes.ObjectId, required: true },
       addDateTime: { type: Date, default: Date.now(), ref: 'userProfile' },
+      visible: { type : 'Boolean', default:true},
     },
   ],
 });

--- a/src/routes/teamRouter.js
+++ b/src/routes/teamRouter.js
@@ -7,17 +7,20 @@ const router = function (team) {
 
   teamRouter.route('/team')
     .get(controller.getAllTeams)
-    .post(controller.postTeam);
+    .post(controller.postTeam)
+    .put(controller.updateTeamVisibility);
 
   teamRouter.route('/team/:teamId')
     .get(controller.getTeamById)
     .put(controller.putTeam)
-    .delete(controller.deleteTeam);
+    .delete(controller.deleteTeam)
+
+
 
   teamRouter.route('/team/:teamId/users/')
     .post(controller.assignTeamToUsers)
     .get(controller.getTeamMembership)
-    .put(controller.updateTeamVisiblity);
+
 
 
   return teamRouter;

--- a/src/routes/teamRouter.js
+++ b/src/routes/teamRouter.js
@@ -16,7 +16,9 @@ const router = function (team) {
 
   teamRouter.route('/team/:teamId/users/')
     .post(controller.assignTeamToUsers)
-    .get(controller.getTeamMembership);
+    .get(controller.getTeamMembership)
+    .put(controller.updateTeamVisiblity);
+
 
   return teamRouter;
 };

--- a/src/utilities/addMembersToTeams.js
+++ b/src/utilities/addMembersToTeams.js
@@ -50,3 +50,5 @@ const run = () => {
 };
 
 run();
+
+// initial commit 

--- a/src/utilities/addMembersToTeams.js
+++ b/src/utilities/addMembersToTeams.js
@@ -17,7 +17,7 @@ const addMembersField = async () => {
   const updateOperations = allUsers
     .map((user) => {
       const { _id, teams, createdDate } = user;
-      return teams.map(team => Teams.updateOne({ _id: team }, { $addToSet: { members: { userId: _id, addDateTime: createdDate } } }));
+      return teams.map(team => Teams.updateOne({ _id: team }, { $addToSet: { members: { userId: _id, addDateTime: createdDate, visibility: true } } }));
     })
     .flat();
 


### PR DESCRIPTION
# Description
- A “Limit See-All” option for teams 

-  Other Links ->Teams

- When this option is turned on for a team member,  the team member  shouldn't  be able to see  other members of the team in their dashboard 

- The member however should be able to see team members of other teams  they are part of 

## Related PRS (if any):
This backend PR is related to the [1425](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1425) frontend PR.
To test this backend PR you need to checkout the [1425](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1425) frontend PR.

## Main changes explained:

- Added  a "visible" attribute to Member Object in Teams document and set it to true by default.
- Added a new route to updating the team member visibility. 
- Add  a  function  called  "updateTeamVisibility "in teams Controller   to process the newly selected visiblity of the team member


## How to test:
1. check into current branch
2. run node src/utilities/addMembersToTeams.js so that "visible" attribute gets added to all existing team members
3. run `npm install ` followed by `npm run build start`  and  `npm start ` to run this PR locally
4.  Now follow the steps mentioned in the front end PR


## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HGNRest/assets/89441435/887ed506-2ce6-443d-beb4-645abc471335


## Note:
- Kindly mention any  bugs , errors you see in the console. 
- Try breaking the functionality , any suggestion is helpful 
