### PR TITLE
Hoang prevent overriding task edit suggestion's approval/rejection

### DIFF
--- a/src/controllers/taskEditSuggestionController.js
+++ b/src/controllers/taskEditSuggestionController.js
@@ -5,9 +5,18 @@ const wbs = require('../models/wbs');
 const taskEditSuggestionController = function (TaskEditSuggestion) {
   const createOrUpdateTaskEditSuggestion = async function (req, res) {
     try {
-      const profile = await userProfile.findById(mongoose.Types.ObjectId(req.body.userId)).select('firstName lastName');
-      const wbsProjectId = await wbs.findById(mongoose.Types.ObjectId(req.body.oldTask.wbsId)).select('projectId');
-      const projectMembers = await userProfile.find({ projects: mongoose.Types.ObjectId(wbsProjectId.projectId) }, '_id firstName lastName profilePic').sort({ firstName: 1, lastName: 1 });
+      const profile = await userProfile
+        .findById(mongoose.Types.ObjectId(req.body.userId))
+        .select('firstName lastName');
+      const wbsProjectId = await wbs
+        .findById(mongoose.Types.ObjectId(req.body.oldTask.wbsId))
+        .select('projectId');
+      const projectMembers = await userProfile
+        .find(
+          { projects: mongoose.Types.ObjectId(wbsProjectId.projectId) },
+          '_id firstName lastName profilePic',
+        )
+        .sort({ firstName: 1, lastName: 1 });
 
       const taskIdQuery = { taskId: mongoose.Types.ObjectId(req.body.taskId) };
       const update = {
@@ -22,7 +31,10 @@ const taskEditSuggestionController = function (TaskEditSuggestion) {
         projectMembers,
       };
       const options = {
-        upsert: true, new: true, setDefaultsOnInsert: true, rawResult: true,
+        upsert: true,
+        new: true,
+        setDefaultsOnInsert: true,
+        rawResult: true,
       };
       const tes = await TaskEditSuggestion.findOneAndUpdate(taskIdQuery, update, options);
       res.status(200).send(tes);
@@ -47,8 +59,16 @@ const taskEditSuggestionController = function (TaskEditSuggestion) {
 
   const deleteTaskEditSuggestion = async function (req, res) {
     try {
-      await TaskEditSuggestion.deleteOne(req.param.taskEditSuggestionId);
-      res.status(200).send({ message: `Deleted task edit suggestion with _id: ${req.param.taskEditSuggestionId}` });
+      const result = await TaskEditSuggestion.deleteOne(req.param.taskEditSuggestionId);
+      if (result.deletedCount === 1) {
+        res.status(200).send({
+          message: `Deleted task edit suggestion with _id: ${req.param.taskEditSuggestionId}`,
+        });
+      } else {
+        res.status(400).send({
+          message: `Failed to delete task edit suggestion with _id: ${req.param.taskEditSuggestionId}`,
+        });
+      }
     } catch (error) {
       res.status(400).send(error);
     }


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HGNRest/assets/35129229/f272a622-664a-42af-a701-8bf9986d58a4)

Issue videos:

https://drive.google.com/file/d/10EGb6LMg6LxpAYdRhUZoHlaZgMe1xHFE/view
https://drive.google.com/file/d/1WyJIv5byGLI0UcwV01nnxkF4Tpz525bY/view
https://drive.google.com/file/d/1atldiRx1NMd2dkuzjo-agL9sm_N_cerg/view *(have to reload to get the suggestions data)*.


## Related PRS (if any):
This backend PR is related to the https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2413 frontend PR.


## Main changes explained:
- Add a check if a deletion of a suggestion fails *(400 status code)* or succeeds *(200 status code)*.


## How to test:
1. Check into current branch
2. Do `npm install` and `npm run dev` to run this PR locally
3. Follow instructions on frontend PR to test


## Screenshots or videos of changes:
None.


## Note:
None.
