### PR TITLE
XiaoW_Hot fix of cannot create new user

### DIFF
--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -159,7 +159,7 @@ const userProfileSchema = new Schema({
     default: '',
     validate: {
       validator(v) {
-        const teamCoderegex = /^([a-zA-Z]-[a-zA-Z]{3}|[a-zA-Z]{5})$/;
+        const teamCoderegex = /^([a-zA-Z]-[a-zA-Z]{3}|[a-zA-Z]{5})$|^$/;
         return teamCoderegex.test(v);
       },
       message:


### PR DESCRIPTION
# Description
When creating a new user, it doesn't have a teamCode, which will be empty string, and the teamCode validator in userProfile model doesn't cover this case.

## Main changes explained:
- accept empty string for the teamCoderegex 
