### PR TITLE
Shengwei - Fix Bug: Badge Earned Date Not Updated Correctly When Badge Count Decreases

### DIFF
--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -47,8 +47,15 @@ const badgeController = function (Badge) {
 
   const fillEarnedDateToMatchCount = (earnedDate, count) => {
     const result = [...earnedDate];
-    while (result.length < count) {
+    if (result.length > count) {
+      while (result.length >= count) {
+        result.shift();
+      }
       result.push(formatDate());
+    } else if (result.length < count) {
+      while (result.length < count) {
+        result.push(formatDate());
+      }
     }
     return result;
   };


### PR DESCRIPTION
# Description
This PR is closed. We have a new functional requirement for the badge feature in the backend, which is covered in [PR703](https://github.com/OneCommunityGlobal/HGNRest/pull/703)
- Modify the assign badges function to update the earned date when the badge count decreases.  
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/69882989/c7971c17-7f1a-494f-86c5-e9852d729726) 

## Related PRS (if any):
No related PR. 

## Main changes explained:
 - Update file src/controllers/badgeController.js for including new earned date transformation.

## How to test:
1. check into the current branch and the latest frontend development branch 
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log in as an admin user
5. go to view profile → select feature → 
6. Update the badge count to a lower count 
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/69882989/7917d82b-2d9a-4838-801f-eccb4b74d1ae)
7. refresh the page and verify the new earned date match with the new badge count.
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/69882989/0c06236a-dedd-4e97-98ce-724765221928)

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
