### PR TITLE
Lin_dashBoardController_unit_testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This module is the REST module built on NodeJS to support MongoDB activities, Since EmberData has no direct adapters for MongoDB. This module will later be intergrated with EmberJS HGN project to maintain singularity.",
   "main": "restapp",
   "scripts": {
-    "test": "jest --passWithNoTests --silent --noStackTrace --runInBand --forceExit dashBoardController",
+    "test": "jest --passWithNoTests --silent --noStackTrace --runInBand --forceExit",
     "test:verbose": "jest --passWithNoTests --runInBand",
     "test:unit": "npm test -- --watch -c jest-unit.config.js",
     "test:integration": "npm test -- --watch -c jest-integration.config.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This module is the REST module built on NodeJS to support MongoDB activities, Since EmberData has no direct adapters for MongoDB. This module will later be intergrated with EmberJS HGN project to maintain singularity.",
   "main": "restapp",
   "scripts": {
-    "test": "jest --passWithNoTests --silent --noStackTrace --runInBand --forceExit",
+    "test": "jest --passWithNoTests --silent --noStackTrace --runInBand --forceExit dashBoardController",
     "test:verbose": "jest --passWithNoTests --runInBand",
     "test:unit": "npm test -- --watch -c jest-unit.config.js",
     "test:integration": "npm test -- --watch -c jest-integration.config.js",

--- a/requirements/dashBoardController/dashboarddata.md
+++ b/requirements/dashBoardController/dashboarddata.md
@@ -1,0 +1,12 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# Post Badge
+
+> ## Positive case
+
+1. ✅ Returns 200 if there is no error and return results
+
+> ## Negative case
+
+> ## Edge case

--- a/requirements/dashBoardController/editSuggestionOption.md
+++ b/requirements/dashBoardController/editSuggestionOption.md
@@ -1,0 +1,17 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# Post Badge
+
+> ## Positive case
+
+1. ✅ Returns 200 if suggestionData.field is added a new field
+2. ✅ Returns 200 if suggestionData.suggestion is added a new suggestion
+3. ✅ Returns 200 if suggestionData.field is deleted
+4. ✅ Returns 200 if suggestionData.suggestion is deleted
+
+> ## Negative case
+
+1. ❌ Returns 500 if there is an error in the function
+
+> ## Edge case

--- a/requirements/dashBoardController/getAIPrompt.md
+++ b/requirements/dashBoardController/getAIPrompt.md
@@ -1,0 +1,17 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# Post Badge
+
+> ## Positive case
+
+1. ❌ Receives a POST request in the **/api/userProfile** route
+2. ✅ Returns 200 if the GPT exists and send the results back
+2. ✅ Returns 200 if there is no error and new GPT Prompt is created
+
+> ## Negative case
+
+1. ❌ Returns 500 if GPT Prompt does not exist
+2. ❌ Returns 500 if there is an error in creating the GPT Prompt
+
+> ## Edge case

--- a/requirements/dashBoardController/getPromptCopiedDate.md
+++ b/requirements/dashBoardController/getPromptCopiedDate.md
@@ -1,0 +1,14 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# Post Badge
+
+> ## Positive case
+
+1. ✅ Returns 200 if there is a user and return copied AI prompt 
+
+> ## Negative case
+
+
+> ## Edge case
+1. Returns undefined when the user is not found

--- a/requirements/dashBoardController/getSuggestionOption.md
+++ b/requirements/dashBoardController/getSuggestionOption.md
@@ -1,0 +1,15 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# Post Badge
+
+> ## Positive case
+
+1. ✅ Returns 200 if there is suggestion data
+
+> ## Negative case
+
+1. ❌ Returns 404 if the suggestion data is not found
+2. ❌ Returns 500 if there is an error in the function
+
+> ## Edge case

--- a/requirements/dashBoardController/leaderboarddata.md
+++ b/requirements/dashBoardController/leaderboarddata.md
@@ -1,0 +1,15 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# Post Badge
+
+> ## Positive case
+
+1. ✅ Returns 200 if there is leaderboard data
+2. ✅ Returns 200 if leaderboard data is empty and returns getUserLaborData
+
+> ## Negative case
+
+1. ❌ Returns 400 if there is an error
+
+> ## Edge case

--- a/requirements/dashBoardController/monthlydata.md
+++ b/requirements/dashBoardController/monthlydata.md
@@ -1,0 +1,14 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# Post Badge
+
+> ## Positive case
+
+1. ❌ Receives a POST request in the **/api/userProfile** route
+2. ✅ Returns 200 if there is no results and return empty results
+3. ✅ Returns 200 if there is results and return results
+
+> ## Negative case
+
+> ## Edge case

--- a/requirements/dashBoardController/orgData.md
+++ b/requirements/dashBoardController/orgData.md
@@ -1,0 +1,14 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# Post Badge
+
+> ## Positive case
+
+1. ✅ Returns 200 if the result is found and returns result
+
+> ## Negative case
+
+1. ❌ Returns 400 if there is an error in the function
+
+> ## Edge case

--- a/requirements/dashBoardController/sendBugReport.md
+++ b/requirements/dashBoardController/sendBugReport.md
@@ -1,0 +1,14 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# Post Badge
+
+> ## Positive case
+
+1. ✅ Returns 200 if the bug report email is sent 
+
+> ## Negative case
+
+1. ❌ Returns 500 if the email fails to send
+
+> ## Edge case

--- a/requirements/dashBoardController/sendMakeSuggestion.md
+++ b/requirements/dashBoardController/sendMakeSuggestion.md
@@ -1,0 +1,14 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# Post Badge
+
+> ## Positive case
+
+1. ✅ Returns 200 if the suggestion email is sent successfully
+
+> ## Negative case
+
+1. ❌ Returns 500 if the suggestion email fails to send
+
+> ## Edge case

--- a/requirements/dashBoardController/updateAIPrompt.md
+++ b/requirements/dashBoardController/updateAIPrompt.md
@@ -1,0 +1,16 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# Post Badge
+
+> ## Positive case
+
+1. ❌ Receives a POST request in the **/api/userProfile** route
+2. ✅ Returns 200 if there is no error and AI Prompt is saved
+
+> ## Negative case
+
+1. ❌ Returns error 500 if the error occurs in the AI Prompt function
+
+> ## Edge case
+1. Returns undefined if the requestor role is not an owner

--- a/requirements/dashBoardController/updateCopiedPrompt.md
+++ b/requirements/dashBoardController/updateCopiedPrompt.md
@@ -1,0 +1,16 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# Post Badge
+
+> ## Positive case
+
+1. ❌ Receives a POST request in the **/api/userProfile** route
+2. ✅ Returns 200 if there is no error and user is found
+
+> ## Negative case
+
+1. ❌ Returns error 404 if the user is not found
+2. ❌ Returns error 500 if the error occurs in the file update function
+
+> ## Edge case

--- a/requirements/dashBoardController/weeklydata.md
+++ b/requirements/dashBoardController/weeklydata.md
@@ -1,0 +1,13 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# Post Badge
+
+> ## Positive case
+
+1. ❌ Receives a POST request in the **/api/userProfile** route
+2. ✅ Returns 200 if there is no error and labordata is found
+
+> ## Negative case
+
+> ## Edge case

--- a/src/controllers/dashBoardController.js
+++ b/src/controllers/dashBoardController.js
@@ -2,12 +2,13 @@
 const path = require("path");
 const fs = require("fs/promises");
 const mongoose = require("mongoose");
-const dashboardhelper = require("../helpers/dashboardhelper")();
+const dashboardHelperClosure = require("../helpers/dashboardhelper");
 const emailSender = require("../utilities/emailSender");
 const AIPrompt = require("../models/weeklySummaryAIPrompt");
 const User = require("../models/userProfile");
 
 const dashboardcontroller = function () {
+  const dashboardhelper = dashboardHelperClosure();
   const dashboarddata = function (req, res) {
     const userId = mongoose.Types.ObjectId(req.params.userId);
 

--- a/src/controllers/dashBoardController.js
+++ b/src/controllers/dashBoardController.js
@@ -348,3 +348,4 @@ const dashboardcontroller = function () {
 };
 
 module.exports = dashboardcontroller;
+

--- a/src/controllers/dashBoardController.spec.js
+++ b/src/controllers/dashBoardController.spec.js
@@ -135,7 +135,7 @@ describe('Dashboard Controller tests', () => {
       expect(mockRes.send).toHaveBeenCalledWith({ message: mockUser.copiedAiPrompt });
     });
 
-    test.only('Returns undefined when the user is not found', async () => {
+    test('Returns undefined when the user is not found', async () => {
 
       const { getPromptCopiedDate } = makeSut(); 
 

--- a/src/controllers/dashBoardController.spec.js
+++ b/src/controllers/dashBoardController.spec.js
@@ -26,7 +26,8 @@ const makeSut = () => {
     dashboarddata,
     sendBugReport,
     sendMakeSuggestion,
-    // getSuggestionOption
+    getSuggestionOption,
+    editSuggestionOption
   } = dashBoardController(AIPrompt);
   return { 
     updateCopiedPrompt,
@@ -40,7 +41,8 @@ const makeSut = () => {
     dashboarddata,
     sendBugReport,
     sendMakeSuggestion,
-    // getSuggestionOption
+    getSuggestionOption,
+    editSuggestionOption
   };
 };
 
@@ -49,14 +51,10 @@ const flushPromises = async () => new Promise(setImmediate);
 
 describe('Dashboard Controller tests', () => {
   beforeAll(() => {
-    // const dashboardHelperObject = 
-    //   {
-    //     laborthisweek: jest.fn(() => Promise.resolve([]))
-    //   };
-    // dashboardHelperClosure.mockImplementation(() => dashboardHelperObject);
+
   });
   beforeEach(() => {
-    dashboardhelper = dashboardHelperClosure();
+    // dashboardhelper = dashboardHelperClosure();
   });
   afterEach(() => {
     jest.clearAllMocks();
@@ -565,8 +563,9 @@ describe('Dashboard Controller tests', () => {
   describe('sendBugReport Tests', () => {
 
     test('Returns 200 if the bug report email is sent ', async () => {
-      const mockReq = {
-        body: {
+      
+      mockReq.body =  {
+          ...mockReq.body,
           firstName: 'Lin',
           lastName: 'Test',
           title: 'Bug in feature X',
@@ -577,7 +576,6 @@ describe('Dashboard Controller tests', () => {
           visual: 'Screenshot attached',
           severity: 'High',
           email: 'lin.test@example.com',
-        },
       };
 
       const { sendBugReport } = makeSut();
@@ -591,19 +589,19 @@ describe('Dashboard Controller tests', () => {
     })
 
     test('Returns 500 if the email fails to send', async () => {
-      const mockReq = {
-        body: {
-          firstName: 'Lin',
-          lastName: 'Test',
-          title: 'Bug in feature X',
-          environment: 'macOS 10.15, Chrome 89, App version 1.2.3',
-          reproduction: '1. Click on button A\n2. Enter invalid data\n3. Click submit',
-          expected: 'The app should display an error message',
-          actual: 'The app',
-          visual: 'Screenshot attached',
-          severity: 'High',
-          email: 'lin.test@example.com',
-        },
+      
+      mockReq.body =  {
+        ...mockReq.body,
+        firstName: 'Lin',
+        lastName: 'Test',
+        title: 'Bug in feature X',
+        environment: 'macOS 10.15, Chrome 89, App version 1.2.3',
+        reproduction: '1. Click on button A\n2. Enter valid data\n3. Click submit',
+        expected: 'The app should not display an error message',
+        actual: 'The app',
+        visual: 'Screenshot attached',
+        severity: 'High',
+        email: 'lin.test@example.com',
       };
 
       emailSender.mockImplementation(() => {
@@ -626,8 +624,8 @@ describe('Dashboard Controller tests', () => {
 
   describe('sendMakeSuggestion Tests', () => {
     test('Returns 500 if the suggestion email fails to send', async () => {
-      const mockReq = {
-        body: {
+      
+      mockReq.body =  {
           suggestioncate: 'Identify and remedy poor client and/or user service experiences',
           suggestion: 'This is a sample suggestion',
           confirm: 'true',
@@ -635,7 +633,6 @@ describe('Dashboard Controller tests', () => {
           firstName: 'Lin',
           lastName: 'Test',
           field: ['field1', 'field2'],
-        },
       };
       
       emailSender.mockImplementation(() => {
@@ -653,8 +650,9 @@ describe('Dashboard Controller tests', () => {
     })
 
     test('Returns 200 if the suggestion email is sent successfully', async () => {
-      const mockReq = {
-        body: {
+      
+      mockReq.body = {
+          ...mockReq.body,
           suggestioncate: 'Identify and remedy poor client and/or user service experiences',
           suggestion: 'This is a sample suggestion',
           confirm: 'true',
@@ -662,7 +660,6 @@ describe('Dashboard Controller tests', () => {
           firstName: 'John',
           lastName: 'Doe',
           field: ['field1', 'field2'],
-        },
       };
 
       emailSender.mockImplementation(() => {
@@ -681,18 +678,161 @@ describe('Dashboard Controller tests', () => {
 
   })
 
-  // describe('getSuggestionOption Tests', () => {
-  //   test.only('Returns 404 if the suggestion data is not found', async () => {
-  //     const mockReq = {}
-  //     dashBoardController.suggestionData = null;
+  // Need to make test cases for negative case
+  describe('getSuggestionOption Tests', () => {
 
-  //     const { getSuggestionOption } = makeSut();
+    // test.only('Returns 404 if the suggestion data is not found', async () => {
 
-  //     await getSuggestionOption(mockReq, mockRes);
+    //   const { getSuggestionOption } = makeSut();
 
-  //     await flushPromises();
+    //   await getSuggestionOption(mockReq, mockRes);
 
-  //     expect(mockRes.status).toBeCalledWith(200);
-  //   })
-  // })
+    //   await flushPromises();
+
+    //   expect(mockRes.status).toHaveBeenCalledWith(404);
+    //   expect(mockRes.send).toHaveBeenCalledWith('Suggestion Data Not Found');
+    // });
+
+    test('Returns 200 if there is suggestion data', async () => {
+      
+      const suggestionData = {
+        "field": [], 
+        "suggestion": [
+          "Identify and remedy poor client and/or user service experiences", 
+          "Identify bright spots and enhance positive service experiences", 
+          "Make fundamental changes to our programs and/or operations", 
+          "Inform the development of new programs/projects", 
+          "Identify where we are less inclusive or equitable across demographic groups", 
+          "Strengthen relationships with the people we serve", 
+          "Understand people's needs and how we can help them achieve their goals", 
+          "Other"
+        ]
+      };
+
+      const { getSuggestionOption } = makeSut();
+
+      await getSuggestionOption(mockReq, mockRes);
+
+      await flushPromises();
+
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.send).toHaveBeenCalledWith(suggestionData);
+    })
+  })
+
+  // Need to make test cases for negative case
+  describe('editSuggestionOption tests', () => {
+    test('Returns 200 if suggestionData.field is added a new field', async () => {
+      
+      const suggestionData = {
+        suggestion: ['newSuggestion'],
+        field: ['newField'],
+      };
+
+      mockReq.body = {
+        suggestion: true,
+        action: 'add',
+        newField: 'new field',
+      };
+
+      const { editSuggestionOption } = makeSut();
+
+      await editSuggestionOption(mockReq, mockRes);
+
+      await flushPromises();
+
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(suggestionData.field).toEqual(['newField']);
+      expect(mockRes.send).toHaveBeenCalledWith('success');
+    });
+
+    test('Returns 200 if suggestionData.suggestion is added a new suggestion', async () => {
+      
+      const suggestionData = {
+        suggestion: ['newSuggestion'],
+        field: [],
+      };
+
+      mockReq.body = {
+        suggestion: true,
+        action: 'add',
+        newField: 'new suggestion',
+      };
+
+      const { editSuggestionOption } = makeSut();
+
+      await editSuggestionOption(mockReq, mockRes);
+
+      await flushPromises();
+
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(suggestionData.suggestion).toEqual(['newSuggestion']);
+      expect(mockRes.send).toHaveBeenCalledWith('success');
+    })
+
+    test('Returns 200 if suggestionData.field is deleted', async () => {
+      
+      const suggestionData = {
+        suggestion: ['newSuggestion'],
+        field: [],
+      };
+
+      mockReq.body = {
+        suggestion: true,
+        action: 'delete',
+        newField: 'new field',
+      };
+
+      const { editSuggestionOption } = makeSut();
+
+      await editSuggestionOption(mockReq, mockRes);
+
+      await flushPromises();
+
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(suggestionData.field).toEqual([]);
+      expect(mockRes.send).toHaveBeenCalledWith('success');
+    });
+
+    test('Returns 200 if suggestionData.suggestion is deleted', async () => {
+      
+      const suggestionData = {
+        suggestion: [],
+        field: [],
+      };
+
+      mockReq.body = {
+        suggestion: true,
+        action: 'delete',
+        newField: 'new field',
+      };
+
+      const { editSuggestionOption } = makeSut();
+
+      await editSuggestionOption(mockReq, mockRes);
+
+      await flushPromises();
+
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(suggestionData.suggestion).toEqual([]);
+      expect(mockRes.send).toHaveBeenCalledWith('success');
+    });
+
+    // test.only('Returns 500 if there is an error in the function', async () => {
+
+    // const { editSuggestionOption } = makeSut();
+
+    // await editSuggestionOption(mockReq, mockRes);
+
+    // jest
+    //   .spyOn(console, 'error')
+    //   .mockRejectedValueOnce('Internal Server Error')
+    
+    // expect(mockRes.status).toHaveBeenCalledWith(500);
+    // expect(mockRes.send).toHaveBeenCalledWith('Internal Server Error');
+    // });
+
+
+  })
+
 });

--- a/src/controllers/dashBoardController.spec.js
+++ b/src/controllers/dashBoardController.spec.js
@@ -112,28 +112,45 @@ describe('Dashboard Controller tests', () => {
 
   });
 
-  // describe('getPromptCopiedDate', () => {
-  //   test('Returns 200 if there is a user and return copied AI prompt',async () => {
-  //     const { getPromptCopiedDate } = makeSut();
+  describe('getPromptCopiedDate', () => {
+    test('Returns 200 if there is a user and return copied AI prompt',async () => {
+      const mockUser = { _id: 'testUserId', copiedAiPrompt: 'Test Prompt'};
 
-  //     jest
-  //       .spyOn(UserProfile, 'findOne')
-  //       .mockImplementationOnce(() =>
-  //         Promise.resolve({})
-  //       );
+      const newReq = {
+        ...mockReq,
+        params: {
+          userId: 'testUserId'
+        }
+      };
 
-  //     const response = getPromptCopiedDate(mockReq, mockRes);
+      const { getPromptCopiedDate } = makeSut();
 
-  //     await flushPromises();
+      jest
+        .spyOn(UserProfile, 'findOne')
+        .mockResolvedValueOnce(mockUser);
 
-  //     assertResMock(
-  //       200,
-  //       {},
-  //       response,
-  //       mockRes,
-  //     );
-  //   })
-  // })
+      await getPromptCopiedDate(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.send).toHaveBeenCalledWith({ message: mockUser.copiedAiPrompt });
+    });
+
+    test.only('Returns undefined when the user is not found', async () => {
+
+      const { getPromptCopiedDate } = makeSut(); 
+
+      jest
+        .spyOn(UserProfile, 'findOne')
+        .mockResolvedValueOnce(null);
+
+      getPromptCopiedDate(mockReq, mockRes);
+
+      await flushPromises();
+
+      expect(mockRes.status).not.toHaveBeenCalled();
+      expect(mockRes.send).not.toHaveBeenCalled();
+    })
+  })
 
   describe('updateAIPrompt Tests', () => {
     test('Returns error 500 if the error occurs in the AI Prompt function', async () => {

--- a/src/controllers/dashBoardController.spec.js
+++ b/src/controllers/dashBoardController.spec.js
@@ -17,7 +17,10 @@ const makeSut = () => {
     updateAIPrompt, 
     getAIPrompt,
     monthlydata,
-    weeklydata
+    weeklydata,
+    leaderboarddata,
+    orgData,
+    dashboarddata
   } = dashBoardController(AIPrompt);
   return { 
     updateCopiedPrompt,
@@ -25,7 +28,10 @@ const makeSut = () => {
     updateAIPrompt,
     getAIPrompt,
     monthlydata,
-    weeklydata
+    weeklydata,
+    leaderboarddata,
+    orgData,
+    dashboarddata
   };
 };
 
@@ -34,14 +40,14 @@ const flushPromises = async () => new Promise(setImmediate);
 
 describe('Dashboard Controller tests', () => {
   beforeAll(() => {
-    const dashboardHelperObject = 
-      {
-        laborthisweek: jest.fn(() => Promise.resolve([]))
-      };
-    dashboardHelperClosure.mockImplementation(() => dashboardHelperObject);
+    // const dashboardHelperObject = 
+    //   {
+    //     laborthisweek: jest.fn(() => Promise.resolve([]))
+    //   };
+    // dashboardHelperClosure.mockImplementation(() => dashboardHelperObject);
   });
   beforeEach(() => {
-    // mockReq.params.userId = '5a7ccd20fde60f1f1857ba16';
+    dashboardhelper = dashboardHelperClosure();
   });
   afterEach(() => {
     jest.clearAllMocks();
@@ -353,7 +359,7 @@ describe('Dashboard Controller tests', () => {
         mockRes,
       );
     })
-  })
+  });
 
   describe('monthlydata Tests', () => {
 
@@ -405,8 +411,146 @@ describe('Dashboard Controller tests', () => {
       );
     })
 
+  });
+
+  describe('leaderboarddata Tests', () => {
+    test('Returns 200 if there is leaderboard data', async () => {
+      const dashboardHelperObject = {
+        getLeaderboard: jest.fn(() => Promise.resolve({})),
+        getUserLaborData: jest.fn(() => Promise.resolve({}))
+      };
+
+      dashboardHelperClosure.mockImplementationOnce(() => dashboardHelperObject);
+
+      const { leaderboarddata } = makeSut();
+
+      const response = leaderboarddata(mockReq, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        200,
+        {},
+        response,
+        mockRes,
+      );
+    })
+
+    test('Returns 200 if leaderboard data is empty and returns getUserLaborData', async () => {
+      const dashboardHelperObject = {
+        getLeaderboard: jest.fn(() => Promise.resolve([])),
+        getUserLaborData: jest.fn(() => Promise.resolve([]))
+      };
+
+      dashboardHelperClosure.mockImplementationOnce(() => dashboardHelperObject);
+
+      const { leaderboarddata } = makeSut();
+
+      const response = leaderboarddata(mockReq, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        200,
+        [],
+        response,
+        mockRes,
+      );
+    })
+
+    test('Returns 400 if there is an error', async () => {
+      const dashboardHelperObject = {
+        getLeaderboard: jest.fn(() => Promise.reject({}))
+      };
+
+      dashboardHelperClosure.mockImplementationOnce(() => dashboardHelperObject);
+
+      const { leaderboarddata } = makeSut();
+
+      const response = leaderboarddata(mockReq, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        400,
+        {},
+        response,
+        mockRes,
+      );
+    })
   })
   
+  describe('orgData Tests', () => {
+    
+    test('Returns 400 if there is an error in the function', async () => {
 
+      const dashboardHelperObject = {
+        getOrgData: jest.fn(() => Promise.reject(error))
+      };
+
+      dashboardHelperClosure.mockImplementationOnce(() => dashboardHelperObject);
+
+      const { orgData } = makeSut();
+
+      const response = orgData(mockReq, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        400,
+        error,
+        response,
+        mockRes,
+      );
+    })
+
+    test('Returns 200 if the result is found and returns result', async () => {
+      const mockResult = { id: 1, name: 'Mock Results'};
+
+      const dashboardHelperObject = {
+        getOrgData: jest.fn(() => Promise.resolve([mockResult]))
+      }
+
+      dashboardHelperClosure.mockImplementationOnce(() => dashboardHelperObject);
+
+      const { orgData } = makeSut();
+
+      const response = orgData(mockReq, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        200,
+        mockResult,
+        response,
+        mockRes,
+      );
+    })
+  });
+
+  describe('dashboarddata Tests', () => {
+    test('Returns 200 if there is no error and return results', async () => {
+
+      const dashboardHelperObject = {
+        personaldetails: jest.fn(() => Promise.resolve({}))
+      }
+
+      dashboardHelperClosure.mockImplementationOnce(() => dashboardHelperObject);
+
+      const { dashboarddata } = makeSut();
+
+      const response = dashboarddata(mockReq, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        200,
+        {},
+        response,
+        mockRes,
+      )
+    })
+
+  });
   
 });

--- a/src/controllers/dashBoardController.spec.js
+++ b/src/controllers/dashBoardController.spec.js
@@ -129,7 +129,7 @@ describe('Dashboard Controller tests', () => {
         .spyOn(UserProfile, 'findOne')
         .mockResolvedValueOnce(mockUser);
 
-      await getPromptCopiedDate(mockReq, mockRes);
+      await getPromptCopiedDate(newReq, mockRes);
 
       expect(mockRes.status).toHaveBeenCalledWith(200);
       expect(mockRes.send).toHaveBeenCalledWith({ message: mockUser.copiedAiPrompt });

--- a/src/controllers/dashBoardController.spec.js
+++ b/src/controllers/dashBoardController.spec.js
@@ -1,0 +1,395 @@
+// const mongoose = require('mongoose');
+const AIPrompt = require('../models/weeklySummaryAIPrompt');
+const { mockReq, mockRes, assertResMock } = require('../test');
+const UserProfile = require('../models/userProfile');
+
+jest.mock('../helpers/dashboardhelper');
+const dashboardHelperClosure = require('../helpers/dashboardhelper');
+const dashBoardController = require('./dashBoardController');
+
+// mock the cache function before importing so we can manipulate the implementation
+// jest.mock('../utilities/nodeCache');
+// const cache = require('../utilities/nodeCache');
+const makeSut = () => {
+  const { 
+    updateCopiedPrompt,
+    getPromptCopiedDate, 
+    updateAIPrompt, 
+    getAIPrompt,
+    monthlydata,
+    weeklydata
+  } = dashBoardController(AIPrompt);
+  return { 
+    updateCopiedPrompt,
+    getPromptCopiedDate,
+    updateAIPrompt,
+    getAIPrompt,
+    monthlydata,
+    weeklydata
+  };
+};
+
+
+const flushPromises = async () => new Promise(setImmediate);
+
+describe('Dashboard Controller tests', () => {
+  beforeAll(() => {
+    const dashboardHelperObject = 
+      {
+        laborthisweek: jest.fn(() => Promise.resolve([]))
+      };
+    dashboardHelperClosure.mockImplementation(() => dashboardHelperObject);
+  });
+  beforeEach(() => {
+    // mockReq.params.userId = '5a7ccd20fde60f1f1857ba16';
+  });
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+  const error = new Error('any error');
+
+
+  describe('updateCopiedPrompt Tests', () => {
+    test('Returns error 500 if the error occurs in the file update function', async () => {
+
+      const { updateCopiedPrompt } = makeSut();
+      
+      jest
+        .spyOn(UserProfile, 'findOneAndUpdate')
+        .mockImplementationOnce(() =>
+          Promise.reject(new Error('Error Occured in the findOneAndUpdate function')),
+        );
+
+      const response = await updateCopiedPrompt(mockReq, mockRes);
+
+      assertResMock(
+        500,
+        new Error('Error Occured in the findOneAndUpdate function'),
+        response,
+        mockRes,
+      );
+    });
+
+    test('Returns error 404 if the user is not found', async () => {
+
+      const { updateCopiedPrompt } = makeSut();
+
+      jest.
+        spyOn(UserProfile, 'findOneAndUpdate')
+        .mockImplementationOnce(() =>
+          Promise.resolve(null)
+        );
+
+      const response = await updateCopiedPrompt(mockReq, mockRes);
+
+      assertResMock(
+        404,
+        { message: "User not found " },
+        response,
+        mockRes,
+      );
+    });
+
+    test('Returns 200 if there is no error and user is found', async () => {
+
+      const { updateCopiedPrompt } = makeSut();
+
+      jest
+        .spyOn(UserProfile, 'findOneAndUpdate')
+        .mockImplementationOnce(() => 
+          Promise.resolve("Copied AI prompt")
+        );
+
+      const response = await updateCopiedPrompt(mockReq, mockRes);
+
+      assertResMock(
+        200,
+        "Copied AI prompt",
+        response,
+        mockRes,
+      );
+    })
+
+  });
+
+  // describe('getPromptCopiedDate', () => {
+  //   test('Returns 200 if there is a user and return copied AI prompt',async () => {
+  //     const { getPromptCopiedDate } = makeSut();
+
+  //     jest
+  //       .spyOn(UserProfile, 'findOne')
+  //       .mockImplementationOnce(() =>
+  //         Promise.resolve({})
+  //       );
+
+  //     const response = getPromptCopiedDate(mockReq, mockRes);
+
+  //     await flushPromises();
+
+  //     assertResMock(
+  //       200,
+  //       {},
+  //       response,
+  //       mockRes,
+  //     );
+  //   })
+  // })
+
+  describe('updateAIPrompt Tests', () => {
+    test('Returns error 500 if the error occurs in the AI Prompt function', async () => {
+      const newRequest = {
+        ...mockReq,
+        body: {
+          requestor: {
+            role: 'Owner'
+          }
+        }
+      };
+
+      const { updateAIPrompt } = makeSut();
+
+      jest
+        .spyOn(AIPrompt, 'findOneAndUpdate')
+        .mockImplementationOnce(() => Promise.reject(error));
+
+      const response = updateAIPrompt(newRequest, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        500,
+        error,
+        response,
+        mockRes,
+      );
+    });
+
+    test('Returns 200 if there is no error and AI Prompt is saved', async () => {
+      const newRequest = {
+        ...mockReq,
+        body: {
+          requestor: {
+            role: 'Owner'
+          }
+        }
+      };
+
+      const { updateAIPrompt } = makeSut();
+
+      jest
+        .spyOn(AIPrompt, 'findOneAndUpdate')
+        .mockImplementationOnce(() => Promise.resolve("Successfully saved AI prompt."));
+
+      const response = updateAIPrompt(newRequest, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        200,
+        "Successfully saved AI prompt.",
+        response,
+        mockRes,
+      );
+    });
+
+    test('Returns undefined if requestor role is not an owner', () => {
+      const newRequest = {
+        ...mockReq,
+        body: {
+          requestor: {
+            role: 'Administrator'
+          }
+        }
+      };
+      const { updateAIPrompt } = makeSut();
+
+      const mockFindOneAndUpdate = jest
+        .spyOn(AIPrompt, 'findOneAndUpdate')
+        .mockImplementationOnce(() => 
+          Promise.resolve({undefined}),
+        );
+      
+      const response = updateAIPrompt(newRequest, mockRes);
+
+      expect(response).toBeUndefined();
+      expect(mockRes.status).not.toHaveBeenCalled();
+      expect(mockRes.send).not.toHaveBeenCalled();
+      expect(mockFindOneAndUpdate).not.toHaveBeenCalled();
+    });
+
+  });
+
+  describe('getAIPrompt Tests', () => {
+    
+    test('Returns 200 if the GPT exists and send the results back', async () => {
+
+      const { getAIPrompt } = makeSut();
+
+      jest
+        .spyOn(AIPrompt,'findById')
+        .mockImplementationOnce(() => Promise.resolve({}))
+
+      const response = getAIPrompt(mockReq, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        200,
+        {},
+        response,
+        mockRes,
+      )
+    });
+
+    test('Returns 200 if there is no error and new GPT Prompt is created', async () => {
+
+      const { getAIPrompt } = makeSut();
+
+      jest
+        .spyOn(AIPrompt, 'findById')
+        .mockResolvedValueOnce(null);
+
+      jest
+        .spyOn(AIPrompt, 'create')
+        .mockImplementationOnce(() => Promise.resolve({}));
+
+      const response = getAIPrompt(mockReq, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        200, 
+        {}, 
+        response, 
+        mockRes,
+        )
+    });
+
+    test('Returns 500 if GPT Prompt does not exist', async () => {
+
+      const { getAIPrompt } = makeSut();
+      const errorMessage = 'GPT Prompt does not exist';
+
+      jest
+        .spyOn(AIPrompt, 'findById')
+        .mockRejectedValueOnce(new Error(errorMessage));
+
+      const response = getAIPrompt(mockReq, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        500,
+        new Error(errorMessage),
+        response,
+        mockRes,
+      );
+    });
+
+    test('Returns 500 if there is an error in creating the GPT Prompt', async () => {
+
+      const { getAIPrompt } = makeSut();
+      const errorMessage = 'Error in creating the GPT Prompt';
+
+      jest
+        .spyOn(AIPrompt, 'findById')
+        .mockResolvedValueOnce(null);
+
+      jest
+        .spyOn(AIPrompt, 'create')
+        .mockRejectedValueOnce(new Error(errorMessage));
+
+      const response = getAIPrompt(mockReq, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        500,
+        new Error(errorMessage),
+        response,
+        mockRes,
+      );
+    }); 
+
+  });
+
+  describe('weeklydata Tests', () => {
+
+    test('Returns 200 if there is no error and labordata is found', async () => {
+      const dashboardHelperObject = 
+      {
+        laborthisweek: jest.fn(() => Promise.resolve([]))
+      };
+
+      dashboardHelperClosure.mockImplementationOnce(() => dashboardHelperObject);
+
+      const { weeklydata } = makeSut();
+
+      const response = weeklydata(mockReq, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        200,
+        [],
+        response,
+        mockRes,
+      );
+    })
+  })
+
+  describe('monthlydata Tests', () => {
+
+    test('Returns 200 if there is no results and return empty results', async () => {
+      const dashboardHelperObject = {
+        laborthismonth: jest.fn(() => Promise.resolve([{
+          projectName: "",
+          timeSpent_hrs: 0,
+      }]))
+      };
+
+      dashboardHelperClosure.mockImplementationOnce(() => dashboardHelperObject);
+
+      const { monthlydata } = makeSut();
+
+      const response = monthlydata(mockReq, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        200,
+        [{
+            projectName: "",
+            timeSpent_hrs: 0,
+        }],
+        response,
+        mockRes,
+      );
+    })
+
+    test('Returns 200 if there is results and return results', async () => {
+      const dashboardHelperObject = {
+        laborthismonth: jest.fn(() => Promise.resolve({}))
+      };
+
+      dashboardHelperClosure.mockImplementationOnce(() => dashboardHelperObject);
+
+      const { monthlydata } = makeSut();
+
+      const response = monthlydata(mockReq, mockRes);
+
+      await flushPromises();
+
+      assertResMock(
+        200,
+        {},
+        response,
+        mockRes,
+      );
+    })
+
+  })
+  
+
+  
+});


### PR DESCRIPTION
# Description
Do unit testing for dashBoard Controller

## Related PRS (if any):
N/A
…

## Main changes explained:
- unit tests for updateCopiedPrompt,
- unit tests for getPromptCopiedDate, 
- unit tests for updateAIPrompt, 
- unit tests for getAIPrompt,
- unit tests for monthlydata,
- unit tests for weeklydata,
- unit tests for leaderboarddata,
-  unit tests for orgData,
- unit tests for dashboarddata,
- unit tests for sendBugReport,
- unit tests for sendMakeSuggestion,
- unit tests for getSuggestionOption,
- unit tests for editSuggestionOption

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. run 'npm run test dashBoardController'
4. verify all tests passed

## Screenshots or videos of changes:
<img width="1356" alt="PR #965" src="https://github.com/user-attachments/assets/1eb27679-59ad-458a-8dd9-499a135041d6">

## Note:
Negative cases not passed for getSuggestionOption and editSuggestionOption

