### PR TITLE
Wanting new make 5 letter codes editable only by admin&owner

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -79,7 +79,7 @@ const userProfileController = function (UserProfile) {
         res.status(200).send(results);
       })
       .catch((error) => res.status(404).send(error));
-      
+
   };
 
   const getProjectMembers = async function (req, res) {
@@ -233,8 +233,8 @@ const userProfileController = function (UserProfile) {
         || req.body.requestor.requestorId === userid
       )
     );
-  
-    const canEditTeamCode = req.body.requestor.role === "Owner" 
+
+    const canEditTeamCode = req.body.requestor.role === "Owner"
       || req.body.requestor.role === "Administrator"
       || req.body.requestor.permissions?.frontPermissions.includes("editTeamCode");
 
@@ -570,15 +570,16 @@ const userProfileController = function (UserProfile) {
     const { userId } = req.params;
     const { key, value } = req.body;
 
-    if (key === "teamCode") {
-      const canEditTeamCode = req.body.requestor.role === "Owner" ||
-        req.body.requestor.permissions?.frontPermissions.includes("editTeamCode");
+    if (key === 'teamCode') {
+      const canEditTeamCode = req.body.requestor.role === 'Owner'
+        || req.body.requestor.role === 'Administrator'
+        || req.body.requestor.permissions?.frontPermissions.includes('editTeamCode');
 
       if(!canEditTeamCode){
         res.status(403).send("You are not authorized to edit team code.");
         return;
       }
-  
+
     }
 
     // remove user from cache, it should be loaded next time

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -234,8 +234,9 @@ const userProfileController = function (UserProfile) {
       )
     );
   
-    const canEditTeamCode = req.body.requestor.role === "Owner" ||
-      req.body.requestor.permissions?.frontPermissions.includes("editTeamCode");
+    const canEditTeamCode = req.body.requestor.role === "Owner" 
+      || req.body.requestor.role === "Administrator"
+      || req.body.requestor.permissions?.frontPermissions.includes("editTeamCode");
 
     if (!isRequestorAuthorized) {
       res.status(403).send("You are not authorized to update this user");


### PR DESCRIPTION
# Description
<img width="853" alt="截屏2023-11-03 上午11 16 18" src="https://github.com/OneCommunityGlobal/HGNRest/assets/105323719/1fcc02b6-fb24-43a3-96de-ba9fb93e4e89">


## Related PRS (if any):
FE #1485

## Main changes explained:
update userProfileController.js
…

## How to test:
1. check into current branch and FE #1485
2. do `npm run build` and `npm start` to run this PR locally


## Screenshots or videos of changes:
see FE #1485

## Note:
see FE #1485
