### PR TITLE
Shengwei (hotfix) fix the task scheduler to run weekly

### DIFF
--- a/src/cronjobs/userProfileJobs.js
+++ b/src/cronjobs/userProfileJobs.js
@@ -5,7 +5,8 @@ const userhelper = require('../helpers/userHelper')();
 
 const userProfileJobs = () => {
   const allUserProfileJobs = new CronJob(
-    '1 0 * * *', // Every day, 1 minute past midnight (PST).
+    // '* * * * *', // Comment out for testing. Run Every minute.
+    '0 0 * * 0', // Every Sunday, at midnight.
     async () => {
       const SUNDAY = 0;
       if (moment().tz('America/Los_Angeles').day() === SUNDAY) {

--- a/src/cronjobs/userProfileJobs.js
+++ b/src/cronjobs/userProfileJobs.js
@@ -6,7 +6,7 @@ const userhelper = require('../helpers/userHelper')();
 const userProfileJobs = () => {
   const allUserProfileJobs = new CronJob(
     // '* * * * *', // Comment out for testing. Run Every minute.
-    '0 0 * * 0', // Every Sunday, at midnight.
+    '1 0 * * 0', // Every Sunday, 1 minute past midnight.
     async () => {
       const SUNDAY = 0;
       if (moment().tz('America/Los_Angeles').day() === SUNDAY) {


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/69882989/4e19ba54-b951-44e2-9662-79b515d1922c)

## Related PRS (if any):


## Main changes explained:
- Update file userProfileJobs.js to include new cron configuration


## How to test:
1. check into the current branch
2. do `npm install` and `...` to run this PR locally
3. verify the cron expression specifies that the job should run at 1 minute past midnight every Sunday in PST in file userProfileJobs.js

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
