### PR TITLE
Diya Changes to return specific error

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -685,7 +685,17 @@ const userProfileController = function (UserProfile) {
             'update',
           );
         })
-        .catch((error) => res.status(400).send(error));
+        .catch((error) => {
+          if (error.name === 'ValidationError' && error.errors.lastName) {
+            const errors = Object.values(error.errors).map(er => er.message);
+            return res.status(400).json({
+              message: 'Validation Error',
+              error: errors,
+            });
+          }
+            console.error('Failed to save record:', error);
+            return res.status(400).json({ error: 'Failed to save record.' });
+        });
     });
   };
 


### PR DESCRIPTION
# Description
Updating the Last Name on the User Profile to an initial throws a 400 error with a localhost webpage error saying "An error occurred while attempting to save this profile"

## Related PRS (if any):
To test this backend PR you need to checkout the frontend PR [#2440](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2440)

## Main changes explained:
- Displaying the error returned from backend

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. View Profile > Change the last name to an initial
6. Verify the localhost:3000 shows the error 'Path 'lastname' ('[_your entered initial_]') is shorter than the minimum allowed length (2).

## Screenshots or videos of changes:

https://github.com/OneCommunityGlobal/HGNRest/assets/54880903/ff0f7f18-e420-4b00-99b6-11ccb6ae6f3e
