### PR TITLE
Xiao F Give manager default permission to suggest instead of edit

### DIFF
--- a/src/utilities/createInitialPermissions.js
+++ b/src/utilities/createInitialPermissions.js
@@ -109,7 +109,7 @@ const permissionsRoles = [
       'putUserProfile',
       'infringementAuthorizer',
       'getReporteesLimitRoles',
-      'updateTask',
+      'suggestTask',
       'putTeam',
       'getAllInvInProjectWBS',
       'postInvInProjectWBS',


### PR DESCRIPTION
# Description
![CleanShot 2023-10-26 at 00 06 27](https://github.com/OneCommunityGlobal/HGNRest/assets/43768723/ff947871-90a3-41b6-9c5a-720c90188bed)
Manager has both edit and suggest permissions in the database, but edit permission overrides suggest so that 'suggest' button won't appear for manager. 

## Related PRS (if any):
[PR#1458](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1458)

## Main changes explained:
- Update file `src/utilities/createInitialPermissions.js` to initialize manager permission with suggest

## How to test:
1. check into current branch
2. do `npm install`, `npm run build`and `npm start` to run this PR locally
3. log in as manager user
4. go to dashboard -> Tasks -> click on task name -> should see 'suggest' button

Difficulties: Although I turned off edit permission for manager with owner account and ran the BE code in the PR, the edit permission on manager will be restored after some time. Any help will be appreciated.

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HGNRest/assets/43768723/6297aade-807d-47f9-be83-cafb55eafa9b


## Note:
1. For BE, this `TypeError: Cannot read property 'permissions' of null` error exists on dev branch:
![CleanShot 2023-10-25 at 22 53 07](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/43768723/8146475d-4be9-40db-ad19-8064c2f4a623)

