### PR TITLE
Fix time off request notification not being sent to the owner

### DIFF
--- a/src/controllers/timeOffRequestController.js
+++ b/src/controllers/timeOffRequestController.js
@@ -82,13 +82,20 @@ const timeOffRequestController = function (TimeOffRequest, Team, UserProfile) {
         _id: { $in: uniqueUserIdsArray },
       });
 
-      const rolesToInclude = ['Manager', 'Mentor', 'Administrator', 'Owner'];
+      const ownerAcc = await UserProfile.find({
+        role: 'Owner',
+      }).select('email').exec();
+
+      const rolesToInclude = ['Manager', 'Mentor', 'Administrator'];
       const userEmails = userProfiles.map((userProfile) => {
         if (rolesToInclude.includes(userProfile.role)) {
           return userProfile.email;
         }
         return null;
-      });
+      }).filter(email => email !== null);
+
+      ownerAcc.forEach(user => userEmails.push(user.email));
+
 
       if (Array.isArray(userEmails) && userEmails.length > 0) {
         userEmails.forEach((email) => {


### PR DESCRIPTION
# Description
This PR addresses the issue of notification emails not being sent to the owner when a user adds or deletes a time off request.

## Screenshots of changes:

![image (3)](https://github.com/OneCommunityGlobal/HGNRest/assets/49083865/6ad96b7f-34b9-4266-854e-895916b57a5c)
