### PR TITLE
Kaikanes-Routes/Controllers for updating name and unit of measurement

### DIFF
--- a/src/controllers/bmdashboard/bmInventoryTypeController.js
+++ b/src/controllers/bmdashboard/bmInventoryTypeController.js
@@ -1,19 +1,54 @@
 const bmInventoryTypeController = function (InvType) {
   const fetchMaterialTypes = async (req, res) => {
     try {
-      InvType
-        .find()
-        .exec()
-        .then(result => res.status(200).send(result))
-        .catch(error => res.status(500).send(error));
-    } catch (err) {
-      res.json(err);
+      const result = await InvType.find().exec();
+      res.status(200).send(result);
+    } catch (error) {
+      res.status(500).send(error);
+    }
+  };
+  const fetchSingleInventoryType = async (req, res) => {
+    const { invtypeId } = req.params;
+    try {
+      const result = await InvType.findById(invtypeId).exec();
+      res.status(200).send(result);
+    } catch (error) {
+      res.status(500).send(error);
     }
   };
 
-  return {
-    fetchMaterialTypes,
+  const updateNameAndUnit = async (req, res) => {
+    try {
+      const { invtypeId } = req.params;
+      const { name, unit } = req.body;
+
+      const updateData = {};
+
+      if (name) {
+        updateData.name = name;
+      }
+
+      if (unit) {
+        updateData.unit = unit;
+      }
+
+      const updatedInvType = await InvType.findByIdAndUpdate(
+        invtypeId,
+        updateData,
+        { new: true, runValidators: true },
+      );
+
+      if (!updatedInvType) {
+        return res.status(404).json({ error: 'invType Material not found check Id' });
+      }
+
+      res.status(200).json(updatedInvType);
+    } catch (error) {
+      res.status(500).send(error);
+    }
   };
+
+  return { fetchMaterialTypes, fetchSingleInventoryType, updateNameAndUnit };
 };
 
 module.exports = bmInventoryTypeController;

--- a/src/controllers/bmdashboard/bmInventoryTypeController.js
+++ b/src/controllers/bmdashboard/bmInventoryTypeController.js
@@ -1,10 +1,13 @@
 const bmInventoryTypeController = function (InvType) {
   const fetchMaterialTypes = async (req, res) => {
     try {
-      const result = await InvType.find().exec();
-      res.status(200).send(result);
-    } catch (error) {
-      res.status(500).send(error);
+      InvType
+        .find()
+        .exec()
+        .then(result => res.status(200).send(result))
+        .catch(error => res.status(500).send(error));
+    } catch (err) {
+      res.json(err);
     }
   };
   const fetchSingleInventoryType = async (req, res) => {

--- a/src/routes/bmdashboard/bmInventoryTypeRouter.js
+++ b/src/routes/bmdashboard/bmInventoryTypeRouter.js
@@ -4,9 +4,14 @@ const routes = function (invType) {
   const inventoryTypeRouter = express.Router();
   const controller = require('../../controllers/bmdashboard/bmInventoryTypeController')(invType);
 
+  // Route for fetching all material types
   inventoryTypeRouter.route('/invtypes/materials')
     .get(controller.fetchMaterialTypes);
 
+  // Combined routes for getting a single inventory type and updating its name and unit of measurement
+  inventoryTypeRouter.route('/invtypes/material/:invtypeId')
+    .get(controller.fetchSingleInventoryType)
+    .put(controller.updateNameAndUnit);
   return inventoryTypeRouter;
 };
 


### PR DESCRIPTION
# Description
Created controller functions and routes to give users the ability to update the inventorytype unit of measurement and name

## Related PRS (if any):
Front ed still work in progress
…

## Main changes explained:
- Added two more functions to bmInventoryTypeController
- First one gets a single inventorytype
- second one updates the name and unit of measurement
- also created routes in bmInventoryTypeRouter.js to use new controller functions
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run build` to run this PR locally
3. Clear site data/cache
4. localhost:4500/api/bm/invtypes/materials/ and get a id
5. test localhost:4500/api/bm/invtypes/material/:id get and put routes
6. params are` {"name" : "updated name", "unit": "updated unit"}`
7. You should be able to get a single inventory type and update the name and unit


## Screenshots or videos of changes:
https://github.com/OneCommunityGlobal/HGNRest/assets/114305309/ea3d4fc4-c4ab-40d6-8708-b74a23f584af

## Note:

Dont forget to add your headers
You can get your auth token in local storage when you log in.
<img width="524" alt="image" src="https://github.com/OneCommunityGlobal/HGNRest/assets/114305309/5fdfe776-5556-4a9e-a553-f42c45ad915e">



