### PR TITLE
Jay - Edit Header Message Permission Back End

### DIFF
--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -54,8 +54,13 @@ const badgeController = function (Badge) {
   };
 
   const assignBadges = async function (req, res) {
-    if (!(await hasPermission(req.body.requestor, 'assignBadges'))) {
-      res.status(403).send('You are not authorized to assign badges.');
+    if (
+      !(
+        (await hasPermission(req.body.requestor, "assignBadges")) ||
+        (await hasPermission(req.body.requestor, "modifyBadgeAmount"))
+      )
+    ) {
+      res.status(403).send("You are not authorized to assign badges.");
       return;
     }
 

--- a/src/controllers/ownerMessageController.js
+++ b/src/controllers/ownerMessageController.js
@@ -1,3 +1,5 @@
+const hasPermission = require("../utilities/permissions");
+
 const ownerMessageController = function (OwnerMessage) {
   const getOwnerMessage = async function (req, res) {
     try {
@@ -15,7 +17,10 @@ const ownerMessageController = function (OwnerMessage) {
   };
 
   const updateOwnerMessage = async function (req, res) {
-    if (req.body.requestor.role !== 'Owner') {
+    
+    const canEditHeaderMessage = req.body.requestor.permissions.frontPermissions.includes('editHeaderMessage');
+    
+    if (req.body.requestor.role !== 'Owner' && !canEditHeaderMessage) {
       res.status(403).send('You are not authorized to create messages!');
     }
     const { isStandard, newMessage } = req.body;

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -236,7 +236,7 @@ const userProfileController = function (UserProfile) {
     const isRequestorAuthorized = !!(
       canRequestorUpdateUser(req.body.requestor.requestorId, userid) && (
         await hasPermission(req.body.requestor, 'putUserProfile')
-        || req.body.requestor.requestorId === userid
+        || (await hasPermission(req.body.requestor, "modifyBadgeAmount")) || req.body.requestor.requestorId === userid
       )
     );
 
@@ -330,7 +330,7 @@ const userProfileController = function (UserProfile) {
           // If their last update was made today, remove that
           const lasti = record.weeklycommittedHoursHistory.length - 1;
           const lastChangeDate = moment(
-            record.weeklycommittedHoursHistory[lasti].dateChanged,
+          record.weeklycommittedHoursHistory[lasti].dateChanged,
           );
           const now = moment();
 


### PR DESCRIPTION
# Description
A user with a 'editHeaderMessage' permission is now able to access and edit the header. 

## Related PRS (if any):
To test this backend PR you need to checkout the [#]() frontend PR.
…

## Main changes explained:
- Add permission logic for users to be able to access and edit the header message.
…

## How to test:
1. check into current branch
2. do `npm install`, `npm run build` and `npm run start` to run this PR locally
3. Clear site data/cache
