### PR TITLE
Jordy add owner message controller unit tests

### DIFF
--- a/requirements/ownerMessageController/deleteOwnerMessage.md
+++ b/requirements/ownerMessageController/deleteOwnerMessage.md
@@ -1,0 +1,13 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# update Owner Messages
+
+> ## Negative Cases
+
+1. ✅ Returns error status 500 if an error occurs during the delete
+2. ✅ Returns error status 403 if requestor is not an owner
+
+> ## Positive Cases
+
+1. ✅ Returns status 200 and deletes the owner message correctly

--- a/requirements/ownerMessageController/getOwnerMessage.md
+++ b/requirements/ownerMessageController/getOwnerMessage.md
@@ -5,7 +5,7 @@ Cross Mark: ❌
 
 > ## Negative Cases
 
-1. ❌ Returns error status 404 if Owner Message cant be found
+1. ✅ Returns error status 404 if Owner Message cant be found
 
 
 > ## Positive Cases

--- a/requirements/ownerMessageController/getOwnerMessage.md
+++ b/requirements/ownerMessageController/getOwnerMessage.md
@@ -11,4 +11,4 @@ Cross Mark: ❌
 > ## Positive Cases
 
 1. ❌ Returns status 200 and initializes a new owner message if none exists.
-2. ❌ Returns status 200 and returns the existing owner message if one or more exist.
+2. ✅ Returns status 200 and returns the existing owner message if one or more exist.

--- a/requirements/ownerMessageController/getOwnerMessage.md
+++ b/requirements/ownerMessageController/getOwnerMessage.md
@@ -10,5 +10,5 @@ Cross Mark: ❌
 
 > ## Positive Cases
 
-1. ❌ Returns status 200 and initializes a new owner message if none exists.
+1. ✅ Returns status 200 and initializes a new owner message if none exists.
 2. ✅ Returns status 200 and returns the existing owner message if one or more exist.

--- a/requirements/ownerMessageController/getOwnerMessage.md
+++ b/requirements/ownerMessageController/getOwnerMessage.md
@@ -1,0 +1,14 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# Get Owner Messages
+
+> ## Negative Cases
+
+1. ❌ Returns error status 404 if Owner Message cant be found
+
+
+> ## Positive Cases
+
+1. ❌ Returns status 200 and initializes a new owner message if none exists.
+2. ❌ Returns status 200 and returns the existing owner message if one or more exist.

--- a/requirements/ownerMessageController/updateOwnerMessage.md
+++ b/requirements/ownerMessageController/updateOwnerMessage.md
@@ -1,0 +1,13 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# update Owner Messages
+
+> ## Negative Cases
+
+1. ✅ Returns error status 500 if an error occurs during the update
+2. ✅ Returns error status 403 if requestor is not an owner
+
+> ## Positive Cases
+
+1. ✅ Returns status 201 and updates the owner message correctly with new message

--- a/requirements/ownerMessageController/updateOwnerMessage.md
+++ b/requirements/ownerMessageController/updateOwnerMessage.md
@@ -10,4 +10,4 @@ Cross Mark: ❌
 
 > ## Positive Cases
 
-1. ✅ Returns status 201 and updates the owner message correctly with new message
+1. ❌ Returns status 201 and updates the owner message correctly with new message

--- a/src/controllers/ownerMessageController.spec.js
+++ b/src/controllers/ownerMessageController.spec.js
@@ -1,10 +1,10 @@
-const ownerMessage = require('../models/ownerMessage');
+const OwnerMessage = require('../models/ownerMessage');
 const ownerMessageController = require('./ownerMessageController');
 const { mockReq, mockRes, assertResMock } = require('../test');
 
 const makeSut = () => {
   const { getOwnerMessage, updateOwnerMessage, deleteOwnerMessage } =
-    ownerMessageController(ownerMessage);
+    ownerMessageController(OwnerMessage);
   return {
     getOwnerMessage,
     updateOwnerMessage,
@@ -21,7 +21,7 @@ describe('ownerMessageController Unit Tests', () => {
   });
 
   beforeEach(() => {
-    mockFind = jest.spyOn(ownerMessage, 'find');
+    mockFind = jest.spyOn(OwnerMessage, 'find');
     mockSave = jest.fn();
   });
   describe('getOwnerMessage', () => {
@@ -33,21 +33,29 @@ describe('ownerMessageController Unit Tests', () => {
       await flushPromises();
       assertResMock(404, errorMsg, response, mockRes);
     });
-    // test('Ensures getOwnerMessage returns status 200 with new owner message if none exist', async () => {
-    //   mockFind.mockResolvedValue({});
-    //   const ownerMessageInstance = {
-    //     set: jest.fn(),
-    //     save: mockSave,
-    //   };
+    test('Ensures getOwnerMessage returns status 200 with new owner message if none exist', async () => {
+      mockFind.mockResolvedValue([]);
+      const ownerMessageInstance = new OwnerMessage();
+      ownerMessageInstance.set = jest.fn();
+      const mockSaveFn = jest.fn().mockResolvedValue(ownerMessageInstance);
 
-    //   jest.spyOn(ownerMessage.prototype, 'save').mockImplementation(() => ownerMessageInstance);
-    //   await makeSut().getOwnerMessage(mockReq, mockRes);
-    //   await flushPromises();
+      jest.spyOn(OwnerMessage.prototype, 'save').mockImplementation(mockSaveFn);
+      await makeSut().getOwnerMessage(mockReq, mockRes);
+      await flushPromises();
 
-    //   expect(mockRes.status).toHaveBeenCalledWith(200);
-    //   expect(mockRes.send).toHaveBeenCalledWith({ ownerMessage: ownerMessageInstance });
-    //   expect(mockSave).toHaveBeenCalled();
-    // });
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ownerMessage: expect.objectContaining({
+            _id: expect.anything(),
+            message: '',
+            standardMessage: '',
+          }),
+        }),
+      );
+      expect(mockSaveFn).toHaveBeenCalled();
+    });
+
     test('Ensures getOwnerMessage returns status 200 with the first owner message if it exists', async () => {
       const existingMessage = { message: 'Existing message', standardMessage: 'Standard message' };
       mockFind.mockResolvedValue([existingMessage]);

--- a/src/controllers/ownerMessageController.spec.js
+++ b/src/controllers/ownerMessageController.spec.js
@@ -14,6 +14,9 @@ const makeSut = () => {
 const flushPromises = () => new Promise(setImmediate);
 
 describe('ownerMessageController Unit Tests', () => {
+    afterEach(()=> {
+        jest.clearAllMocks();
+    })
   describe('getOwnerMessage', () => {
     test('Ensures getOwnerMessage returns status 404 if owner message cant be found', async () => {
       const { getOwnerMessage } = makeSut();
@@ -23,5 +26,17 @@ describe('ownerMessageController Unit Tests', () => {
       await flushPromises();
       assertResMock(404, new Error(errorMsg), response, mockRes);
     });
+    test('Ensures getOwnerMessage returns status 200 OK with new owner message if none exists and saves it', async () => {
+        const { getOwnerMessage } = makeSut();
+        jest.spyOn(ownerMessage, 'find').mockResolvedValueOnce([]);
+        const expectedMessage = {
+
+          };
+        const mockSave = jest.fn().mockResolvedValue(expectedMessage);
+        jest.spyOn(ownerMessage.prototype, 'save').mockImplementation(mockSave);
+        const response =  await getOwnerMessage(mockReq, mockRes);
+        await flushPromises();
+        assertResMock(200, mockSave, response, mockRes);
+    })
   });
 });

--- a/src/controllers/ownerMessageController.spec.js
+++ b/src/controllers/ownerMessageController.spec.js
@@ -15,14 +15,14 @@ const flushPromises = () => new Promise(setImmediate);
 
 describe('ownerMessageController Unit Tests', () => {
   let mockFind;
-  // let mockSave;
+  let mockSave;
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   beforeEach(() => {
     mockFind = jest.spyOn(ownerMessage, 'find');
-    // mockSave = jest.fn();
+    mockSave = jest.fn();
   });
   describe('getOwnerMessage', () => {
     test('Ensures getOwnerMessage returns status 404 if owner message cant be found', async () => {
@@ -54,6 +54,43 @@ describe('ownerMessageController Unit Tests', () => {
       await makeSut().getOwnerMessage(mockReq, mockRes);
       expect(mockRes.status).toHaveBeenCalledWith(200);
       expect(mockRes.send).toHaveBeenCalledWith({ ownerMessage: existingMessage });
+    });
+  });
+  describe('updateOwnerMessage', () => {
+    test('Ensures updateOwnerMessage returns status 403 if requestor is not an owner', async () => {
+      const { updateOwnerMessage } = makeSut();
+      const req = { body: { requestor: { role: 'User' } } };
+      const response = await updateOwnerMessage(req, mockRes);
+      await flushPromises();
+      assertResMock(403, 'You are not authorized to create messages!', response, mockRes);
+    });
+    test('Ensures updateOwnerMessage returns status 201 and updates the owner message correctly with custom message', async () => {
+      const existingMessage = { message: '', standardMessage: '', save: mockSave };
+      mockFind.mockResolvedValue([existingMessage]);
+      const mockReqDup = {
+        ...mockReq,
+        body: {
+          ...mockReq.body,
+          isStandard: false,
+          newMessage: 'New custom message',
+          requestor: { role: 'Owner' },
+        },
+      };
+      await makeSut().updateOwnerMessage(mockReqDup, mockRes);
+      expect(mockRes.status).toHaveBeenCalledWith(201);
+      expect(mockRes.send).toHaveBeenCalledWith({
+        _serverMessage: 'Update successfully!',
+        ownerMessage: { standardMessage: '', message: 'New custom message' },
+      });
+      expect(mockSave).toHaveBeenCalled();
+    });
+    test('Ensures updateOwnerMessage returns status 500 if an error occurs during the update', async () => {
+      const errorMsg = 'Error occurred during update';
+      mockFind.mockRejectedValue(errorMsg);
+      const mockReqDup = { ...mockReq, body: { ...mockReq.body, requestor: { role: 'Owner' } } };
+      await makeSut().updateOwnerMessage(mockReqDup, mockRes);
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.send).toHaveBeenCalledWith(errorMsg);
     });
   });
 });

--- a/src/controllers/ownerMessageController.spec.js
+++ b/src/controllers/ownerMessageController.spec.js
@@ -14,29 +14,46 @@ const makeSut = () => {
 const flushPromises = () => new Promise(setImmediate);
 
 describe('ownerMessageController Unit Tests', () => {
-    afterEach(()=> {
-        jest.clearAllMocks();
-    })
+  let mockFind;
+  // let mockSave;
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  beforeEach(() => {
+    mockFind = jest.spyOn(ownerMessage, 'find');
+    // mockSave = jest.fn();
+  });
   describe('getOwnerMessage', () => {
     test('Ensures getOwnerMessage returns status 404 if owner message cant be found', async () => {
       const { getOwnerMessage } = makeSut();
       const errorMsg = 'Error occurred when finding owner message';
-      jest.spyOn(ownerMessage, 'find').mockImplementationOnce(() => Promise.reject(new Error(errorMsg)));
+      mockFind.mockImplementationOnce(() => Promise.reject(errorMsg));
       const response = await getOwnerMessage(mockReq, mockRes);
       await flushPromises();
-      assertResMock(404, new Error(errorMsg), response, mockRes);
+      assertResMock(404, errorMsg, response, mockRes);
     });
-    test('Ensures getOwnerMessage returns status 200 OK with new owner message if none exists and saves it', async () => {
-        const { getOwnerMessage } = makeSut();
-        jest.spyOn(ownerMessage, 'find').mockResolvedValueOnce([]);
-        const expectedMessage = {
+    // test('Ensures getOwnerMessage returns status 200 with new owner message if none exist', async () => {
+    //   mockFind.mockResolvedValue({});
+    //   const ownerMessageInstance = {
+    //     set: jest.fn(),
+    //     save: mockSave,
+    //   };
 
-          };
-        const mockSave = jest.fn().mockResolvedValue(expectedMessage);
-        jest.spyOn(ownerMessage.prototype, 'save').mockImplementation(mockSave);
-        const response =  await getOwnerMessage(mockReq, mockRes);
-        await flushPromises();
-        assertResMock(200, mockSave, response, mockRes);
-    })
+    //   jest.spyOn(ownerMessage.prototype, 'save').mockImplementation(() => ownerMessageInstance);
+    //   await makeSut().getOwnerMessage(mockReq, mockRes);
+    //   await flushPromises();
+
+    //   expect(mockRes.status).toHaveBeenCalledWith(200);
+    //   expect(mockRes.send).toHaveBeenCalledWith({ ownerMessage: ownerMessageInstance });
+    //   expect(mockSave).toHaveBeenCalled();
+    // });
+    test('Ensures getOwnerMessage returns status 200 with the first owner message if it exists', async () => {
+      const existingMessage = { message: 'Existing message', standardMessage: 'Standard message' };
+      mockFind.mockResolvedValue([existingMessage]);
+      await makeSut().getOwnerMessage(mockReq, mockRes);
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.send).toHaveBeenCalledWith({ ownerMessage: existingMessage });
+    });
   });
 });

--- a/src/controllers/ownerMessageController.spec.js
+++ b/src/controllers/ownerMessageController.spec.js
@@ -1,0 +1,27 @@
+const ownerMessage = require('../models/ownerMessage');
+const ownerMessageController = require('./ownerMessageController');
+const { mockReq, mockRes, assertResMock } = require('../test');
+
+const makeSut = () => {
+  const { getOwnerMessage, updateOwnerMessage, deleteOwnerMessage } =
+    ownerMessageController(ownerMessage);
+  return {
+    getOwnerMessage,
+    updateOwnerMessage,
+    deleteOwnerMessage,
+  };
+};
+const flushPromises = () => new Promise(setImmediate);
+
+describe('ownerMessageController Unit Tests', () => {
+  describe('getOwnerMessage', () => {
+    test('Ensures getOwnerMessage returns status 404 if owner message cant be found', async () => {
+      const { getOwnerMessage } = makeSut();
+      const errorMsg = 'Error occurred when finding owner message';
+      jest.spyOn(ownerMessage, 'find').mockImplementationOnce(() => Promise.reject(new Error(errorMsg)));
+      const response = await getOwnerMessage(mockReq, mockRes);
+      await flushPromises();
+      assertResMock(404, new Error(errorMsg), response, mockRes);
+    });
+  });
+});


### PR DESCRIPTION
# Description

Unit tests for ownerMessageController

## Related PRS (if any):
N/A

## Main changes explained:

- unit tests for `getOwnerMessage`
- unit tests for `updateOwnerMessage`
- unit tests for `deleteOwnerMessage`

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. run `npm run test owner`

**If  you want a detailed description you can run `npm run test owner -- --verbose`**

## Screenshots

![ownerMessageControllerComplete](https://github.com/OneCommunityGlobal/HGNRest/assets/95154804/4849fcc0-243b-44a6-bae9-c633a0a17aca)

## Note:

N/A