### PR TITLE
Recovery of PR818

### DIFF
--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -13,7 +13,7 @@ const badgeController = function (Badge) {
   const cache = cacheClosure();
 
   const getAllBadges = async function (req, res) {
-    if (!(await helper.hasPermission(req.body.requestor, 'seeBadges'))) {
+    if (!(await helper.hasPermission(req.body.requestor, 'seeBadges')) && !(await helper.hasPermission(req.body.requestor, 'assignBadges'))) {
       res.status(403).send('You are not authorized to view all badge data.');
       return;
     }


### PR DESCRIPTION
# Description
This is the recovery for PR818:https://github.com/OneCommunityGlobal/HGNRest/pull/818

![bug](https://github.com/OneCommunityGlobal/HGNRest/assets/113215317/13b4f5bb-8ee3-4393-8822-7324a578ba7d)


## Related PRS (if any):
This backend PR is related to the [#2089](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2089) frontend PR.

## Main changes explained:
- Update the assigning badge permission
- Fix the bug of assigning badge on other user profile

## How to test:
1. check into current branch
2. do `npm install`, `npm run build` and `npm run start` to run this PR locally.
3. Please adhere to the instructions outlined in the frontend PR.


## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HGNRest/assets/113215317/ad7a4c70-cfb8-4c14-b577-dba6c1b0ac95



## Note:

- If you cannot see other users in the leaderboard, you can use the Owner account to add them to the team.
- If the displayed badges have reached their limit, click "Selected Feature" to check for new badges.
- One possible reason for the badge list not displaying is due to cache. If this occurs, please clear the cache and try again.