### PR TITLE
Jordy add pop up editor controller unit tests

### DIFF
--- a/requirements/popUpEditorController/createPopPopupEditor.md
+++ b/requirements/popUpEditorController/createPopPopupEditor.md
@@ -1,0 +1,14 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# createPopPopupEditor Function
+
+> ### Positive case
+
+> 1. ✅ Should return 201 and the new pop-up editor on success
+
+> ### Negative case
+
+> 1. ✅ Should return 403 if user does not have permission to create a pop-up editor
+> 2. ✅ Should return 400 if the request body is missing required fields
+> 3. ✅ Should return 500 if there is an error saving the new pop-up editor to the database

--- a/requirements/popUpEditorController/getAllPopupEditors.md
+++ b/requirements/popUpEditorController/getAllPopupEditors.md
@@ -1,0 +1,10 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# getAllPopupEditors Function
+
+> ## Positive case
+> 1. ✅ Should return 200 and all pop-up editors on success
+
+> ## Negative case
+> 1. ✅ Should return 404 if there is an error retrieving the pop-up editors from the database

--- a/requirements/popUpEditorController/getPopupEditorById.md
+++ b/requirements/popUpEditorController/getPopupEditorById.md
@@ -1,0 +1,10 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# getPopupEditorById Function
+
+> ## Positive case
+> 1. ✅ Should return 200 and the pop-up editor on success
+
+> ## Negative case
+> 1. ✅ Should return 404 if the pop-up editor is not found

--- a/requirements/popUpEditorController/updatePopupEditor.md
+++ b/requirements/popUpEditorController/updatePopupEditor.md
@@ -1,0 +1,11 @@
+Check mark: ✅
+Cross Mark: ❌
+
+# updatePopupEditor Function
+
+> ## Positive case
+> 1. ✅ Should return 200 and the updated pop-up editor on success
+
+
+> ## Negative case
+> 1. ✅ Should return 404 if the pop-up editor is not found

--- a/src/controllers/popupEditorController.spec.js
+++ b/src/controllers/popupEditorController.spec.js
@@ -1,0 +1,45 @@
+const PopUpEditor = require('../models/popupEditor');
+const { mockReq, mockRes, assertResMock } = require('../test');
+
+jest.mock('../utilities/permissions');
+
+const helper = require('../utilities/permissions');
+const popupEditorController = require('./popupEditorController');
+
+const flushPromises = () => new Promise(setImmediate);
+
+const mockHasPermission = (value) =>
+  jest.spyOn(helper, 'hasPermission').mockImplementationOnce(() => Promise.resolve(value));
+
+const makeSut = () => {
+  const { getAllPopupEditors, getPopupEditorById, createPopupEditor, updatePopupEditor } =
+    popupEditorController(PopUpEditor);
+  return { getAllPopupEditors, getPopupEditorById, createPopupEditor, updatePopupEditor };
+};
+
+describe('popupEditorController Controller Unit tests', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe(`getAllPopupEditors function`, () => {
+    test(`Should return 200 and popup editors on success`, async () => {
+      const { getAllPopupEditors } = makeSut();
+      const mockPopupEditors = [{ popupName: 'popup', popupContent: 'content' }];
+      jest.spyOn(PopUpEditor, 'find').mockResolvedValue(mockPopupEditors);
+      const response = await getAllPopupEditors(mockReq, mockRes);
+      assertResMock(200, mockPopupEditors, response, mockRes);
+    });
+
+    test(`Should return 404 on error`, async () => {
+      const { getAllPopupEditors } = makeSut();
+      const error = new Error('Test Error');
+
+      jest.spyOn(PopUpEditor, 'find').mockRejectedValue(error);
+      const response = await getAllPopupEditors(mockReq, mockRes);
+      await flushPromises();
+
+      assertResMock(404, error, response, mockRes);
+    });
+  });
+});

--- a/src/controllers/popupEditorController.spec.js
+++ b/src/controllers/popupEditorController.spec.js
@@ -42,4 +42,26 @@ describe('popupEditorController Controller Unit tests', () => {
       assertResMock(404, error, response, mockRes);
     });
   });
+
+  describe(`getPopupEditorById function`, () => {
+    test(`Should return 200 and popup editor on success`, async () => {
+      const { getPopupEditorById } = makeSut();
+      const mockPopupEditor = { popupName: 'popup', popupContent: 'content' };
+      jest.spyOn(PopUpEditor, 'findById').mockResolvedValue(mockPopupEditor);
+      const response = await getPopupEditorById(mockReq, mockRes);
+      assertResMock(200, mockPopupEditor, response, mockRes);
+    });
+
+    test(`Should return 404 on error`, async () => {
+      const { getPopupEditorById } = makeSut();
+      const error = new Error('Test Error');
+
+      jest.spyOn(PopUpEditor, 'findById').mockRejectedValue(error);
+      const response = await getPopupEditorById(mockReq, mockRes);
+      await flushPromises();
+
+      assertResMock(404, error, response, mockRes);
+    });
+  });
+
 });


### PR DESCRIPTION
# Description

Unit tests for popupEditorController

## Related PRS (if any):
N/A

## Main changes explained:

- unit tests for `getAllPopupEditors`
- unit tests for `getPopupEditorById`
- unit tests for `createPopupEditor`
- unit tests for `updatePopupEditor`


## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. run `npm run test popupeditor -- --verbose`

## Screenshots
<img width="579" alt="Screenshot 2024-08-04 at 1 32 48 AM" src="https://github.com/user-attachments/assets/e7f4ec1a-fad1-4402-8573-2fb1bc91ef31">

## Note:

Check that all tests are passing
N/A