### PR TITLE
Yubo- Fix-define "coreTeamExtraHour" for PR673

### DIFF
--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -423,6 +423,9 @@ const userHelper = function () {
             { new: true },
           );
         }
+        // No extra hours is needed if blue squares isn't over 5.
+        // length +1 is because new infringement hasn't been created at this stage.
+        const coreTeamExtraHour =  Math.max(0,(oldInfringements.length +1) - 5)
 
         const utcStartMoment = moment(pdtStartOfLastWeek).add(1, 'second');
           const utcEndMoment = moment(pdtStartOfLastWeek).subtract(1, 'second');


### PR DESCRIPTION
# This is a hotfix for PR #673 
# Description
<img width="848" alt="Screenshot 2023-12-29 at 21 37 54" src="https://github.com/OneCommunityGlobal/HGNRest/assets/57503876/17dbb710-0cc8-4e11-9a1e-9a98495f16f8">

The reason of doing this is that **Core Team** members need to bring their missed hours to next week, otherwise they get another blue square. Now it shows the hours they logged, the required hours each week and the missed hours they have. 

## Main changes explained:
- Add an extra description in the Core Team's email body, so it now tells receiver if there will be extra hours.


## How to test:
### Setup the Google Oauth2 so that you will receive the email as expected. 
1. If you already did, make sure change `refresh token`.
2. If you haven't, I copied from other similar test so you know how to set up:
To send an email using the Gmail API with OAuth2 and nodemailer, follow the video below and set it up.
https://www.youtube.com/watch?v=-rcRf7yswfM&t=10s&ab_channel=MafiaCodes

Make sure you fill in the these variable values from the above setup in the `.env` file of the backend.
REACT_APP_EMAIL =
REACT_APP_EMAIL_CLIENT_ID =
REACT_APP_EMAIL_CLIENT_SECRET =
REACT_APP_EMAIL_REFRESH_TOKEN =
REACT_APP_EMAIL_CLIENT_REDIRECT_URI = https://developers.google.com/oauthplayground
sendEmail = true

### How to test this
1. check into current branch
2. do `npm run build` and `npm start` to run this PR locally. **Firstly choose either 3 or 4**
3. Modify the `userProfileJobs.js` to run the CRON job every minute as below, comment out unnecessary function to save time.
<img width="720" alt="Screenshot 2023-12-29 at 21 49 40" src="https://github.com/OneCommunityGlobal/HGNRest/assets/57503876/d39b477b-1411-473a-8ed7-abb2f1e5098d">

4. **(Alternative Postman way) Skip if you've already done 3:** if you don't like changing CRON job like shown above, you can use Postman and create a test function in `userProfileController.js` and create another specific router for test only. Remember to login first to get token. You can refer PR #313 for how to use this way.
<img width="682" alt="Screenshot 2023-12-29 at 21 50 55" src="https://github.com/OneCommunityGlobal/HGNRest/assets/57503876/3e98fb80-f993-4dd3-950c-cbbab313b922">
<img width="644" alt="Screenshot 2023-12-23 at 23 50 22" src="https://github.com/OneCommunityGlobal/HGNRest/assets/57503876/51a42021-1fbe-41db-a991-57a9b37ca53a">

5. In userHelper file, you can modify to search only accounts you created to test: see example 
<img width="431" alt="Screenshot 2023-12-29 at 21 15 02" src="https://github.com/OneCommunityGlobal/HGNRest/assets/57503876/81d8c557-742d-466d-9720-60bb82ad03f2">

6. You can log some time entries in previous week for the Core Team accounts you want to test. So the numbers in the email will change.
7. Verify your Core Team accounts email receive the email in the new format, see below.
8. Veriy that when **Blue Suquares** <= 5, there's no extra hours. More **Blue Suquares** above 5, more hours will be added. For example, 6th blue square will add 1 extra hours, 7th will add 2 hours, etc.

## Screenshots or videos of changes:
<img width="1522" alt="Screenshot 2023-12-29 at 21 56 31" src="https://github.com/OneCommunityGlobal/HGNRest/assets/57503876/34b11537-fb7d-48f1-a1d0-37858f553633">


## Note:
# 1. Only Core Team accounts get this new blue squares email
# 2. Remember in the Google Oauth Playground, follow the video carefully to setup.
# 3. If you modify the userHelper.js, make sure you add fistName and lastName like what I did in the screenshot.
