### PR TITLE
Jordy add notificationController unit tests

### DIFF
--- a/requirements/notificationController/createUserNotification.md
+++ b/requirements/notificationController/createUserNotification.md
@@ -1,0 +1,10 @@
+Check mark: ✅
+Cross Mark: ❌
+
+
+# createUserNotifications
+
+
+## Positive case
+
+1. ✅ Returns status 200 with notification data when a valid userId is provided and is found.

--- a/requirements/notificationController/deleteUserNotification.md
+++ b/requirements/notificationController/deleteUserNotification.md
@@ -6,11 +6,11 @@ Cross Mark: ❌
 
 ## Negative case
 
-1. ❌ Returns a 400 status error if the provided notification ID is not valid.
-2. ❌ Returns a 400 status error if no notification is found with the provided ID.
-3. ❌ Returns a  403 status error with a message if the requestor’s ID does not match the recipient ID.
-4. ❌ Returns a  400 status error if an error occurs during the `.remove()` operation.
+1. ✅ Returns a 400 status error if the provided notification ID is not valid.
+2. ✅ Returns a 400 status error if no notification is found with the provided ID.
+3. ✅ Returns a  403 status error with a message if the requestor’s ID does not match the recipient ID.
+4. ✅ Returns a  400 status error if an error occurs during the `.remove()` operation.
 
 ## Positive case
 
-1. ❌ Returns a 200 status code with a success message when notification is succesfully deleted.
+1. ✅ Returns a 200 status code with a success message when notification is successfully deleted.

--- a/requirements/notificationController/deleteUserNotification.md
+++ b/requirements/notificationController/deleteUserNotification.md
@@ -1,0 +1,16 @@
+Check mark: ✅
+Cross Mark: ❌
+
+
+# Delete User Notifications
+
+## Negative case
+
+1. ❌ Returns a 400 status error if the provided notification ID is not valid.
+2. ❌ Returns a 400 status error if no notification is found with the provided ID.
+3. ❌ Returns a  403 status error with a message if the requestor’s ID does not match the recipient ID.
+4. ❌ Returns a  400 status error if an error occurs during the `.remove()` operation.
+
+## Positive case
+
+1. ❌ Returns a 200 status code with a success message when notification is succesfully deleted.

--- a/requirements/notificationController/getUserNotification.md
+++ b/requirements/notificationController/getUserNotification.md
@@ -1,0 +1,14 @@
+Check mark: ✅
+Cross Mark: ❌
+
+
+# GET User Notifications
+
+## Positive case
+
+1. ❌ Returns status 200 with notification data when a valid userId is provided and is found.
+
+## Negative case
+
+1. ❌ Returns error 400 if the userId is not valid.
+2. ❌ Returns error 400 if there is an error in finding the user.

--- a/requirements/notificationController/getUserNotification.md
+++ b/requirements/notificationController/getUserNotification.md
@@ -10,5 +10,5 @@ Cross Mark: ❌
 
 ## Negative case
 
-1. ❌ Returns error 400 if the userId is not valid.
-2. ❌ Returns error 400 if there is an error in finding the user.
+1. ✅ Returns error 400 if the userId is not valid.
+2. ✅ Returns error 400 if there is an error in finding the user.

--- a/requirements/notificationController/getUserNotification.md
+++ b/requirements/notificationController/getUserNotification.md
@@ -4,11 +4,12 @@ Cross Mark: ❌
 
 # GET User Notifications
 
-## Positive case
-
-1. ✅ Returns status 200 with notification data when a valid userId is provided and is found.
-
 ## Negative case
 
 1. ✅ Returns error 400 if the userId is not valid.
 2. ✅ Returns error 400 if there is an error in finding the user.
+   
+## Positive case
+
+1. ✅ Returns status 200 with notification data when a valid userId is provided and is found.
+

--- a/requirements/notificationController/getUserNotification.md
+++ b/requirements/notificationController/getUserNotification.md
@@ -6,7 +6,7 @@ Cross Mark: ❌
 
 ## Positive case
 
-1. ❌ Returns status 200 with notification data when a valid userId is provided and is found.
+1. ✅ Returns status 200 with notification data when a valid userId is provided and is found.
 
 ## Negative case
 

--- a/src/controllers/notificationController.js
+++ b/src/controllers/notificationController.js
@@ -10,8 +10,12 @@ const notificationController = function (Notification) {
     }
 
     Notification.find({ recipient: userid }, '_id message eventType')
-      .then((results) => { res.status(200).send(results); })
-      .catch((errors) => { res.status(400).send(errors); });
+      .then((results) => {
+        res.status(200).send(results);
+      })
+      .catch((errors) => {
+        res.status(400).send(errors);
+      });
   };
 
   const createUserNotification = function (notification) {
@@ -20,21 +24,27 @@ const notificationController = function (Notification) {
 
   const deleteUserNotification = function (req, res) {
     if (!mongoose.Types.ObjectId.isValid(req.params.notificationId)) {
-      res.status(400).send({ error: 'Bad request' }); return;
+      res.status(400).send({ error: 'Bad request' });
+      return;
     }
 
     Notification.findById(req.params.notificationId)
       .then((result) => {
         // verify is requestor same as assignee
         if (req.body.requestor.requestorId !== result.recipient) {
-          res.status(403).send({ error: 'Unauthroized request' });
+          res.status(403).send({ error: 'Unauthorized request' });
           return;
         }
-        result.remove()
+        result
+          .remove()
           .then(res.status(200).send({ message: 'Deleted notification' }))
-          .catch((error) => { res.status(400).send(error); });
+          .catch((error) => {
+            res.status(400).send(error);
+          });
       })
-      .catch((error) => { res.status(400).send(error); });
+      .catch((error) => {
+        res.status(400).send(error);
+      });
   };
 
   return {

--- a/src/controllers/notificationController.spec.js
+++ b/src/controllers/notificationController.spec.js
@@ -3,11 +3,13 @@ const Notification = require('../models/notification');
 const { mockReq, mockRes, assertResMock } = require('../test');
 
 const makeSut = () => {
-  const { getUserNotifications, createUserNotification } = notificationController(Notification);
+  const { getUserNotifications, createUserNotification, deleteUserNotification } =
+    notificationController(Notification);
 
   return {
     getUserNotifications,
     createUserNotification,
+    deleteUserNotification,
   };
 };
 
@@ -69,6 +71,15 @@ describe('Notification controller tests', () => {
       await flushPromises();
 
       expect(mockNotification.save).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('deleteUserNotification', () => {
+    test('Ensure deleteUserNotification returns 400 if notification ID is not valid', () => {
+      const { deleteUserNotification } = makeSut();
+      mockReq.params.notificationId = 'badnotificationId';
+      const response = deleteUserNotification(mockReq, mockRes);
+      assertResMock(400, { error: 'Bad request' }, response, mockRes);
     });
   });
 });

--- a/src/controllers/notificationController.spec.js
+++ b/src/controllers/notificationController.spec.js
@@ -18,6 +18,7 @@ const flushPromises = () => new Promise(setImmediate);
 describe('Notification controller tests', () => {
   beforeEach(() => {
     mockReq.params.userId = '65cf6c3706d8ac105827bb2e';
+    mockReq.params.notificationId = '507f191e810c19729de860ea';
   });
 
   afterEach(() => {
@@ -61,7 +62,7 @@ describe('Notification controller tests', () => {
   });
 
   describe('createUserNotification', () => {
-    test('Ensures createUserNofication calls on save notification', async () => {
+    test('Ensures createUserNotification calls on save notification', async () => {
       const { createUserNotification } = makeSut();
       const mockNotification = {
         save: jest.fn().mockImplementationOnce(() => Promise.resolve(true)),
@@ -84,12 +85,14 @@ describe('Notification controller tests', () => {
 
     test('Ensures deleteUserNotification returns 400 if any error occurs when finding a notification', async () => {
       const { deleteUserNotification } = makeSut();
-      jest
-        .spyOn(Notification, 'findById')
-        .mockImplementationOnce(() => Promise.reject(new Error('error')));
+
+      const errorMsg = 'Error occurred when finding notification';
+
+      jest.spyOn(Notification, 'findById').mockImplementationOnce(() => Promise.reject(errorMsg));
+
       const response = deleteUserNotification(mockReq, mockRes);
       await flushPromises();
-      assertResMock(400, { error: 'Bad request' }, response, mockRes);
+      assertResMock(400, errorMsg, response, mockRes);
     });
   });
 });

--- a/src/controllers/notificationController.spec.js
+++ b/src/controllers/notificationController.spec.js
@@ -1,0 +1,30 @@
+const notificationController = require('./notificationController');
+const Notification = require('../models/notification');
+const { mockReq, mockRes, assertResMock } = require('../test');
+
+const makeSut = () => {
+  const { getUserNotifications } = notificationController(Notification);
+
+  return {
+    getUserNotifications,
+  };
+};
+
+describe('Notification controller tests', () => {
+  beforeEach(() => {
+    mockReq.params.userId = '65cf6c3706d8ac105827bb2e';
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getUserNotifications', () => {
+    test('Ensures getUserNotifications returns 400 if userId is not valid', () => {
+      const { getUserNotifications } = makeSut();
+      mockReq.params.userId = 'invalidId';
+      const response = getUserNotifications(mockReq, mockRes);
+      assertResMock(400, { error: 'Bad Request' }, response, mockRes);
+    });
+  });
+});

--- a/src/controllers/notificationController.spec.js
+++ b/src/controllers/notificationController.spec.js
@@ -38,5 +38,22 @@ describe('Notification controller tests', () => {
       await flushPromises();
       assertResMock(400, new Error('error'), response, mockRes);
     });
+
+    test('Ensures getUserNotifications returns 200 with notifications for userId if it is valid and is found', async () => {
+      const { getUserNotifications } = makeSut();
+      const notifications = [];
+      const findNotificationMock = jest
+        .spyOn(Notification, 'find')
+        .mockImplementationOnce(() => Promise.resolve(notifications));
+      const response = getUserNotifications(mockReq, mockRes);
+      await flushPromises();
+      expect(findNotificationMock).toHaveBeenCalledWith(
+        {
+          recipient: '65cf6c3706d8ac105827bb2e',
+        },
+        '_id message eventType',
+      );
+      assertResMock(200, notifications, response, mockRes);
+    });
   });
 });

--- a/src/controllers/notificationController.spec.js
+++ b/src/controllers/notificationController.spec.js
@@ -3,10 +3,11 @@ const Notification = require('../models/notification');
 const { mockReq, mockRes, assertResMock } = require('../test');
 
 const makeSut = () => {
-  const { getUserNotifications } = notificationController(Notification);
+  const { getUserNotifications, createUserNotification } = notificationController(Notification);
 
   return {
     getUserNotifications,
+    createUserNotification,
   };
 };
 
@@ -54,6 +55,20 @@ describe('Notification controller tests', () => {
         '_id message eventType',
       );
       assertResMock(200, notifications, response, mockRes);
+    });
+  });
+
+  describe('createUserNotification', () => {
+    test('Ensures createUserNofication calls on save notification', async () => {
+      const { createUserNotification } = makeSut();
+      const mockNotification = {
+        save: jest.fn().mockImplementationOnce(() => Promise.resolve(true)),
+      };
+
+      createUserNotification(mockNotification);
+      await flushPromises();
+
+      expect(mockNotification.save).toHaveBeenCalledWith();
     });
   });
 });

--- a/src/controllers/notificationController.spec.js
+++ b/src/controllers/notificationController.spec.js
@@ -121,5 +121,19 @@ describe('Notification controller tests', () => {
       expect(mockNotification.remove).toHaveBeenCalled();
       assertResMock(200, { message: 'Deleted notification' }, response, mockRes);
     });
+    test('Ensures deleteUserNotification returns 400 on failure to remove notification', async () => {
+      const { deleteUserNotification } = makeSut();
+      const errorMsg = 'Error occurred  when removing notification';
+      const mockNotification = {
+        recipient: '65cf6c3706d8ac105827bb2e',
+        remove: jest.fn().mockRejectedValue(errorMsg),
+      };
+      jest
+        .spyOn(Notification, 'findById')
+        .mockImplementationOnce(() => Promise.resolve(mockNotification));
+      const response = deleteUserNotification(mockReq, mockRes);
+      await flushPromises();
+      assertResMock(400, errorMsg, response, mockRes);
+    });
   });
 });

--- a/src/controllers/notificationController.spec.js
+++ b/src/controllers/notificationController.spec.js
@@ -107,5 +107,19 @@ describe('Notification controller tests', () => {
       await flushPromises();
       assertResMock(403, { error: 'Unauthorized request' }, response, mockRes);
     });
+    test('Ensures deleteUserNotification returns 200 if notification removal is successful', async () => {
+      const { deleteUserNotification } = makeSut();
+      const mockNotification = {
+        recipient: '65cf6c3706d8ac105827bb2e',
+        remove: jest.fn().mockResolvedValue({}),
+      };
+      jest
+        .spyOn(Notification, 'findById')
+        .mockImplementationOnce(() => Promise.resolve(mockNotification));
+      const response = deleteUserNotification(mockReq, mockRes);
+      await flushPromises();
+      expect(mockNotification.remove).toHaveBeenCalled();
+      assertResMock(200, { message: 'Deleted notification' }, response, mockRes);
+    });
   });
 });

--- a/src/controllers/notificationController.spec.js
+++ b/src/controllers/notificationController.spec.js
@@ -94,5 +94,18 @@ describe('Notification controller tests', () => {
       await flushPromises();
       assertResMock(400, errorMsg, response, mockRes);
     });
+    test('Ensures deleteUserNotification returns 403 if recipient ID does match requestor ID', async () => {
+      const { deleteUserNotification } = makeSut();
+      mockReq.body.requestor.requestorId = '65cf6c3706d8ac105827bb2e';
+      const mockNotification = {
+        recipient: 'wrongrecipientId',
+      };
+      jest
+        .spyOn(Notification, 'findById')
+        .mockImplementationOnce(() => Promise.resolve(mockNotification));
+      const response = deleteUserNotification(mockReq, mockRes);
+      await flushPromises();
+      assertResMock(403, { error: 'Unauthorized request' }, response, mockRes);
+    });
   });
 });

--- a/src/controllers/notificationController.spec.js
+++ b/src/controllers/notificationController.spec.js
@@ -75,10 +75,20 @@ describe('Notification controller tests', () => {
   });
 
   describe('deleteUserNotification', () => {
-    test('Ensure deleteUserNotification returns 400 if notification ID is not valid', () => {
+    test('Ensures deleteUserNotification returns 400 if notification ID is not valid', () => {
       const { deleteUserNotification } = makeSut();
       mockReq.params.notificationId = 'badnotificationId';
       const response = deleteUserNotification(mockReq, mockRes);
+      assertResMock(400, { error: 'Bad request' }, response, mockRes);
+    });
+
+    test('Ensures deleteUserNotification returns 400 if any error occurs when finding a notification', async () => {
+      const { deleteUserNotification } = makeSut();
+      jest
+        .spyOn(Notification, 'findById')
+        .mockImplementationOnce(() => Promise.reject(new Error('error')));
+      const response = deleteUserNotification(mockReq, mockRes);
+      await flushPromises();
       assertResMock(400, { error: 'Bad request' }, response, mockRes);
     });
   });

--- a/src/controllers/notificationController.spec.js
+++ b/src/controllers/notificationController.spec.js
@@ -10,6 +10,8 @@ const makeSut = () => {
   };
 };
 
+const flushPromises = () => new Promise(setImmediate);
+
 describe('Notification controller tests', () => {
   beforeEach(() => {
     mockReq.params.userId = '65cf6c3706d8ac105827bb2e';
@@ -25,6 +27,16 @@ describe('Notification controller tests', () => {
       mockReq.params.userId = 'invalidId';
       const response = getUserNotifications(mockReq, mockRes);
       assertResMock(400, { error: 'Bad Request' }, response, mockRes);
+    });
+
+    test('Ensures getUserNotifications returns 400 if userId is valid but finding user fails', async () => {
+      const { getUserNotifications } = makeSut();
+      jest
+        .spyOn(Notification, 'find')
+        .mockImplementationOnce(() => Promise.reject(new Error('error')));
+      const response = getUserNotifications(mockReq, mockRes);
+      await flushPromises();
+      assertResMock(400, new Error('error'), response, mockRes);
     });
   });
 });


### PR DESCRIPTION
# Description

Unit tests for notificationController

## Related PRS (if any):
N/A

## Main changes explained:

- Unit tests for the getUserNotifications endpoint
- Unit tests for the createUserNotifications endpoint
- Unit tests for the deleteUserNotifications endpoint

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. run `npm run test notification`

**If  you want a detailed description you can run `npm run test notification -- --verbose`**


## Screenshots or videos of changes:

![userNotificationControllerUnitTests](https://github.com/OneCommunityGlobal/HGNRest/assets/95154804/391192dd-25f0-4073-b341-eaee79df4ac2)


![deleteUserNotification](https://github.com/OneCommunityGlobal/HGNRest/assets/95154804/9971641d-3cb1-4af2-901c-2fc393cbdb55)

![createUsernotification](https://github.com/OneCommunityGlobal/HGNRest/assets/95154804/21db6bfb-0dce-4c6c-ac8a-33429954930c)


## Note:

When I was working on the unauthorized method, I corrected the spelling on the controller.
