### PR TITLE
Diego update readme get started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ To clone the code, navigate to the source directory where you want to maintain t
 
 Step2: Run npm install. Best way is to open the code in the editor and open integrated teminal. Run npm install.
 
-Step3: If running on MacOS or Linux, run `npm run prepare`. This will install husky and allow integration with git hooks.
+Step3: If running on MacOS or Linux, run `npm run prepare-macos-linux`. This will install husky and allow integration with git hooks. Windows users don't need and should not run this command.
 
 Step4: Start the app: To start the app, you need to set up several process.env variables. These variables are:  
 user=<user>  

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start": "node dist/server.js",
     "dev": "nodemon --exec babel-node src/server.js",
     "serve": "babel-node src/server.js",
-    "prepare": "husky install && chmod ug+x .husky/* && chmod ug+x .git/hooks/*"
+    "prepare-macos-linux": "husky install && chmod ug+x .husky/* && chmod ug+x .git/hooks/*"
   },
   "author": "AK",
   "license": "ISC",


### PR DESCRIPTION
# Description
Updates readme's get started section to run an additional script for Linux and Macos users. This script installs husky and gives executable permissions (only necessary in Macos and Linux) to husky files. 

## Related PRS:
N/A

## Main changes explained:
N/A

## How to test:
N/A

## Screenshots or videos of changes:

## Note:
Macos and Linux users will have to run the 'prepare-macos-linux' script in after `npm install` to benefit from automated linting, testing and running prettier on every commit.

MacOS and Linux OS are special in that they sometimes require to update execute permissions to run some files (in this case binding husky to git hooks) but that's not the case for Windows.
