### PR TITLE
Nathan fix isUsingAPermission logic

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -709,9 +709,7 @@ const timeEntrycontroller = function (TimeEntry) {
 
       const isNotUsingAPermission =
         (!canEditTimeEntryTime && isTimeModified) ||
-        (!canEditTimeEntryDescription && isDescriptionModified) ||
-        (!canEditTimeEntryDate && dateOfWorkChanged) ||
-        (!canEditTimeEntryIsTangible && tangibilityChanged);
+        (!canEditTimeEntryDate && dateOfWorkChanged);
 
       // Time
       if (


### PR DESCRIPTION
# Description
This PR corrects the logic so users with permission to update time entries only get an edit history if they are not using any permissions.

## Main changes explained:
- Edit `is(Not)UsingAPermission` logic

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Edit task time
6. Don't get new edit history in user profile


