### PR TITLE
Shengwei Hotfix PR703 

### DIFF
--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -86,6 +86,7 @@ const badgeController = function (Badge) {
           if (element.count < 1) {
             throw new Error('Badge count should be greater than 0.');
           }
+          return element;
         });
       } catch (err) {
         logger.logException(`Internal Error: Badge Collection. ${err.message} User ID: ${userToBeAssigned} Badge Collection: ${JSON.stringify(req.body.badgeCollection)}`);

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -985,18 +985,21 @@ const userHelper = function () {
         if (!recordToUpdate) {
           throw new Error('Badge not found');
         }
+        // If the count is the same, do nothing
+        if (recordToUpdate.count === count) {
+          return;
+        }
         const copyOfEarnedDate = recordToUpdate.earnedDate;
-        if (copyOfEarnedDate.length < count) {
-          // if the EarnedDate count is less than the new count, add a earned date to the end of the collection
-          while (copyOfEarnedDate.length < count) {
+        // Update: We refrain from automatically correcting the mismatch problem as we intend to preserve the original
+        // earned date even when a badge is deleted. This approach ensures that a record of badges earned is maintained,
+        // preventing oversight of any mismatches caused by bugs.
+        if (recordToUpdate.count < count) {
+          let dateToAdd = count - recordToUpdate.count;
+        // if the EarnedDate count is less than the new count, add a earned date to the end of the collection
+          while (dateToAdd > 0) {
             copyOfEarnedDate.push(earnedDateBadge());
+            dateToAdd -= 1;
           }
-        } else {
-          // if the EarnedDate count is greater than the new count, remove the oldest earned date of the collection until it matches the new count - 1
-          while (copyOfEarnedDate.length >= count) {
-            copyOfEarnedDate.shift();
-          }
-          copyOfEarnedDate.push(earnedDateBadge());
         }
         newEarnedDate = [...copyOfEarnedDate];
         userProfile.updateOne(
@@ -1006,6 +1009,7 @@ const userHelper = function () {
               'badgeCollection.$.count': count,
               'badgeCollection.$.lastModified': Date.now().toString(),
               'badgeCollection.$.earnedDate': newEarnedDate,
+              'badgeCollection.$.hasBadgeDeletionImpact': recordToUpdate.count > count, // badge deletion impact set to true if the new count is less than the old count
             },
           },
           (err) => {

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -77,6 +77,7 @@ const userProfileSchema = new Schema({
       count: { type: Number, default: 0 },
       earnedDate: { type: Array, default: [] },
       lastModified: { type: Date, required: true, default: new Date()},
+      hasBadgeDeletionImpact: { type: Boolean, default: false },
       featured: {
         type: Boolean,
         required: true,


### PR DESCRIPTION
# Description
This PR fixes an issue caused by [PR703](https://github.com/OneCommunityGlobal/HGNRest/pull/703) that leads to a blank page after the badge assignment.

Issue: [Video](https://highest-good.slack.com/archives/D06K64HM97Z/p1708563007774419)

PR1830 + PR703 has been reverted in the development branch

## Related PRS (if any):
This backend PR is related to the #[1981](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1981) fronted PR.

## Main changes explained:
- Update code in manual/user badge assignment and automatic weekly badge assignment to accommodate new changes - keep earned date when badge count decreases.
- Update badge collection data model


## How to test:
1. check into the current branch and frontend branch #[1981](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/1981) 
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks→ task→…
6. verify function “A” (feel free to include screenshot here)

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
