### PR TITLE
Vishala Leaderboard api and Task api fix

### DIFF
--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -834,7 +834,7 @@ const taskController = function (Task) {
   const getTasksForTeamsByUser = async (req, res) => {
     try {
       const userId = mongoose.Types.ObjectId(req.params.userId);
-      const teamsData = await taskHelper.getTasksForTeams(userId).exec();
+      const teamsData = await taskHelper.getTasksForTeams(userId);
       if (teamsData.length > 0) {
         res.status(200).send(teamsData);
       } else {

--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -3,6 +3,8 @@ const mongoose = require('mongoose');
 const userProfile = require('../models/userProfile');
 const timeentry = require('../models/timeentry');
 const myTeam = require('../helpers/helperModels/myTeam');
+const team = require('../models/team');
+
 
 const dashboardhelper = function () {
   const personaldetails = function (userId) {

--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -161,6 +161,11 @@ const dashboardhelper = function () {
 
   const getLeaderboard = async function (userId) {
     const userid = mongoose.Types.ObjectId(userId);
+    const userById = await userProfile.findOne({ _id: userid , isActive:true}, {role:1})
+                    .then((res)=>{ return res;  }).catch((e)=>{});
+
+    if(userById==null) return null;
+    const userRole = userById.role;
     const pdtstart = moment()
       .tz('America/Los_Angeles')
       .startOf('week')
@@ -169,262 +174,358 @@ const dashboardhelper = function () {
       .tz('America/Los_Angeles')
       .endOf('week')
       .format('YYYY-MM-DD');
-    const output = await myTeam.aggregate([
-      {
-        $match: {
-          _id: userid,
-        },
+
+    let teamMemberIds = [userid]
+    let teamMembers = [];
+
+    if(userRole!='Administrator' && userRole!='Owner' && userRole!='Core Team') //Manager , Mentor , Volunteer ... , Show only team members
+    {
+      
+      const teamsResult = await team.find( { "members.userId": { $in: [userid] } }, {members:1} )
+      .then((res)=>{ return res; }).catch((e)=>{})
+
+      teamsResult.map((_myTeam)=>{
+        _myTeam.members.map((teamMember)=> {
+          if(!teamMember.userId.equals(userid))
+          teamMemberIds.push( teamMember.userId );
+       } )
+      })
+
+      teamMembers = await userProfile.find({ _id: { $in: teamMemberIds } , isActive:true },
+          {role:1,firstName:1,lastName:1,isVisible:1,weeklycommittedHours:1,weeklySummaries:1})
+        .then((res)=>{ return res;  }).catch((e)=>{})
+      
+    }
+    else { 
+      if(userRole == 'Administrator'){ //All users except Owner and Core Team
+        const excludedRoles = ['Core Team', 'Owner'];
+        teamMembers = await userProfile.find({ isActive:true , role: { $nin: excludedRoles } },
+          {role:1,firstName:1,lastName:1,isVisible:1,weeklycommittedHours:1,weeklySummaries:1})
+        .then((res)=>{ return res;  }).catch((e)=>{})
+      }
+      else{ //'Core Team', 'Owner' //All users
+        teamMembers = await userProfile.find({ isActive:true},
+          {role:1,firstName:1,lastName:1,isVisible:1,weeklycommittedHours:1,weeklySummaries:1})
+        .then((res)=>{ return res;  }).catch((e)=>{})
+      }
+
+     
+    }
+
+    teamMemberIds = teamMembers.map(member => member._id);
+
+    const timeEntries = await timeentry.find({
+      dateOfWork: {
+        $gte: pdtstart,
+        $lte: pdtend,
       },
-      {
-        $unwind: '$myteam',
-      },
-      {
-        $project: {
-          _id: 0,
-          role: 1,
-          personId: '$myteam._id',
-          name: '$myteam.fullName',
-        },
-      },
-      {
-        $lookup: {
-          from: 'userProfiles',
-          localField: 'personId',
-          foreignField: '_id',
-          as: 'persondata',
-        },
-      },
-      {
-        $match: {
-          // leaderboard user roles hierarchy
-          $or: [
-            {
-              role: { $in: ['Owner', 'Core Team'] },
-            },
-            {
-              $and: [
-                {
-                  role: 'Administrator',
-                },
-                { 'persondata.0.role': { $nin: ['Owner', 'Administrator'] } },
-              ],
-            },
-            {
-              $and: [
-                {
-                  role: { $in: ['Manager', 'Mentor'] },
-                },
-                {
-                  'persondata.0.role': {
-                    $nin: ['Manager', 'Mentor', 'Core Team', 'Administrator', 'Owner'],
-                  },
-                },
-              ],
-            },
-            { 'persondata.0._id': userId },
-            { 'persondata.0.role': 'Volunteer' },
-            { 'persondata.0.isVisible': true },
-          ],
-        },
-      },
-      {
-        $project: {
-          personId: 1,
-          name: 1,
-          role: {
-            $arrayElemAt: ['$persondata.role', 0],
-          },
-          isVisible: {
-            $arrayElemAt: ['$persondata.isVisible', 0],
-          },
-          hasSummary: {
-            $ne: [
-              {
-                $arrayElemAt: [
-                  {
-                    $arrayElemAt: ['$persondata.weeklySummaries.summary', 0],
-                  },
-                  0,
-                ],
-              },
-              '',
-            ],
-          },
-          weeklycommittedHours: {
-            $sum: [
-              {
-                $arrayElemAt: ['$persondata.weeklycommittedHours', 0],
-              },
-              {
-                $ifNull: [{ $arrayElemAt: ['$persondata.missedHours', 0] }, 0],
-              },
-            ],
-          },
-        },
-      },
-      {
-        $lookup: {
-          from: 'timeEntries',
-          localField: 'personId',
-          foreignField: 'personId',
-          as: 'timeEntryData',
-        },
-      },
-      {
-        $project: {
-          personId: 1,
-          name: 1,
-          role: 1,
-          isVisible: 1,
-          hasSummary: 1,
-          weeklycommittedHours: 1,
-          timeEntryData: {
-            $filter: {
-              input: '$timeEntryData',
-              as: 'timeentry',
-              cond: {
-                $and: [
-                  {
-                    $gte: ['$$timeentry.dateOfWork', pdtstart],
-                  },
-                  {
-                    $lte: ['$$timeentry.dateOfWork', pdtend],
-                  },
-                  {
-                    $not: [
-                      {
-                        $in: ['$$timeentry.entryType', ['person', 'team', 'project']],
-                      },
-                    ],
-                  },
-                ],
-              },
-            },
-          },
-        },
-      },
-      {
-        $unwind: {
-          path: '$timeEntryData',
-          preserveNullAndEmptyArrays: true,
-        },
-      },
-      {
-        $project: {
-          personId: 1,
-          name: 1,
-          role: 1,
-          isVisible: 1,
-          hasSummary: 1,
-          weeklycommittedHours: 1,
-          totalSeconds: {
-            $cond: [
-              {
-                $gte: ['$timeEntryData.totalSeconds', 0],
-              },
-              '$timeEntryData.totalSeconds',
-              0,
-            ],
-          },
-          isTangible: {
-            $cond: [
-              {
-                $gte: ['$timeEntryData.totalSeconds', 0],
-              },
-              '$timeEntryData.isTangible',
-              false,
-            ],
-          },
-        },
-      },
-      {
-        $addFields: {
-          tangibletime: {
-            $cond: [
-              {
-                $eq: ['$isTangible', true],
-              },
-              '$totalSeconds',
-              0,
-            ],
-          },
-          intangibletime: {
-            $cond: [
-              {
-                $eq: ['$isTangible', false],
-              },
-              '$totalSeconds',
-              0,
-            ],
-          },
-        },
-      },
-      {
-        $group: {
-          _id: {
-            personId: '$personId',
-            weeklycommittedHours: '$weeklycommittedHours',
-            name: '$name',
-            role: '$role',
-            isVisible: '$isVisible',
-            hasSummary: '$hasSummary',
-          },
-          totalSeconds: {
-            $sum: '$totalSeconds',
-          },
-          tangibletime: {
-            $sum: '$tangibletime',
-          },
-          intangibletime: {
-            $sum: '$intangibletime',
-          },
-        },
-      },
-      {
-        $project: {
-          _id: 0,
-          personId: '$_id.personId',
-          name: '$_id.name',
-          role: '$_id.role',
-          isVisible: '$_id.isVisible',
-          hasSummary: '$_id.hasSummary',
-          weeklycommittedHours: '$_id.weeklycommittedHours',
-          totaltime_hrs: {
-            $divide: ['$totalSeconds', 3600],
-          },
-          totaltangibletime_hrs: {
-            $divide: ['$tangibletime', 3600],
-          },
-          totalintangibletime_hrs: {
-            $divide: ['$intangibletime', 3600],
-          },
-          percentagespentintangible: {
-            $cond: [
-              {
-                $eq: ['$totalSeconds', 0],
-              },
-              0,
-              {
-                $multiply: [
-                  {
-                    $divide: ['$tangibletime', '$totalSeconds'],
-                  },
-                  100,
-                ],
-              },
-            ],
-          },
-        },
-      },
-      {
-        $sort: {
-          totaltangibletime_hrs: -1,
-          name: 1,
-          role: 1,
-        },
-      },
-    ]);
-    return output;
+      personId: { $in: teamMemberIds }
+    });
+
+    let timeEntryByPerson = {}
+    timeEntries.map((timeEntry)=>{
+        
+      let personIdStr = timeEntry.personId.toString();
+
+      if(timeEntryByPerson[personIdStr]==null) 
+         timeEntryByPerson[personIdStr] = {tangibleSeconds:0,intangibleSeconds:0,totalSeconds:0};
+
+      if (timeEntry.isTangible === true) {
+        timeEntryByPerson[personIdStr].tangibleSeconds += timeEntry.totalSeconds;
+      } else {
+        timeEntryByPerson[personIdStr].intangibleSeconds += timeEntry.totalSeconds;
+      }
+
+      timeEntryByPerson[personIdStr].totalSeconds += timeEntry.totalSeconds;
+    })
+
+    
+    let leaderBoardData = [];
+    teamMembers.map((teamMember)=>{
+        let obj = {
+          personId : teamMember._id,
+          role : teamMember.role,
+          name : teamMember.firstName + ' ' + teamMember.lastName,
+          isVisible : teamMember.isVisible,
+          hasSummary : teamMember.weeklySummaries?.length > 0 ? teamMember.weeklySummaries[0].summary!='' : false,
+          weeklycommittedHours : teamMember.weeklycommittedHours,
+          totaltangibletime_hrs : ((timeEntryByPerson[teamMember._id.toString()]?.tangibleSeconds / 3600) || 0),
+          totalintangibletime_hrs : ((timeEntryByPerson[teamMember._id.toString()]?.intangibleSeconds / 3600) || 0),
+          totaltime_hrs : ((timeEntryByPerson[teamMember._id.toString()]?.totalSeconds / 3600) || 0),
+          percentagespentintangible : 
+              (timeEntryByPerson[teamMember._id.toString()] && timeEntryByPerson[teamMember._id.toString()]?.totalSeconds !=0 && timeEntryByPerson[teamMember._id.toString()]?.tangibleSeconds !=0) ? 
+              (timeEntryByPerson[teamMember._id.toString()]?.tangibleSeconds / timeEntryByPerson[teamMember._id.toString()]?.totalSeconds) * 100
+              :
+              0
+        }
+        leaderBoardData.push(obj);
+    })
+
+    let sortedLBData = leaderBoardData.sort((a, b) => {
+      // Sort by totaltangibletime_hrs in descending order
+      if (b.totaltangibletime_hrs !== a.totaltangibletime_hrs) {
+        return b.totaltangibletime_hrs - a.totaltangibletime_hrs;
+      }
+    
+      // Then sort by name in ascending order
+      if (a.name !== b.name) {
+        return a.name.localeCompare(b.name);
+      }
+    
+      // Finally, sort by role in ascending order
+      return a.role.localeCompare(b.role);
+    });
+
+    return sortedLBData;
+
+    // return myTeam.aggregate([
+    //   {
+    //     $match: {
+    //       _id: userid,
+    //     },
+    //   },
+    //   {
+    //     $unwind: '$myteam',
+    //   },
+    //   {
+    //     $project: {
+    //       _id: 0,
+    //       role: 1,
+    //       personId: '$myteam._id',
+    //       name: '$myteam.fullName',
+    //     },
+    //   },
+    //   {
+    //     $lookup: {
+    //       from: 'userProfiles',
+    //       localField: 'personId',
+    //       foreignField: '_id',
+    //       as: 'persondata',
+    //     },
+    //   },
+    //   {
+    //     $match: {
+    //       // leaderboard user roles hierarchy
+    //       $or: [
+    //         {
+    //           role: { $in: ['Owner', 'Core Team'] },
+    //         },
+    //         {
+    //           $and: [
+    //             {
+    //               role: 'Administrator',
+    //             },
+    //             { 'persondata.0.role': { $nin: ['Owner', 'Administrator'] } },
+    //           ],
+    //         },
+    //         {
+    //           $and: [
+    //             {
+    //               role: { $in: ['Manager', 'Mentor'] },
+    //             },
+    //             {
+    //               'persondata.0.role': {
+    //                 $nin: ['Manager', 'Mentor', 'Core Team', 'Administrator', 'Owner'],
+    //               },
+    //             },
+    //           ],
+    //         },
+    //         { 'persondata.0._id': userId },
+    //         { 'persondata.0.role': 'Volunteer' },
+    //         { 'persondata.0.isVisible': true },
+    //       ],
+    //     },
+    //   },
+    //   {
+    //     $project: {
+    //       personId: 1,
+    //       name: 1,
+    //       role: {
+    //         $arrayElemAt: ['$persondata.role', 0],
+    //       },
+    //       isVisible: {
+    //         $arrayElemAt: ['$persondata.isVisible', 0],
+    //       },
+    //       hasSummary: {
+    //         $ne: [
+    //           {
+    //             $arrayElemAt: [
+    //               {
+    //                 $arrayElemAt: ['$persondata.weeklySummaries.summary', 0],
+    //               },
+    //               0,
+    //             ],
+    //           },
+    //           '',
+    //         ],
+    //       },
+    //       weeklycommittedHours: {
+    //         $sum: [
+    //           {
+    //             $arrayElemAt: ['$persondata.weeklycommittedHours', 0],
+    //           },
+    //           {
+    //             $ifNull: [{ $arrayElemAt: ['$persondata.missedHours', 0] }, 0],
+    //           },
+    //         ],
+    //       },
+    //     },
+    //   },
+    //   {
+    //     $lookup: {
+    //       from: 'timeEntries',
+    //       localField: 'personId',
+    //       foreignField: 'personId',
+    //       as: 'timeEntryData',
+    //     },
+    //   },
+    //   {
+    //     $project: {
+    //       personId: 1,
+    //       name: 1,
+    //       role: 1,
+    //       isVisible: 1,
+    //       hasSummary: 1,
+    //       weeklycommittedHours: 1,
+    //       timeEntryData: {
+    //         $filter: {
+    //           input: '$timeEntryData',
+    //           as: 'timeentry',
+    //           cond: {
+    //             $and: [
+    //               {
+    //                 $gte: ['$$timeentry.dateOfWork', pdtstart],
+    //               },
+    //               {
+    //                 $lte: ['$$timeentry.dateOfWork', pdtend],
+    //               },
+    //             ],
+    //           },
+    //         },
+    //       },
+    //     },
+    //   },
+    //   {
+    //     $unwind: {
+    //       path: '$timeEntryData',
+    //       preserveNullAndEmptyArrays: true,
+    //     },
+    //   },
+    //   {
+    //     $project: {
+    //       personId: 1,
+    //       name: 1,
+    //       role: 1,
+    //       isVisible: 1,
+    //       hasSummary: 1,
+    //       weeklycommittedHours: 1,
+    //       totalSeconds: {
+    //         $cond: [
+    //           {
+    //             $gte: ['$timeEntryData.totalSeconds', 0],
+    //           },
+    //           '$timeEntryData.totalSeconds',
+    //           0,
+    //         ],
+    //       },
+    //       isTangible: {
+    //         $cond: [
+    //           {
+    //             $gte: ['$timeEntryData.totalSeconds', 0],
+    //           },
+    //           '$timeEntryData.isTangible',
+    //           false,
+    //         ],
+    //       },
+    //     },
+    //   },
+    //   {
+    //     $addFields: {
+    //       tangibletime: {
+    //         $cond: [
+    //           {
+    //             $eq: ['$isTangible', true],
+    //           },
+    //           '$totalSeconds',
+    //           0,
+    //         ],
+    //       },
+    //       intangibletime: {
+    //         $cond: [
+    //           {
+    //             $eq: ['$isTangible', false],
+    //           },
+    //           '$totalSeconds',
+    //           0,
+    //         ],
+    //       },
+    //     },
+    //   },
+    //   {
+    //     $group: {
+    //       _id: {
+    //         personId: '$personId',
+    //         weeklycommittedHours: '$weeklycommittedHours',
+    //         name: '$name',
+    //         role: '$role',
+    //         isVisible: '$isVisible',
+    //         hasSummary: '$hasSummary',
+    //       },
+    //       totalSeconds: {
+    //         $sum: '$totalSeconds',
+    //       },
+    //       tangibletime: {
+    //         $sum: '$tangibletime',
+    //       },
+    //       intangibletime: {
+    //         $sum: '$intangibletime',
+    //       },
+    //     },
+    //   },
+    //   {
+    //     $project: {
+    //       _id: 0,
+    //       personId: '$_id.personId',
+    //       name: '$_id.name',
+    //       role: '$_id.role',
+    //       isVisible: '$_id.isVisible',
+    //       hasSummary: '$_id.hasSummary',
+    //       weeklycommittedHours: '$_id.weeklycommittedHours',
+    //       totaltime_hrs: {
+    //         $divide: ['$totalSeconds', 3600],
+    //       },
+    //       totaltangibletime_hrs: {
+    //         $divide: ['$tangibletime', 3600],
+    //       },
+    //       totalintangibletime_hrs: {
+    //         $divide: ['$intangibletime', 3600],
+    //       },
+    //       percentagespentintangible: {
+    //         $cond: [
+    //           {
+    //             $eq: ['$totalSeconds', 0],
+    //           },
+    //           0,
+    //           {
+    //             $multiply: [
+    //               {
+    //                 $divide: ['$tangibletime', '$totalSeconds'],
+    //               },
+    //               100,
+    //             ],
+    //           },
+    //         ],
+    //       },
+    //     },
+    //   },
+    //   {
+    //     $sort: {
+    //       totaltangibletime_hrs: -1,
+    //       name: 1,
+    //       role: 1,
+    //     },
+    //   },
+    // ]);
   };
 
   /**

--- a/src/helpers/taskHelper.js
+++ b/src/helpers/taskHelper.js
@@ -1,12 +1,6 @@
 const moment = require('moment-timezone');
 const userProfile = require('../models/userProfile');
-const timeentry = require('../models/timeentry');
-const myTeam = require('../helpers/helperModels/myTeam');
-const team = require('../models/team');
-const Task = require('../models/task');
-const TaskNotification = require('../models/taskNotification');
-const Wbs = require('../models/wbs');
-const mongoose = require('mongoose');
+const myteam = require('../helpers/helperModels/myTeam');
 
 const taskHelper = function () {
   const getTasksForTeams = async function (userId) {
@@ -15,7 +9,6 @@ const taskHelper = function () {
     const userById = await userProfile.findOne({ _id: userid , isActive:true}, {role:1,firstName:1, lastName:1, role:1, isVisible:1, weeklycommittedHours:1, weeklySummaries:1})
                     .then((res)=>{ return res;  }).catch((e)=>{});
 
-                    
     if(userById==null) return null;
     const userRole = userById.role;
 

--- a/src/helpers/taskHelper.js
+++ b/src/helpers/taskHelper.js
@@ -1,6 +1,12 @@
 const moment = require('moment-timezone');
 const userProfile = require('../models/userProfile');
-const myteam = require('../helpers/helperModels/myTeam');
+const timeentry = require('../models/timeentry');
+const myTeam = require('../helpers/helperModels/myTeam');
+const team = require('../models/team');
+const Task = require('../models/task');
+const TaskNotification = require('../models/taskNotification');
+const Wbs = require('../models/wbs');
+const mongoose = require('mongoose');
 
 const taskHelper = function () {
   const getTasksForTeams = async function (userId) {

--- a/src/helpers/taskHelper.js
+++ b/src/helpers/taskHelper.js
@@ -3,7 +3,14 @@ const userProfile = require('../models/userProfile');
 const myteam = require('../helpers/helperModels/myTeam');
 
 const taskHelper = function () {
-  const getTasksForTeams = function (userId) {
+  const getTasksForTeams = async function (userId) {
+    const userid = mongoose.Types.ObjectId(userId);
+    const userById = await userProfile.findOne({ _id: userid , isActive:true}, {role:1,firstName:1, lastName:1, role:1, isVisible:1, weeklycommittedHours:1, weeklySummaries:1})
+                    .then((res)=>{ return res;  }).catch((e)=>{});
+
+    if(userById==null) return null;
+    const userRole = userById.role;
+
     const pdtstart = moment()
       .tz('America/Los_Angeles')
       .startOf('week')
@@ -12,291 +19,413 @@ const taskHelper = function () {
       .tz('America/Los_Angeles')
       .endOf('week')
       .format('YYYY-MM-DD');
-    return myteam.aggregate([
+
+      let teamMemberIds = [userid]
+      let teamMembers = [];
+
+      if(userRole!='Administrator' && userRole!='Owner' && userRole!='Core Team') //Manager , Mentor , Volunteer ... , Show only team members
       {
-        $match: {
-          _id: userId,
+        
+        const teamsResult = await team.find( { "members.userId": { $in: [userid] } }, {members:1} )
+          .then((res)=>{ return res; }).catch((e)=>{})
+
+          teamsResult.map((_myTeam)=>{
+            _myTeam.members.map((teamMember)=> {
+              if(!teamMember.userId.equals(userid))
+              teamMemberIds.push( teamMember.userId );
+          } )
+          })
+
+          teamMembers = await userProfile.find({ _id: { $in: teamMemberIds } , isActive:true },
+              {role:1,firstName:1,lastName:1,weeklycommittedHours:1})
+            .then((res)=>{ return res;  }).catch((e)=>{})
+      }
+      else { 
+        if(userRole == 'Administrator'){ //All users except Owner and Core Team
+          const excludedRoles = ['Core Team', 'Owner'];
+          teamMembers = await userProfile.find({ isActive:true , role: { $nin: excludedRoles } },
+            {role:1,firstName:1,lastName:1,weeklycommittedHours:1})
+          .then((res)=>{ return res;  }).catch((e)=>{})
+        }
+        else{ //'Core Team', 'Owner' //All users
+          teamMembers = await userProfile.find({ isActive:true},
+            {role:1,firstName:1,lastName:1,weeklycommittedHours:1})
+          .then((res)=>{ return res;  }).catch((e)=>{})
+        }  
+      }
+
+      teamMemberIds = teamMembers.map(member => member._id);
+
+      const timeEntries = await timeentry.find({
+        dateOfWork: {
+          $gte: pdtstart,
+          $lte: pdtend,
         },
-      },
-      {
-        $unwind: '$myteam',
-      },
-      {
-        $project: {
-          _id: 0,
-          personId: '$myteam._id',
-          name: '$myteam.fullName',
-          role: 1,
-        },
-      },
-      // have personId, name, role
-      {
-        $lookup: {
-          from: 'userProfiles',
-          localField: 'personId',
-          foreignField: '_id',
-          as: 'persondata',
-        },
-      },
-      {
-        $match: {
-          // dashboard tasks user roles hierarchy
-          $or: [
-            {
-              role: { $in: ['Owner', 'Core Team'] },
-            },
-            {
-              $and: [
-                {
-                  role: 'Administrator',
-                },
-                { 'persondata.0.role': { $nin: ['Owner', 'Administrator'] } },
-              ],
-            },
-            {
-              $and: [
-                {
-                  role: { $in: ['Manager', 'Mentor'] },
-                },
-                {
-                  'persondata.0.role': {
-                    $nin: ['Manager', 'Mentor', 'Core Team', 'Administrator', 'Owner'],
-                  },
-                },
-              ],
-            },
-            { 'persondata.0._id': userId },
-            { 'persondata.0.role': 'Volunteer' },
-            { 'persondata.0.isVisible': true },
-          ],
-        },
-      },
-      {
-        $project: {
-          personId: 1,
-          name: 1,
-          weeklycommittedHours: {
-            $sum: [
-              {
-                $arrayElemAt: ['$persondata.weeklycommittedHours', 0],
-              },
-              {
-                $ifNull: [{ $arrayElemAt: ['$persondata.missedHours', 0] }, 0],
-              },
-            ],
-          },
-          role: 1,
-        },
-      },
-      {
-        $lookup: {
-          from: 'timeEntries',
-          localField: 'personId',
-          foreignField: 'personId',
-          as: 'timeEntryData',
-        },
-      },
-      {
-        $project: {
-          personId: 1,
-          name: 1,
-          weeklycommittedHours: 1,
-          timeEntryData: {
-            $filter: {
-              input: '$timeEntryData',
-              as: 'timeentry',
-              cond: {
-                $and: [
-                  {
-                    $gte: ['$$timeentry.dateOfWork', pdtstart],
-                  },
-                  {
-                    $lte: ['$$timeentry.dateOfWork', pdtend],
-                  },
-                  {
-                    $in: ['$$timeentry.entryType', ['default', null]],
-                  },
-                ],
-              },
-            },
-          },
-          role: 1,
-        },
-      },
-      {
-        $unwind: {
-          path: '$timeEntryData',
-          preserveNullAndEmptyArrays: true,
-        },
-      },
-      {
-        $project: {
-          personId: 1,
-          name: 1,
-          weeklycommittedHours: 1,
-          totalSeconds: {
-            $cond: [
-              {
-                $gte: ['$timeEntryData.totalSeconds', 0],
-              },
-              '$timeEntryData.totalSeconds',
-              0,
-            ],
-          },
-          isTangible: {
-            $cond: [
-              {
-                $gte: ['$timeEntryData.totalSeconds', 0],
-              },
-              '$timeEntryData.isTangible',
-              false,
-            ],
-          },
-          role: 1,
-        },
-      },
-      {
-        $addFields: {
-          tangibletime: {
-            $cond: [
-              {
-                $eq: ['$isTangible', true],
-              },
-              '$totalSeconds',
-              0,
-            ],
-          },
-        },
-      },
-      {
-        $group: {
-          _id: {
-            personId: '$personId',
-            weeklycommittedHours: '$weeklycommittedHours',
-            name: '$name',
-            role: '$role',
-          },
-          totalSeconds: {
-            $sum: '$totalSeconds',
-          },
-          tangibletime: {
-            $sum: '$tangibletime',
-          },
-        },
-      },
-      {
-        $project: {
-          _id: 0,
-          personId: '$_id.personId',
-          name: '$_id.name',
-          weeklycommittedHours: '$_id.weeklycommittedHours',
-          totaltime_hrs: {
-            $divide: ['$totalSeconds', 3600],
-          },
-          totaltangibletime_hrs: {
-            $divide: ['$tangibletime', 3600],
-          },
-          role: '$_id.role',
-        },
-      },
-      {
-        $lookup: {
-          from: 'tasks',
-          localField: 'personId',
-          foreignField: 'resources.userID',
-          as: 'tasks',
-        },
-      },
-      {
-        $project: {
-          tasks: {
-            resources: {
-              profilePic: 0,
-            },
-          },
-        },
-      },
-      {
-        $unwind: {
-          path: '$tasks',
-          preserveNullAndEmptyArrays: true,
-        },
-      },
-      {
-        $lookup: {
-          from: 'wbs',
-          localField: 'tasks.wbsId',
-          foreignField: '_id',
-          as: 'projectId',
-        },
-      },
-      {
-        $addFields: {
-          'tasks.projectId': {
-            $cond: [
-              { $ne: ['$projectId', []] },
-              { $arrayElemAt: ['$projectId', 0] },
-              '$tasks.projectId',
-            ],
-          },
-        },
-      },
-      {
-        $project: {
-          projectId: 0,
-          tasks: {
-            projectId: {
-              _id: 0,
-              isActive: 0,
-              modifiedDatetime: 0,
-              wbsName: 0,
-              createdDatetime: 0,
-              __v: 0,
-            },
-          },
-        },
-      },
-      {
-        $addFields: {
-          'tasks.projectId': '$tasks.projectId.projectId',
-        },
-      },
-      {
-        $lookup: {
-          from: 'taskNotifications',
-          localField: 'tasks._id',
-          foreignField: 'taskId',
-          as: 'tasks.taskNotifications',
-        },
-      },
-      {
-        $group: {
-          _id: '$personId',
-          tasks: {
-            $push: '$tasks',
-          },
-          data: {
-            $first: '$$ROOT',
-          },
-        },
-      },
-      {
-        $addFields: {
-          'data.tasks': {
-            $filter: {
-              input: '$tasks',
-              as: 'task',
-              cond: { $ne: ['$$task', {}] },
-            },
-          },
-        },
-      },
-      {
-        $replaceRoot: {
-          newRoot: '$data',
-        },
-      },
-    ]);
+        personId: { $in: teamMemberIds }
+      });
+  
+      let timeEntryByPerson = {}
+      timeEntries.map((timeEntry)=>{
+          
+        let personIdStr = timeEntry.personId.toString();
+  
+        if(timeEntryByPerson[personIdStr]==null) 
+           timeEntryByPerson[personIdStr] = {tangibleSeconds:0,intangibleSeconds:0,totalSeconds:0};
+  
+        if (timeEntry.isTangible === true) {
+          timeEntryByPerson[personIdStr].tangibleSeconds += timeEntry.totalSeconds;
+        } 
+        timeEntryByPerson[personIdStr].totalSeconds += timeEntry.totalSeconds;
+      })
+
+      const teamMemberTasks = await Task.find({"resources.userID" : {$in : teamMemberIds }}, { 'resources.profilePic': 0 })
+      .populate( {
+        path: 'wbsId',
+        select: 'projectId',
+      })
+      const teamMemberTaskIds = teamMemberTasks.map(task => task._id);
+      const teamMemberTaskNotifications = await TaskNotification.find({"taskId" : {$in : teamMemberTaskIds }})
+
+      const taskNotificationByTaskNdUser = []  
+      teamMemberTaskNotifications.map(teamMemberTaskNotification => {
+
+        let taskIdStr = teamMemberTaskNotification.taskId.toString();
+        let userIdStr = teamMemberTaskNotification.userId.toString();
+        let taskNdUserID = taskIdStr+","+userIdStr;
+
+        if(taskNotificationByTaskNdUser[taskNdUserID]) {
+          taskNotificationByTaskNdUser[taskNdUserID].push(teamMemberTaskNotification)
+        }
+        else{
+          taskNotificationByTaskNdUser[taskNdUserID] = [teamMemberTaskNotification]
+        }
+
+      })
+      
+      const taskByPerson = [] 
+      
+      teamMemberTasks.map(teamMemberTask => {
+
+       let projId = teamMemberTask.wbsId?.projectId;
+       let _teamMemberTask = {...teamMemberTask._doc}
+       _teamMemberTask.projectId = projId;
+       let taskIdStr = _teamMemberTask._id.toString();
+
+         teamMemberTask.resources.map(resource => {
+            
+            let resourceIdStr = resource.userID.toString();
+            let taskNdUserID = taskIdStr+","+resourceIdStr;
+            _teamMemberTask.taskNotifications = taskNotificationByTaskNdUser[taskNdUserID] || []
+            if(taskByPerson[resourceIdStr]) {
+              taskByPerson[resourceIdStr].push(_teamMemberTask)
+            }
+            else{
+              taskByPerson[resourceIdStr] = [_teamMemberTask]
+            }
+        })
+      })
+
+      
+    let teamMemberTasksData = [];
+    teamMembers.map((teamMember)=>{
+        let obj = {
+          personId : teamMember._id,
+          role : teamMember.role,
+          name : teamMember.firstName + ' ' + teamMember.lastName,
+          weeklycommittedHours : teamMember.weeklycommittedHours,
+          totaltangibletime_hrs : ((timeEntryByPerson[teamMember._id.toString()]?.tangibleSeconds / 3600) || 0),
+          totaltime_hrs : ((timeEntryByPerson[teamMember._id.toString()]?.totalSeconds / 3600) || 0),
+          tasks : taskByPerson[teamMember._id.toString()] || []
+        }
+        teamMemberTasksData.push(obj);
+    })
+
+
+    return teamMemberTasksData;
+      
+
+    // return myteam.aggregate([
+    //   {
+    //     $match: {
+    //       _id: userId,
+    //     },
+    //   },
+    //   {
+    //     $unwind: '$myteam',
+    //   },
+    //   {
+    //     $project: {
+    //       _id: 0,
+    //       personId: '$myteam._id',
+    //       name: '$myteam.fullName',
+    //       role: 1,
+    //     },
+    //   },
+    //   // have personId, name, role
+    //   {
+    //     $lookup: {
+    //       from: 'userProfiles',
+    //       localField: 'personId',
+    //       foreignField: '_id',
+    //       as: 'persondata',
+    //     },
+    //   },
+    //   {
+    //     $match: {
+    //       // dashboard tasks user roles hierarchy
+    //       $or: [
+    //         {
+    //           role: { $in: ['Owner', 'Core Team'] },
+    //         },
+    //         {
+    //           $and: [
+    //             {
+    //               role: 'Administrator',
+    //             },
+    //             { 'persondata.0.role': { $nin: ['Owner', 'Administrator'] } },
+    //           ],
+    //         },
+    //         {
+    //           $and: [
+    //             {
+    //               role: { $in: ['Manager', 'Mentor'] },
+    //             },
+    //             {
+    //               'persondata.0.role': {
+    //                 $nin: ['Manager', 'Mentor', 'Core Team', 'Administrator', 'Owner'],
+    //               },
+    //             },
+    //           ],
+    //         },
+    //         { 'persondata.0._id': userId },
+    //         { 'persondata.0.role': 'Volunteer' },
+    //         { 'persondata.0.isVisible': true },
+    //       ],
+    //     },
+    //   },
+    //   {
+    //     $project: {
+    //       personId: 1,
+    //       name: 1,
+    //       weeklycommittedHours: {
+    //         $sum: [
+    //           {
+    //             $arrayElemAt: ['$persondata.weeklycommittedHours', 0],
+    //           },
+    //           {
+    //             $ifNull: [{ $arrayElemAt: ['$persondata.missedHours', 0] }, 0],
+    //           },
+    //         ],
+    //       },
+    //       role: 1,
+    //     },
+    //   },
+    //   {
+    //     $lookup: {
+    //       from: 'timeEntries',
+    //       localField: 'personId',
+    //       foreignField: 'personId',
+    //       as: 'timeEntryData',
+    //     },
+    //   },
+    //   {
+    //     $project: {
+    //       personId: 1,
+    //       name: 1,
+    //       weeklycommittedHours: 1,
+    //       timeEntryData: {
+    //         $filter: {
+    //           input: '$timeEntryData',
+    //           as: 'timeentry',
+    //           cond: {
+    //             $and: [
+    //               {
+    //                 $gte: ['$$timeentry.dateOfWork', pdtstart],
+    //               },
+    //               {
+    //                 $lte: ['$$timeentry.dateOfWork', pdtend],
+    //               },
+    //             ],
+    //           },
+    //         },
+    //       },
+    //       role: 1,
+    //     },
+    //   },
+    //   {
+    //     $unwind: {
+    //       path: '$timeEntryData',
+    //       preserveNullAndEmptyArrays: true,
+    //     },
+    //   },
+    //   {
+    //     $project: {
+    //       personId: 1,
+    //       name: 1,
+    //       weeklycommittedHours: 1,
+    //       totalSeconds: {
+    //         $cond: [
+    //           {
+    //             $gte: ['$timeEntryData.totalSeconds', 0],
+    //           },
+    //           '$timeEntryData.totalSeconds',
+    //           0,
+    //         ],
+    //       },
+    //       isTangible: {
+    //         $cond: [
+    //           {
+    //             $gte: ['$timeEntryData.totalSeconds', 0],
+    //           },
+    //           '$timeEntryData.isTangible',
+    //           false,
+    //         ],
+    //       },
+    //       role: 1,
+    //     },
+    //   },
+    //   {
+    //     $addFields: {
+    //       tangibletime: {
+    //         $cond: [
+    //           {
+    //             $eq: ['$isTangible', true],
+    //           },
+    //           '$totalSeconds',
+    //           0,
+    //         ],
+    //       },
+    //     },
+    //   },
+    //   {
+    //     $group: {
+    //       _id: {
+    //         personId: '$personId',
+    //         weeklycommittedHours: '$weeklycommittedHours',
+    //         name: '$name',
+    //         role: '$role',
+    //       },
+    //       totalSeconds: {
+    //         $sum: '$totalSeconds',
+    //       },
+    //       tangibletime: {
+    //         $sum: '$tangibletime',
+    //       },
+    //     },
+    //   },
+    //   {
+    //     $project: {
+    //       _id: 0,
+    //       personId: '$_id.personId',
+    //       name: '$_id.name',
+    //       weeklycommittedHours: '$_id.weeklycommittedHours',
+    //       totaltime_hrs: {
+    //         $divide: ['$totalSeconds', 3600],
+    //       },
+    //       totaltangibletime_hrs: {
+    //         $divide: ['$tangibletime', 3600],
+    //       },
+    //       role: '$_id.role',
+    //     },
+    //   },
+    //   {
+    //     $lookup: {
+    //       from: 'tasks',
+    //       localField: 'personId',
+    //       foreignField: 'resources.userID',
+    //       as: 'tasks',
+    //     },
+    //   },
+    //   {
+    //     $project: {
+    //       tasks: {
+    //         resources: {
+    //           profilePic: 0,
+    //         },
+    //       },
+    //     },
+    //   },
+    //   {
+    //     $unwind: {
+    //       path: '$tasks',
+    //       preserveNullAndEmptyArrays: true,
+    //     },
+    //   },
+    //   {
+    //     $lookup: {
+    //       from: 'wbs',
+    //       localField: 'tasks.wbsId',
+    //       foreignField: '_id',
+    //       as: 'projectId',
+    //     },
+    //   },
+    //   {
+    //     $addFields: {
+    //       'tasks.projectId': {
+    //         $cond: [
+    //           { $ne: ['$projectId', []] },
+    //           { $arrayElemAt: ['$projectId', 0] },
+    //           '$tasks.projectId',
+    //         ],
+    //       },
+    //     },
+    //   },
+    //   {
+    //     $project: {
+    //       projectId: 0,
+    //       tasks: {
+    //         projectId: {
+    //           _id: 0,
+    //           isActive: 0,
+    //           modifiedDatetime: 0,
+    //           wbsName: 0,
+    //           createdDatetime: 0,
+    //           __v: 0,
+    //         },
+    //       },
+    //     },
+    //   },
+    //   {
+    //     $addFields: {
+    //       'tasks.projectId': '$tasks.projectId.projectId',
+    //     },
+    //   },
+    //   {
+    //     $lookup: {
+    //       from: 'taskNotifications',
+    //       localField: 'tasks._id',
+    //       foreignField: 'taskId',
+    //       as: 'tasks.taskNotifications',
+    //     },
+    //   },
+    //   {
+    //     $group: {
+    //       _id: '$personId',
+    //       tasks: {
+    //         $push: '$tasks',
+    //       },
+    //       data: {
+    //         $first: '$$ROOT',
+    //       },
+    //     },
+    //   },
+    //   {
+    //     $addFields: {
+    //       'data.tasks': {
+    //         $filter: {
+    //           input: '$tasks',
+    //           as: 'task',
+    //           cond: { $ne: ['$$task', {}] },
+    //         },
+    //       },
+    //     },
+    //   },
+    //   {
+    //     $replaceRoot: {
+    //       newRoot: '$data',
+    //     },
+    //   },
+    // ]);
   };
   const getTasksForSingleUser = function (userId) {
     const pdtstart = moment()

--- a/src/helpers/taskHelper.js
+++ b/src/helpers/taskHelper.js
@@ -15,6 +15,7 @@ const taskHelper = function () {
     const userById = await userProfile.findOne({ _id: userid , isActive:true}, {role:1,firstName:1, lastName:1, role:1, isVisible:1, weeklycommittedHours:1, weeklySummaries:1})
                     .then((res)=>{ return res;  }).catch((e)=>{});
 
+                    
     if(userById==null) return null;
     const userRole = userById.role;
 


### PR DESCRIPTION
# Description
This PR is about the Leaderboard api fix and Team Member Tasks api fix. 

## Related PRS (if any):
To test this backend PR you need to checkout the development frontend branch.

## Main changes explained:
- The existing query for leaderboard and teamMemberTasks failed due to heavy load on the aggregation pipeline. Re wrote the queries without aggregation.

## How to test:
1. check into current branch
2. do `npm run build` and `npm run start` to run this PR locally
3. Open development branch on front end
4. Test if the leaderboard data is properly being displayed based on user role 
5. Test if the tasks of team members are being displayed properly based on the user role
6. Owner and Core Team can view all active users
7. Admin can view all active users except Owner and Core Team
8. Other can view their team members

## Screenshots or videos of changes:

[Untitled_ Jan 03,2024 2_37 PM.webm](https://github.com/OneCommunityGlobal/HGNRest/assets/65274029/36a48724-f766-4fda-bb1d-2fc2fbff3a1a)

<img width="407" alt="image" src="https://github.com/OneCommunityGlobal/HGNRest/assets/65274029/bf09b412-665f-488c-81e5-c7f3f39179b4">
<img width="530" alt="image" src="https://github.com/OneCommunityGlobal/HGNRest/assets/65274029/ecad3638-01e9-4c43-9355-822fbb91c806">





