### PR TITLE
Nathan update minimum permissions

### DIFF
--- a/src/utilities/createInitialPermissions.js
+++ b/src/utilities/createInitialPermissions.js
@@ -6,6 +6,9 @@ const permissionsRoles = [
   {
     roleName: 'Administrator',
     permissions: [
+      // Reports
+      'getWeeklySummaries',
+      'getReports', // Doesn't do anything on back-end.
       // Badges
       'seeBadges',
       'assignBadges',
@@ -65,8 +68,7 @@ const permissionsRoles = [
       // General
       'getUserProfiles',
       'getProjectMembers',
-      'getWeeklySummaries',
-      // 'getReportsPage',?
+
       'getTimeZoneAPIKey',
       'checkLeadTeamOfXplus',
     ],
@@ -97,6 +99,7 @@ const permissionsRoles = [
       'getAllInvType',
       'postInvType',
       'getWeeklySummaries',
+      'getReports',
       'getTimeZoneAPIKey',
       'checkLeadTeamOfXplus',
     ],
@@ -124,7 +127,6 @@ const permissionsRoles = [
       'putInvType',
       'getAllInvType',
       'postInvType',
-      'getWeeklySummaries',
       'getTimeZoneAPIKey',
       'checkLeadTeamOfXplus',
     ],
@@ -151,7 +153,6 @@ const permissionsRoles = [
       'putInvType',
       'getAllInvType',
       'postInvType',
-      'getWeeklySummaries',
       'getTimeZoneAPIKey',
       'checkLeadTeamOfXplus',
     ],
@@ -212,6 +213,7 @@ const permissionsRoles = [
       'getAllInvType',
       'postInvType',
       'getWeeklySummaries',
+      'getReports',
       'getTimeZoneAPIKey',
       'checkLeadTeamOfXplus',
       'editTeamCode',


### PR DESCRIPTION
# Description
This PR updates the initial permissions, removing "getWeeklySummaries" from roles that don't necessarily need it and adding "getReports" to the relevant roles.

## Related PRS (if any):
This backend PR is for the [#1658](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1658) frontend PR.

## Main changes explained:
- Added "getReports" to Owners, Admins, and Core Team
- Removed "getWeeklySummaries" from Managers and Mentors

