### PR TITLE
build: updated .babelrc to exclude test files at build time

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,17 +1,22 @@
 {
-    "presets" : ["@babel/preset-env"],
-    "plugins":
-      ["@babel/plugin-transform-async-to-generator", 
-      ["@babel/plugin-transform-runtime",
-        {
-          "corejs": false,
-          "helpers": true,
-          "regenerator": true,
-          "useESModules": false
-        }
-      ],
-      ["module-resolver", {
+  "presets": ["@babel/preset-env"],
+  "plugins": [
+    "@babel/plugin-transform-async-to-generator",
+    [
+      "@babel/plugin-transform-runtime",
+      {
+        "corejs": false,
+        "helpers": true,
+        "regenerator": true,
+        "useESModules": false
+      }
+    ],
+    [
+      "module-resolver",
+      {
         "root": "./src"
-      }]
+      }
     ]
+  ],
+  "ignore": ["**/*.test.js", "**/*.spec.js"]
 }


### PR DESCRIPTION
# Description
Updates .babelrc to exclude test files from being part of the dist folder when project is built with babel.

## Related PRS:
N/A

## Main changes explained:
- Added "ignore" property to .babelrc file to exclude files containing `test` and `spec` extensions.

## How to test:
1. check into current branch
2. do `npm install`
3. delete the `dist` folder (if there is any `dist` folder in the root of the project
4. do `npm run build`
5. the dist folder should not contain any test files in the controllers and in the routes folders.

## Screenshots or videos of changes:

## Note:
This will help reduce the build bundle as test files are only meant to test the source code before deployment. They have no use in production or development servers.
