### PR TITLE
Nathan Hotfix Fix end anchor symbol in escapeRegex

### DIFF
--- a/src/utilities/escapeRegex.js
+++ b/src/utilities/escapeRegex.js
@@ -1,6 +1,6 @@
 
 const escapeRegex = function (text) {
-    return `^${text.replace(/[[\]{}()*+?.\\^$|]/g, '\\$&')}&`;
+    return `^${text.replace(/[[\]{}()*+?.\\^$|]/g, '\\$&')}$`;
 };
 
 module.exports = escapeRegex;


### PR DESCRIPTION
# Description
MongoDB uses `$` to indicate end of string in regex, not `&`. This is making "forgot my password" and probably several other features unusable.
https://www.mongodb.com/docs/manual/reference/operator/query/regex/

## Related PRS (if any):
Fixes this PR: https://github.com/OneCommunityGlobal/HGNRest/pull/600

## Main changes explained:
Replaces `&` with `$` for end anchor character in `escapeRegex`
