### PR TITLE
Nathan allow same-day time edits

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -700,13 +700,18 @@ const timeEntrycontroller = function (TimeEntry) {
       const isDescriptionModified = newNotes !== timeEntry.notes;
 
       const isUsingAPermission =
+        !isSameDayAuthUserEdit && (
         isTimeModified ||
-        (isDescriptionModified && !isSameDayAuthUserEdit) ||
+        isDescriptionModified) ||
         dateOfWorkChanged ||
         tangibilityChanged;
 
       // Time
-      if (isTimeModified && !(await hasPermission(req.body.requestor, 'editTimeEntryTime'))) {
+      if (
+        !isSameDayAuthUserEdit &&
+        isTimeModified &&
+        !(await hasPermission(req.body.requestor, 'editTimeEntryTime'))
+      ) {
         const error = `You do not have permission to edit the time entry time`;
         return res.status(403).send({ error });
       }


### PR DESCRIPTION
# Description
This PR allows for users to edit time entry time if it is the same day as the time entry.


## Main changes explained:
- edit checks for rejecting time entry edits
- edit which changes require permissions to edit

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as volunteer user
5. log tangible time entry
6. edit time entry time
7. verify the time change saves
8. verify edit appears in userProfile->edit history
