### PR TITLE
Summit New personal max Record Award

### DIFF
--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -1377,12 +1377,10 @@ const userHelper = function () {
 
   const getMaxHrs = async (personId, user) => {
     const weeksdata = await getAllWeeksData(personId, user);
-    // console.log('max hours', Math.max(...weeksdata), 'weeks', weeksdata);
     return Math.max(...weeksdata);
-
   };
 
-  const UpdatePersonalMax = async (personId, user) => {
+  const updatePersonalMax = async (personId, user) => {
     try {
       const MaxHrs = await getMaxHrs(personId, user);
       user.personalBestMaxHrs = MaxHrs;
@@ -1425,7 +1423,6 @@ const userHelper = function () {
           );
           // Update the earnedDate array with the new date
           badgeOfType.earnedDate.unshift(moment().format("MMM-DD-YYYY"));
-          // console.log('earnedDates: ',badgeOfType.earnedDate);
         } else {
           addBadge(personId, mongoose.Types.ObjectId(results._id), user.personalBestMaxHrs);
         }
@@ -1744,7 +1741,7 @@ const userHelper = function () {
         const { _id, badgeCollection } = user;
         const personId = mongoose.Types.ObjectId(_id);
         
-        await UpdatePersonalMax(personId, user);
+        await updatePersonalMax(personId, user);
         await checkPersonalMax(personId, user, badgeCollection);
         await checkMostHrsWeek(personId, user, badgeCollection);
         await checkMinHoursMultiple(personId, user, badgeCollection);


### PR DESCRIPTION
# Description
19. (PRIORITY Medium)  Tatyana/Jae: Fix the “New Max-Personal Record Award”. 

*  Every time the weekly  record is broken, it should show up in the New Badge section on the person’s Dashboard.
* The number displayed on the "New Max record hours" badge icon should represent the highest number of hours achieved, not the frequency of records made.
<img width="423" alt="badges" src="https://github.com/OneCommunityGlobal/HGNRest/assets/141872402/d41779ab-5b79-4b71-a97f-9b8978c65d92">

* In the Badge History list, each earned New Max Record Hours badge should be accompanied by a new date and an incremented count  for each earned "New Max record hours" badge.

## Related PRS (if any):
(Related to [PR#619](https://github.com/OneCommunityGlobal/HGNRest/pull/619#issue-2010124521)) 
To test this backend PR, use frontend [development](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp)

## Main changes explained:
- Every time weekly record is broken, it shows up in the new Badge section on person's Dashboard
- Number displayed on "New Max record hours" badge icon now represents the highest number of hours achieved
- Badge History list, each New Max Record Hours Badge has a new date and an incremented count for each earned "New Max record hours" badge.

## How to test:
To test this, the current frontend development can be used.

# frontend
1. check into branch
2. do` npm install` && `npm run start:local`

# backend 
1. check into branch
2. do `npm install` && npm run build

# test setup
1. modify userprofilejobs.js, do this: 
<img width="487" alt="userprofilejobs" src="https://github.com/OneCommunityGlobal/HGNRest/assets/141872402/c3aa9a18-e29f-4e00-9c93-d1050d7f5aa7">

2. in badgecontroller.js, under badgecontroller = function(badge) {
<img width="455" alt="badgecontroller js" src="https://github.com/OneCommunityGlobal/HGNRest/assets/141872402/431822cc-dd15-467a-8bc1-664a9c6a4bae">
<img width="231" alt="badgecontroller" src="https://github.com/OneCommunityGlobal/HGNRest/assets/141872402/bbb7983b-472c-44ca-b882-0af66c558012">

3. in badgerouter.js under badgerouter 
<img width="397" alt="badgerouter" src="https://github.com/OneCommunityGlobal/HGNRest/assets/141872402/24ca6538-6e9f-4af9-ba93-9314e454b782">

4. userHelper.js under awardnewBadges, add:
<img width="413" alt="awardnewbadges" src="https://github.com/OneCommunityGlobal/HGNRest/assets/141872402/4df5dd7a-0773-420a-b741-169966447fd6">
<img width="539" alt="comment these lines" src="https://github.com/OneCommunityGlobal/HGNRest/assets/141872402/a51b8597-35f7-4f28-a7c7-304539c3538c">
Note: use postman to run


# badge icon/feature test
* run backend: npm run dev or run debugger
1. Clear site data/cache
2. Login as admin/owner
3. Click on 'addintangibleTimeEntry' and add time that is higher then the current max hours
4. Navigate to userProfile -> featured badges
5. If the badge is not visible, the badge may need to be assigned to the user. 
6. check to see if the badge icon has updated with the new max hours

# badge icon test cont'd using MongoDB
1.  navigate to userProfile
2. in the filter search for the email used for testing using this format: {email: ' '}
3. look for user.personalbestmaxhrs and see if it contains the new max hours

# steps to test the icon using mongodb:
1. in userhelper.js navigate to awardnewbadges and comment out the updatepersonalmax function
2. go to mongodb compass edit the hrs for lastweektangiblehrs and personalbestmaxhrs to the desired hours (ex. if previous hours was 60 and you want to update it to 61 then edit the two values.) click on update at the bottom.
3. go to the backend code and rerun the debugger. after a moment, check the frontend go to view profile->badge features-> check icon. it should have updated with the new hrs.
note: we comment out updatepersonalmax because any modification made in the db for personalbestmaxhrs will be overwritten. it will not let you change the value.


# badge count/earned-date test
Note: if modifying personalbestmaxhrs in db, I would recommend commenting out await UpdatePersonalMax(personId, user); in 
Awardnewbadges. The function will overwrite any changes made in the database.
1. Using MongoDB, navigate to userProfile
2. In userProfile, navigate to lastweeksTangibleHrs, add the same time as personalbestmaxhrs
3. Run backend
5. run postman log in/ test badge 
6. it may take a few moments for the earned dates to update 
Note: there is a console.log that will show the earned dates once its updated.
7. Once you see the console.log, look for badgecollections, find the object that has "personal max"
8.  to find badge open a new tab and copy and paste the badge {_id: ObjectId(' ')}
9. check to see if the the badgecount has increased
10. click on earnedDate, check to see if a new Date has been added.

# badge count/earned-date test cont'd 
1. Open local host
2. Clear site data/cache
3. Login as admin/owner
4. navigate to userprofile ->featured badges
5. see if badgeicon updated with new max hours
6. click on selected features, see if the date has been earned
7. see if the count has increased

<img width="477" alt="badgecollection" src="https://github.com/OneCommunityGlobal/HGNRest/assets/141872402/9adc1082-b4cc-40d2-856e-30b0ea2583dc">

<img width="268" alt="lastweektangible   personalbestmaxhrs" src="https://github.com/OneCommunityGlobal/HGNRest/assets/141872402/ede5dfb7-34ed-4921-9868-1c90530c7724">


## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HGNRest/assets/141872402/fe57c960-7168-44a6-b5b6-0990e8ef0d45

https://github.com/OneCommunityGlobal/HGNRest/assets/141872402/d28c8635-0807-475f-9dba-b31107369c85


https://github.com/OneCommunityGlobal/HGNRest/assets/141872402/b68c7294-95ff-470a-8a61-034d10ad0826



## Note:
Include the information the reviewers need to know.
* savedTangibleHrs and lastweektangiblehrs will not update with the data, there is a bug related to the data which is causing the data to not appear
* if you see an error in console it is likely do to time entry breadcrumbs
* The badge icon/count/earned-dates takes a while to update
* if it takes a while for the test to run, rerunning post man might help.
* in mongodb modifying savedtangiblehrs will not change the results for the updatepersonalmax. this function is using time entries to get the data. savedtangiblehrs does not reflect the data that comes from time entries.
* I initially used the frontend [PR #2091](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2091) to test this. This PR is not my own and was simply used for testing purposes. the frontend dev should work, if any issues occur, (such as a blank screen) this is a good backup for a frontend PR.


