### PR TITLE
Jiadong - Replace Badges Section on Dashboard / badge count APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4903,9 +4903,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001576",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz",
-      "integrity": "sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg=="
+      "version": "1.0.30001646",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001646.tgz",
+      "integrity": "sha512-dRg00gudiBDDTmUhClSdv3hqRfpbOnU28IpI1T6PBTLWa+kOj0681C8uML3PifYfREuBrVjDGhL3adYpBT6spw=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -8311,12 +8311,6 @@
             "node-releases": "^2.0.14",
             "update-browserslist-db": "^1.0.16"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001638",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001638.tgz",
-          "integrity": "sha512-5SuJUJ7cZnhPpeLHaH0c/HPAnAHZvS6ElWyHK9GSIbVOQABLzowiI2pjmpvZ1WEbkyz46iFd4UXlOHR5SqgfMQ==",
-          "dev": true
         },
         "convert-source-map": {
           "version": "2.0.0",

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -230,6 +230,7 @@ const userProfileSchema = new Schema({
   weeklySummaryOption: { type: String },
   bioPosted: { type: String, default: 'default' },
   isFirstTimelog: { type: Boolean, default: true },
+  badgeCount: { type: Number, default: 0 },
   teamCode: {
     type: String,
     default: '',

--- a/src/routes/badgeRouter.js
+++ b/src/routes/badgeRouter.js
@@ -13,6 +13,10 @@ const routes = function (badge) {
 
   badgeRouter.route('/badge/assign/:userId').put(controller.assignBadges);
 
+  badgeRouter.route('/badge/badgecount/:userId').get(controller.getBadgeCount).put(controller.putBadgecount);
+
+  badgeRouter.route('/badge/badgecount/reset/:userId').put(controller.resetBadgecount);
+
   return badgeRouter;
 };
 


### PR DESCRIPTION
# Description
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/65985986/300cfd3d-41ba-4a0a-80f7-dd6ce75d5670)
![image](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/assets/65985986/cd0822c0-3b69-4227-a64a-ff1f1e1e8acf)

## Related PRS (if any):
This backend PR is related to the #https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2529
…

## Main changes explained:
replace badge section on the dash board to Timlog component
add number indicator
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
4. log as admin user
5. go to dashboard -> Other Links -> Badge Management -> assign a new badge to another user.
6. log out
7. Log in as the user who was recently assigned the badge.
8. Check the number indicator on the dashboard.
9. Click on the "Badge" tab to view the assigned badge.
10. Check if the number indicator reset to 0.

## Screenshots or videos of changes:


https://github.com/user-attachments/assets/476243f0-9309-4d25-8df2-4062e0e72453
