### PR TITLE
XiaoW_Hotfix of cannot send email when too many edits on time entry 

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -1,7 +1,6 @@
 const moment = require('moment-timezone');
 const mongoose = require('mongoose');
 const logger = require('../startup/logger');
-const { getInfringementEmailBody } = require('../helpers/userHelper')();
 const UserProfile = require('../models/userProfile');
 const Project = require('../models/project');
 const Task = require('../models/task');
@@ -329,7 +328,7 @@ const addEditHistory = async (
       description: `${totalRecentEdits} time entry edits in the last calendar year`,
     });
 
-    const infringementNotificationEmail = `
+    const infringementNotificationToAdminEmailBody = `
     <p>
       ${userprofile.firstName} ${userprofile.lastName} (${userprofile.email}) was issued a blue square for editing their time entries ${totalRecentEdits} times
       within the last calendar year.
@@ -339,28 +338,20 @@ const addEditHistory = async (
     </p>
     `;
 
-    const emailInfringement = {
-      date: moment().tz('America/Los_Angeles').format('MMMM-DD-YY'),
-      description: `You edited your time entries ${totalRecentEdits} times within the last 365 days, exceeding the limit of 4 times per year you can edit them without penalty.`,
-    };
+    const infringementNotificationToUserEmailBody = `You edited your time entries ${totalRecentEdits} times within the last 365 days, exceeding the limit of 4 times per year you can edit them without penalty.`;
 
     pendingEmailCollection.push(
       emailSender.bind(
         null,
         'onecommunityglobal@gmail.com',
         `${userprofile.firstName} ${userprofile.lastName} was issued a blue square for for editing a time entry ${totalRecentEdits} times`,
-        infringementNotificationEmail,
+        infringementNotificationToAdminEmailBody,
       ),
       emailSender.bind(
         null,
         userprofile.email,
         "You've been issued a blue square for editing your time entry",
-        getInfringementEmailBody(
-          userprofile.firstName,
-          userprofile.lastName,
-          emailInfringement,
-          userprofile.infringements.length,
-        ),
+        infringementNotificationToUserEmailBody,
       ),
     );
   }

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -430,6 +430,7 @@ const userProfileController = function (UserProfile) {
 
       if (await hasPermission(req.body.requestor, 'putUserProfileImportantInfo')) {
         const importantFields = [
+          'email',
           'role',
           'isRehireable',
           'isActive',


### PR DESCRIPTION
Remove `getInfringementEmailBody` in `timeEntryContoller` because it is mostly for `userprofileController`. Instead `timeEntryController` just directly add email body to the `emailSender`

minor bug: add 'email' in `importantField` for `userprofileController`