### PR TITLE
Diego - build: updated husky preparation script for macos and linux users

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "node dist/server.js",
     "dev": "nodemon --exec babel-node src/server.js",
     "serve": "babel-node src/server.js",
-    "prepare": "husky install && chmod ug+x .husky/* && chmod ug+x .git/hooks/*"
+    "prepare-macos-linux": "husky install && chmod ug+x .husky/* && chmod ug+x .git/hooks/*"
   },
   "author": "AK",
   "license": "ISC",


### PR DESCRIPTION
# Description
Updates 'prepare' script in package json to 'prepare-macos-linux' to avoid windows users from failing to perform `npm install`

## Related PRS:

## Main changes explained:
- updates script name to make husky files executable (only needed for macos and linux users)

## How to test:
1. check into current branch
2. do `npm install`
3. npm install should not exit with an error for any operating system.

## Note:
It's an operating system issue. 'prepare' script is run automatically by npm install, and it doesn't throw errors on Linux and MacOS since they share some bash commands, however on windows the chmod command doesn't exist.

For Linux and Mac users doing npm install won't suffice, they will have to run the 'prepare-macos-linux' script separately to benefit from automated linting, testing and running prettier on every commit (need to update backend installation instructions so that all OS users can benefit from automated scripting tools for every commit).

MacOS and Linux OS are special in that they sometimes require to update execute permissions to run some files (in this case binding husky to git hooks) but that's not the case for Windows.

