### PR TITLE
ambika fix core team unique additions in leaderboard

### DIFF
--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -203,6 +203,7 @@ const dashboardhelper = function () {
             timeOffFrom: 1,
             timeOffTill: 1,
             endDate: 1,
+            missedHours: 1,
           }
 
         );
@@ -220,7 +221,7 @@ const dashboardhelper = function () {
             timeOffFrom: 1,
             timeOffTill: 1,
             endDate: 1,
-
+            missedHours: 1,
           },
         );
       }
@@ -269,6 +270,7 @@ const dashboardhelper = function () {
               ? teamMember.weeklySummaries[0].summary !== ''
               : false,
           weeklycommittedHours: teamMember.weeklycommittedHours,
+          missedHours: (teamMember.missedHours ?? 0),
           totaltangibletime_hrs:
             (timeEntryByPerson[teamMember._id.toString()]?.tangibleSeconds ?? 0) / 3600,
           totalintangibletime_hrs:

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -703,7 +703,7 @@ const userHelper = function () {
                 .localeData()
                 .ordinal(
                   oldInfringements.length + 1,
-                )} blue square. So you should have completed ${weeklycommittedHours} hours and you completed ${timeSpent.toFixed(
+                )} blue square. So you should have completed ${weeklycommittedHours + coreTeamExtraHour} hours and you completed ${timeSpent.toFixed(
                 2,
               )} hours.`;
             } else {
@@ -727,7 +727,7 @@ const userHelper = function () {
                 .localeData()
                 .ordinal(
                   oldInfringements.length + 1,
-                )} blue square. So you should have completed ${weeklycommittedHours} hours and you completed ${timeSpent.toFixed(
+                )} blue square. So you should have completed ${weeklycommittedHours + coreTeamExtraHour} hours and you completed ${timeSpent.toFixed(
                 2,
               )} hours.`;
             } else {

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -656,7 +656,7 @@ const userHelper = function () {
         }
         // No extra hours is needed if blue squares isn't over 5.
         // length +1 is because new infringement hasn't been created at this stage.
-        const coreTeamExtraHour = Math.max(0, oldInfringements.length - 5);
+        const coreTeamExtraHour = Math.max(0, oldInfringements.length + 1 - 5);
         const utcStartMoment = moment(pdtStartOfLastWeek).add(1, 'second');
         const utcEndMoment = moment(pdtEndOfLastWeek).subtract(1, 'day').subtract(1, 'second');
 


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/14fffe22-886a-4e7a-a4d4-26ec42295a77)

This PR addresses the following issues:

- Leaderboard Issue: The leaderboard wasn't updating correctly when additional hours were needed due to missed hours in a unique Core Team role. It was incorrectly showing a green dot based on weekly hours instead of accounting for the special case when hours were missed.

- Timelog Display: The timelog was not reflecting the accurate hours a person needed to complete for a unique Core Team role. It was failing to include the extra hours required due to the presence of more than five blue squares.

- Blue Square Mouseover: When hovering over the blue square in a user's profile, if the number of blue squares exceeds five, additional unique hours should be assigned to the Core Team user. The calculation now correctly updates the required hours as follows: committed hours + (additional makeup hours from last week) + (if the number of blue squares is greater than 5, then (number of blue squares - 5) hours).

- Additional Makeup Hours Calculation: The "additional makeup hours" field in the user's profile now correctly includes hours added when the number of blue squares exceeds five.

Fixes # (bug list priority medium)

## Related PRS (if any):
To test this backend PR you need to checkout the [2600](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2600) frontend PR.

## Main changes explained:
- Update file dashboardHelper.js for including missedHours in case of Core Team role in timelog
- Update file userHelper.js for including additional hours in case of the number of blue squares exceeds five.

## How to test:
1. check into current branch, `git checkout ambika-fix-core-team-unique-hours-additions` and `git pull`
2. do `npm install` and `npm run build && npm start` to run this PR locally
3. Clear site data/cache
4.  log as user with core team role
5. Verify that if additional makeup hours are assigned for this week, the leaderboard will display a red status if those hours are not completed. On mouseover, the additional makeup hours should also be visible, as demonstrated below:
![image](https://github.com/user-attachments/assets/be1d91a7-8907-4290-bf7d-e34ea39bb557).
6. Verify that if there are no additional makeup hours for this week, the green and red statuses on the leaderboard will function based on the weekly committed hours for the Core Team user. On mouseover, the tooltip will not display any information regarding additional makeup hours for this week.
7. Verify that in userprofile, on mouseover for bluesquare, hours added when the number of blue squares exceeds five
8. Verify that in userprofile, the additional make up hours for this week field includes the hours added when the number of blue squares exceeds five as well.
9. Verify that in timelog, the total hours includes hours added when the number of blue squares exceeds five.

## Screenshots or videos of changes:
Video is attached in frontend PR [2600](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2600)
## Note:
- To test this PR, create a new user with the Core Team role.
- To fix an existing core team user's additional makeup hours, first, log in as the owner. Then, manually edit the makeup hours for this week in the user's profile. Login in back as existing core team's user, moving forward, the hours will be calculated correctly on a weekly basis.