### PR TITLE
fix: fixed add new warning to user bug

### DIFF
--- a/src/controllers/warningsController.js
+++ b/src/controllers/warningsController.js
@@ -1,3 +1,4 @@
+/* eslint-disable */
 const mongoose = require('mongoose');
 const userProfile = require('../models/userProfile');
 
@@ -30,25 +31,22 @@ const warningsController = function (UserProfile) {
     try {
       const { userId } = req.params;
 
-      const {
- iconId, color, date, description,
-} = req.body;
+      const { iconId, color, date, description } = req.body;
 
       const record = await UserProfile.findById(userId);
       if (!record) {
         return res.status(400).send({ message: 'No valid records found' });
       }
 
-      record.warnings = record.warnings.concat({
-        userId,
-        iconId,
-        color,
-        date,
-        description,
-      });
-      await record.save();
+      const updatedWarnings = await userProfile.findByIdAndUpdate(
+        {
+          _id: userId,
+        },
+        { $push: { warnings: { userId, iconId, color, date, description } } },
+        { new: true, upsert: true },
+      );
 
-      const completedData = filterWarnings(record.warnings);
+      const completedData = filterWarnings(updatedWarnings.warnings);
 
       res.status(201).send({ message: 'success', warnings: completedData });
     } catch (error) {
@@ -72,9 +70,7 @@ const warningsController = function (UserProfile) {
       }
 
       const sortedWarnings = filterWarnings(warnings.warnings);
-      res
-        .status(201)
-        .send({ message: 'succesfully deleted', warnings: sortedWarnings });
+      res.status(201).send({ message: 'succesfully deleted', warnings: sortedWarnings });
     } catch (error) {
       res.status(401).send({ message: error.message || error });
     }


### PR DESCRIPTION
# Description
Hot fix for adding new warning to a user. 
Would crash when attempting to add a new warning. 

## Related PRS (if any):


## Main changes explained:
-the error was when assigning a new warning to a user  it error saying an error occurred
-instead I used mongoose findByIdAndUpdate method to update a single entity instead of the entire document 


## How to test:
1. check into current branch
2. do `npm run build && npm run start` 
3. Log as Owner account
4. assign a new warning to a user, ensure it doesn't crash by opening the console. 
5. view if the user' received the warning. 
6. refresh and ensure the warning is saved. 


## Screenshots or videos of changes:

https://github.com/user-attachments/assets/3c84b579-face-4823-9b2f-ba7d010efe22


## Note:
