### PR TITLE
XiaoW_Hotfix of timer won't max out 5 hour limit

### DIFF
--- a/src/websockets/TimerService/clientsHandler.js
+++ b/src/websockets/TimerService/clientsHandler.js
@@ -117,7 +117,17 @@ const addGoal = (client, msg) => {
   const duration = parseInt(msg.split('=')[1]);
   const goalAfterAddition = moment.duration(client.goal).add(duration, 'milliseconds').asHours();
 
-  if (goalAfterAddition > MAX_HOURS) return;
+  if (goalAfterAddition >= MAX_HOURS) {
+    const oldGoal = client.goal;
+    client.goal = MAX_HOURS * 60 * 60 * 1000;
+    client.time = moment
+      .duration(client.time)
+      .add(client.goal - oldGoal, 'milliseconds')
+      .asMilliseconds()
+      .toFixed();
+
+    return;
+  }
 
   client.goal = moment
     .duration(client.goal)


### PR DESCRIPTION
# Description
Previously if timer goal is within 15 mins range to 5 hour limit, add more time button won't work. This PR address this issue by allowing user to max out to 5 hour limit even when their goal is within 15 min to 5 hour.

## Related PRS (if any):
This frontend PR is related to the #[2454](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2454#issue-2409731161) frontend PR.


