### PR TITLE
add condictional logic to controller

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -269,8 +269,9 @@ const userProfileController = function (UserProfile) {
         || req.body.requestor.requestorId === userid
       )
     );
+    const canUserToggleInvisibility = await hasPermission(req.body.requestor, 'toggleInvisibility');
+    if (!isRequestorAuthorized && !canUserToggleInvisibility) {
 
-    if (!isRequestorAuthorized) {
       res.status(403).send('You are not authorized to update this user');
       return;
     }

--- a/src/utilities/createInitialPermissions.js
+++ b/src/utilities/createInitialPermissions.js
@@ -48,6 +48,7 @@ const permissionsRoles = [
       'updatePassword',
       'deleteUserProfile',
       'infringementAuthorizer',
+      'toggleInvisibility',
       // WBS
       'postWbs',
       'deleteWbs',
@@ -166,6 +167,7 @@ const permissionsRoles = [
       'addDeleteEditOwners',
       'putUserProfilePermissions',
       'changeUserStatus',
+      'toggleInvisibility',
       'seeBadges',
       'assignBadges',
       'createBadges',


### PR DESCRIPTION
# Description
A user with a 'toggleInvisibility' permission is now able to manipulate the visible/invisible toggle on other users' as well as his/her own profile page under teams tab. 

## Related PRS (if any):
To test this backend PR you need to checkout the [#1787](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1787) frontend PR.
…

## Main changes explained:
- Add permission logic for users to be able to access the visibility column.
…

## How to test:
1. check into current branch
2. do `npm install`, `npm run build` and `npm run start` to run this PR locally
3. Clear site data/cache
