### PR TITLE
Jay - Edit Time Entry Description Permission 

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -189,9 +189,10 @@ const timeEntrycontroller = function (TimeEntry) {
     const isForAuthUser = personId === req.body.requestor.requestorId;
     const isSameDayTimeEntry = moment().tz('America/Los_Angeles').format('YYYY-MM-DD') === newDateOfWork;
     const canEdit = (await hasPermission(req.body.requestor, 'editTimeEntry')) || (isForAuthUser && isSameDayTimeEntry);
+    const canEditTimeEntryDescription = await hasPermission(req.body.requestor, 'editTimeEntryDescription');
 
-    if (!canEdit) {
-      const error = 'Unauthorized request';
+    if (!(canEdit || canEditTimeEntryDescription)) {
+      const error = "Unauthorized request";
       return res.status(403).send({ error });
     }
 
@@ -369,7 +370,6 @@ const timeEntrycontroller = function (TimeEntry) {
     const isInvalid = !req.body.dateOfWork
       || !moment(req.body.dateOfWork).isValid()
       || !req.body.timeSpent;
-
     const returnErr = (result) => {
       result.status(400).send({ error: 'Bad request' });
     };


### PR DESCRIPTION
# Description
A user with a 'editTimeEntryDescription' permission is now able to see the edit button on another user's dashboard and edit it properly.

## Related PRS (if any):
To test this backend PR you need to checkout the [#1859](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1859) frontend PR.
…

## Main changes explained:
- Add controller logic so that the user with the permission has authorization to save the changes.
…

## How to test:
1. check into current branch
2. do `npm install`, `npm run build` and `npm run start` to run this PR locally
3. Clear site data/cache
