### PR TITLE
Jordy fix es6export syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2622,7 +2622,7 @@
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
     "array-includes": {
       "version": "3.1.6",
@@ -4334,7 +4334,7 @@
     "bcryptjs": {
       "version": "2.4.3",
       "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
-      "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms="
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
     },
     "bignumber.js": {
       "version": "9.0.2",
@@ -4460,7 +4460,7 @@
     "buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
     },
     "buffer-from": {
       "version": "1.1.2",
@@ -4713,7 +4713,7 @@
     "clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
     },
     "clone-deep": {
       "version": "4.0.1",
@@ -4841,7 +4841,7 @@
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
     "cookiejar": {
       "version": "2.1.4",
@@ -7073,7 +7073,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "fsevents": {
       "version": "2.3.2",
@@ -7677,7 +7677,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "indent-string": {
@@ -7689,7 +7689,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -8081,7 +8081,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "isobject": {
@@ -9589,7 +9589,7 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "json5": {
@@ -10169,7 +10169,7 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -10180,7 +10180,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w=="
     },
     "micromatch": {
       "version": "4.0.5",
@@ -10547,7 +10547,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "negotiator": {
@@ -10772,7 +10772,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -11540,7 +11540,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "requires": {
         "wrappy": "1"
       }
@@ -11669,7 +11669,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -11690,7 +11690,7 @@
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
     },
     "pend": {
       "version": "1.2.0",
@@ -14041,7 +14041,7 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "throat": {
@@ -14142,7 +14142,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "tsconfig-paths": {
       "version": "3.14.2",
@@ -14405,7 +14405,7 @@
     "url-template": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE="
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="
     },
     "use": {
       "version": "3.1.1",
@@ -14416,12 +14416,12 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="
     },
     "uuid": {
       "version": "3.4.0",
@@ -14473,7 +14473,7 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",
@@ -14505,7 +14505,7 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "whatwg-encoding": {
       "version": "1.0.5",
@@ -14525,7 +14525,7 @@
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -14649,7 +14649,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "write-file-atomic": {
       "version": "3.0.3",

--- a/src/constants/message.js
+++ b/src/constants/message.js
@@ -1,18 +1,24 @@
-export const URL_TO_BLUE_SQUARE_PAGE = 'https://www.onecommunityglobal.org/hands-off-administration-policy'
+const URL_TO_BLUE_SQUARE_PAGE =
+  'https://www.onecommunityglobal.org/hands-off-administration-policy';
 
 // Since the notification banner is blue background, added white color for hyperlink style.
-export const NEW_USER_BLUE_SQUARE_NOTIFICATION_MESSAGE = `
-  <p> Welcome as one of our newest members to the One Community team and family! 
-  Heads up we’ve removed a <a href=${URL_TO_BLUE_SQUARE_PAGE}>“blue square”</a> that 
-  was issued due to not completing your hours and/or summary this past week. The reason we removed 
-  this blue square is because you didn’t have the full week available to complete your volunteer 
+const NEW_USER_BLUE_SQUARE_NOTIFICATION_MESSAGE = `
+  <p> Welcome as one of our newest members to the One Community team and family!
+  Heads up we’ve removed a <a href=${URL_TO_BLUE_SQUARE_PAGE}>“blue square”</a> that
+  was issued due to not completing your hours and/or summary this past week. The reason we removed
+  this blue square is because you didn’t have the full week available to complete your volunteer
   time with us. </p>
-  
-  <p> If you’d like to learn more about this policy and/or blue squares, click here: 
-  <a href=${URL_TO_BLUE_SQUARE_PAGE}> “Blue Square FAQ”</a>  
+
+  <p> If you’d like to learn more about this policy and/or blue squares, click here:
+  <a href=${URL_TO_BLUE_SQUARE_PAGE}> “Blue Square FAQ”</a>
   </p>
-  
+
   <p>Welcome again, we’re glad to have you joining us! </p>
 
   <p>With Gratitude,</br>One Community </p>
   `;
+
+module.exports = {
+  NEW_USER_BLUE_SQUARE_NOTIFICATION_MESSAGE,
+  URL_TO_BLUE_SQUARE_PAGE,
+};

--- a/src/utilities/htmlContentSanitizer.js
+++ b/src/utilities/htmlContentSanitizer.js
@@ -3,6 +3,11 @@ const sanitizeHtml = require('sanitize-html');
 // Please refer to https://www.npmjs.com/package/sanitize-html?activeTab=readme for more information.
 
 // eslint-disable-next-line import/prefer-default-export
-export const cleanHtml = (dirty) => sanitizeHtml(dirty, {
+const cleanHtml = (dirty) =>
+  sanitizeHtml(dirty, {
     allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
-});
+  });
+
+module.exports = {
+  cleanHtml,
+};

--- a/src/utilities/timeUtils.js
+++ b/src/utilities/timeUtils.js
@@ -1,11 +1,11 @@
 const moment = require('moment-timezone');
 
 // converts date to desired format such as Aug-30-2023
-export const formatDateAndTime = date => moment(date).format('MMM-DD-YY, h:mm:ss a');
-export const formatDate = date => moment(date).tz('America/Los_Angeles').format('MMM-DD-YY');
+const formatDateAndTime = (date) => moment(date).format('MMM-DD-YY, h:mm:ss a');
+const formatDate = (date) => moment(date).tz('America/Los_Angeles').format('MMM-DD-YY');
 // converts time to AM/PM format. E.g., '2023-09-21T07:08:09-07:00' becomes '7:08:09 AM'.
-export const formatted_AM_PM_Time = date => moment(date).format('h:mm:ss A');
-export const formatCreatedDate = date => moment(date).format('MM/DD');
+const formattedAmPmTime = (date) => moment(date).format('h:mm:ss A');
+const formatCreatedDate = (date) => moment(date).format('MM/DD');
 
 /**
  * Constants for day of week. Starting from Sunday.
@@ -17,4 +17,13 @@ const DAY_OF_WEEK = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Fr
  * @param {String} utcTs A UTC timestamp String
  * @returns {Number} The day of the week. Starting from Sunday. 0 -> Sunday
  */
-export const getDayOfWeekStringFromUTC = utcTs => moment(utcTs).day();
+const getDayOfWeekStringFromUTC = (utcTs) => moment(utcTs).day();
+
+module.exports = {
+  formatDateAndTime,
+  formatDate,
+  formattedAmPmTime,
+  formatCreatedDate,
+  DAY_OF_WEEK,
+  getDayOfWeekStringFromUTC,
+};

--- a/src/websockets/TimerService/clientsHandler.js
+++ b/src/websockets/TimerService/clientsHandler.js
@@ -4,7 +4,7 @@ const moment = require('moment');
 const Timer = require('../../models/timer');
 const logger = require('../../startup/logger');
 
-export const getClient = async (clients, userId) => {
+const getClient = async (clients, userId) => {
   // In case of there is already a connection that is open for this user
   // for example user open a new connection
   if (!clients.has(userId)) {
@@ -14,26 +14,22 @@ export const getClient = async (clients, userId) => {
       clients.set(userId, timer);
     } catch (e) {
       logger.logException(e);
-      throw new Error(
-        'Something happened when trying to retrieve timer from mongo',
-      );
+      throw new Error('Something happened when trying to retrieve timer from mongo');
     }
   }
   return clients.get(userId);
 };
 
-export const saveClient = async (client) => {
+const saveClient = async (client) => {
   try {
     await Timer.findOneAndUpdate({ userId: client.userId }, client);
   } catch (e) {
     logger.logException(e);
-    throw new Error(
-      `Something happened when trying to save user timer to mongo, Error: ${e}`,
-    );
+    throw new Error(`Something happened when trying to save user timer to mongo, Error: ${e}`);
   }
 };
 
-export const action = {
+const action = {
   START_TIMER: 'START_TIMER',
   PAUSE_TIMER: 'PAUSE_TIMER',
   STOP_TIMER: 'STOP_TIMER',
@@ -119,10 +115,7 @@ const setGoal = (client, msg) => {
 
 const addGoal = (client, msg) => {
   const duration = parseInt(msg.split('=')[1]);
-  const goalAfterAddition = moment
-    .duration(client.goal)
-    .add(duration, 'milliseconds')
-    .asHours();
+  const goalAfterAddition = moment.duration(client.goal).add(duration, 'milliseconds').asHours();
 
   if (goalAfterAddition > MAX_HOURS) return;
 
@@ -163,7 +156,7 @@ const removeGoal = (client, msg) => {
     .toFixed();
 };
 
-export const handleMessage = async (msg, clients, userId) => {
+const handleMessage = async (msg, clients, userId) => {
   if (!clients.has(userId)) {
     throw new Error('It should have this user in memory');
   }
@@ -214,4 +207,14 @@ export const handleMessage = async (msg, clients, userId) => {
   clients.set(userId, client);
   if (resp === null) resp = client;
   return JSON.stringify(resp);
+};
+
+module.exports = {
+  getClient,
+  handleMessage,
+  action,
+  MAX_HOURS,
+  MIN_MINS,
+  saveClient,
+  updatedTimeSinceStart,
 };


### PR DESCRIPTION
# Description

Several files were using ES6 syntax export method. This was causing issues when running unit tests.


## Related PRS (if any):

N/A
…

## Main changes explained:

Found all the files using ES6 export syntax and converted them to commonJs module export method. 

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. do `npm run build`
4. do `npm run test -- --verbose`
5. Check that no export syntax error pops up and all working unit test should be able to run


## Screenshots or videos of changes:

Before:

![Screenshot 2024-05-12 at 12 08 41 AM](https://github.com/OneCommunityGlobal/HGNRest/assets/95154804/e9b66a19-311c-4954-b205-c1574e1f950f)

After:

![Screenshot 2024-05-12 at 12 11 20 AM](https://github.com/OneCommunityGlobal/HGNRest/assets/95154804/567196fd-b7dd-403d-8059-e63fa44abdd3)



## Note:
 Failing unit tests does not mean its not working. The unit tests are running and some fail which is expected. The unit tests were not being executed at all before because of the syntax error.
