### PR TITLE
Nathan - Fix hasPermission() arguments and add catches

### DIFF
--- a/src/controllers/rolePresetsController.js
+++ b/src/controllers/rolePresetsController.js
@@ -2,7 +2,7 @@ const { hasPermission } = require('../utilities/permissions');
 
 const rolePresetsController = function (Preset) {
   const getPresetsByRole = async function (req, res) {
-    if (!await hasPermission(req.body.requestor.role, 'putRole')) {
+    if (!await hasPermission(req.body.requestor, 'putRole')) {
       res.status(403).send('You are not authorized to make changes to roles.');
       return;
     }
@@ -14,7 +14,7 @@ const rolePresetsController = function (Preset) {
   };
 
   const createNewPreset = async function (req, res) {
-    if (!await hasPermission(req.body.requestor.role, 'putRole')) {
+    if (!await hasPermission(req.body.requestor, 'putRole')) {
       res.status(403).send('You are not authorized to make changes to roles.');
       return;
     }
@@ -34,7 +34,7 @@ const rolePresetsController = function (Preset) {
   };
 
   const updatePresetById = async function (req, res) {
-    if (!await hasPermission(req.body.requestor.role, 'putRole')) {
+    if (!await hasPermission(req.body.requestor, 'putRole')) {
       res.status(403).send('You are not authorized to make changes to roles.');
       return;
     }
@@ -53,7 +53,7 @@ const rolePresetsController = function (Preset) {
   };
 
   const deletePresetById = async function (req, res) {
-    if (!await hasPermission(req.body.requestor.role, 'putRole')) {
+    if (!await hasPermission(req.body.requestor, 'putRole')) {
       res.status(403).send('You are not authorized to make changes to roles.');
       return;
     }

--- a/src/utilities/permissions.js
+++ b/src/utilities/permissions.js
@@ -4,12 +4,14 @@ const UserProfile = require('../models/userProfile');
 
 const hasRolePermission = async (role, action) => Role.findOne({ roleName: role })
   .exec()
-  .then(({ permissions }) => permissions.includes(action));
+  .then(({ permissions }) => permissions.includes(action))
+  .catch(false);
 
 const hasIndividualPermission = async (userId, action) => UserProfile.findById(userId)
   .select('permissions')
   .exec()
-  .then(({ permissions }) => permissions.frontPermissions.includes(action));
+  .then(({ permissions }) => permissions.frontPermissions.includes(action))
+  .catch(false);
 
 const hasPermission = async (requestor, action) => await hasRolePermission(requestor.role, action) || hasIndividualPermission(requestor.requestorId, action);
 


### PR DESCRIPTION
# Description


## Main changes explained:
- Change hasPermission() arguments from requestor.role to requestor in rolePresetsController.js
- Add catch statements to hasPermission() calls.

## How to test:
1. check into the current branch
2. do `npm install` and `...` to run this PR locally
3. log in as owner user
4. go to the permissions management page -> some role
5. verify you can create and load presets

## Screenshots or videos of changes:
Before:
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/23086054/14cf7060-9cc2-4b4c-aa34-e8d254baa47e)
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/23086054/497d0496-9085-491a-8f30-691d9e761aba)


After:
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/23086054/dc4a589b-3aee-4142-94f5-7a4bc0e7c3a7)
And no error

