### PR TITLE
XiaoW_hotfix_of_cannot_save_information_modal_change

### DIFF
--- a/src/utilities/escapeRegex.js
+++ b/src/utilities/escapeRegex.js
@@ -1,6 +1,6 @@
 
 const escapeRegex = function (text) {
-    return text.replace(/[[\]{}()*+?.\\^$|]/g, '\\$&');
+    return `^${text.replace(/[[\]{}()*+?.\\^$|]/g, '\\$&')}&`;
 };
 
 module.exports = escapeRegex;


### PR DESCRIPTION
# Description
The `escapeRegex` checks if `infoName` is already in the database, but it will also find a match if only part of the string fits, which is why creating a `LeaderBoard` would send error since there is already a `LeaderBoardOrigin` in the database.

## Main changes explained:
- add `^` and `&` to the two ends of the `escapeRegex` return, make sure it checks the entire name string for existing info name