### PR TITLE
Roberto-fixes logic to push to the edit time entry history

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -254,7 +254,8 @@ const timeEntrycontroller = function (TimeEntry) {
         && timeEntry.totalSeconds !== newTotalSeconds
         && timeEntry.isTangible
         && isForAuthUser
-        && !(await hasPermission(req.body.requestor, 'editTimeEntry'))
+        && (await hasPermission(req.body.requestor, 'editTimeEntry'))
+        && (req.body.requestor.role !== 'Owner' && req.body.requestor.role !== 'Administrator')
       ) {
         const requestor = await UserProfile.findById(
           req.body.requestor.requestorId,


### PR DESCRIPTION
# Description
<img width="1225" alt="Screenshot 2024-03-12 at 10 06 50 PM" src="https://github.com/OneCommunityGlobal/HGNRest/assets/117053202/d8b2fe4c-0792-4642-b2c6-7a07e406adda">



## Related PRS (if any):
Use latest frontend branch


## Main changes explained:
- turned the !(hasPermission()) function into (hasPermission()), reason is if a user does have permission to edit time entry history it should enter the if statement block.
- Added a check to make sure the requestor role is not an Owner or Admin, Admins and Owner's are allowed to edit time entries without having to get marked the time entry edit history which results in blue squares. So for other roles that have the permission to edit time entries are because they have the extended permission assigned to them in which case keep track of their editing time history and issue a blue square after 5 times. 

## How to test:
1. check into current branch
2. do `npm install` and `npm run build && npm start` to run this PR locally
3. Clear site data/cache
4. log as any non Admin/Owner user with the edit time permission.
5. create a time entry, specifically through the add tangible time entry button on dashboard not through timer. 
6. go to that time entry and edit the time → make sure a confirmation modal pops up.
7. repeat for 5 times until you get issued a blue square → confirm the bluesquare by going to your user profile and seeing the latest issued → confirm the changes on the edit history tab in the user profile page as well
