### PR TITLE
Jay - Modify Task X on Dashboard Permission

### DIFF
--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -712,7 +712,7 @@ const taskController = function (Task) {
   };
 
   const updateTask = async (req, res) => {
-    if (!(await hasPermission(req.body.requestor, 'updateTask'))) {
+    if (!(await hasPermission(req.body.requestor, 'updateTask') || await hasPermission(req.body.requestor, 'deleteDashboardTask'))) {
       res.status(403).send({ error: 'You are not authorized to update Task.' });
       return;
     }


### PR DESCRIPTION
# Description
A user with a 'deleteDashboardTask' permission is now able to view X button under task name on dashboard.

## Related PRS (if any):
To test this backend PR you need to checkout the [#1831](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1831) frontend PR.
…

## Main changes explained:
- Add controller logic so that once the user with the deleteDashboardTask permission is able to successfully update the user and see the X button under task name on dashboard.
…

## How to test:
1. check into current branch
2. do `npm install`, `npm run build` and `npm run start` to run this PR locally
3. Clear site data/cache
