### PR TITLE
Vijay Anand - Assign one or multiple badges to one or more multiple users api

### DIFF
--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -71,6 +71,12 @@ const badgeController = function (Badge) {
    * Updated By: Abi
    * Function added:
    * - Refactored method to utilize async await syntax to make the code more testable.
+   * 
+   * Updated Date: 08/31/2024
+   * Updated By: Vijay Anand
+   * Function added:
+   * - Refactored method to handle assigning badge one or multiple badges to one or multiple users at once.
+   * - Refactored method to handle update badges report for a user ID.
    */
 
   const assignBadges = async function (req, res) {
@@ -78,92 +84,81 @@ const badgeController = function (Badge) {
       res.status(403).send('You are not authorized to assign badges.');
       return;
     }
-
-    const userToBeAssigned = mongoose.Types.ObjectId(req.params.userId);
-
-    try {
-      const record = await UserProfile.findById(userToBeAssigned);
-      if (record === null) {
-        res.status(400).send('Can not find the user to be assigned.');
-        return;
-      }
-      let totalNewBadges = 0;
-      const existingBadges = {};
-      if (record.badgeCollection && Array.isArray(record.badgeCollection)) {
-        record.badgeCollection.forEach(badgeItem => {
-          existingBadges[badgeItem.badge] = badgeItem.count;
-        });
-      }
-
-      const badgeGroups = req.body.badgeCollection.reduce((grouped, item) => {
-        const { badge } = item;
-
-        if (typeof item.count !== 'number') {
-          item.count = Number(item.count);
-          if (Number.isNaN(item.count)) {
-            return grouped;
-          }
-        }
-        // if count is 0, skip
-        if (item.count === 0) {
-          return grouped;
-        }
-
-
-        if (!grouped[badge]) {
-          // If the badge is not in the grouped object, add a new entry
-          grouped[badge] = {
-            count: item.count,
-            lastModified: item.lastModified ? item.lastModified : Date.now(),
-            featured: item.featured || false,
-            earnedDate: item.earnedDate,
-          };
-        } else {
-          // If the badge is already in the grouped object, update properties
-          grouped[badge].count += item.count;
-          grouped[badge].lastModified = Date.now();
-          grouped[badge].featured = grouped[badge].featured || item.featured || false;
-
-          // Combine and sort earnedDate arrays
-          if (Array.isArray(item.earnedDate)) {
-            const combinedEarnedDate = [...grouped[badge].earnedDate, ...item.earnedDate];
-            const timestampArray = combinedEarnedDate.map((date) => new Date(date).getTime());
-            timestampArray.sort((a, b) => a - b);
-            grouped[badge].earnedDate = timestampArray.map((timestamp) =>
-              new Date(timestamp)
-                .toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: '2-digit' })
-                .replace(/ /g, '-')
-                .replace(',', ''),
-            );
-          }
-        }
-        if (existingBadges[badge]) {
-          totalNewBadges += Math.max(0, item.count - existingBadges[badge]);
-        } else {
-          totalNewBadges += item.count;
-        }
-
-        return grouped;
-      }, {});
-
-      // Convert badgeGroups object to array
-      const badgeGroupsArray = Object.entries(badgeGroups).map(([badge, data]) => ({
-        badge,
-        count: data.count,
-        lastModified: data.lastModified,
-        featured: data.featured,
-        earnedDate: data.earnedDate,
+  
+    let userIds, badgeCollection;
+  
+    if (req.params.userId) {
+      // Single user update case
+      userIds = [req.params.userId];
+      badgeCollection = req.body.badgeCollection;
+    } else {
+      // Multi-user assign case
+      userIds = req.body.userIds;
+      badgeCollection = req.body.selectedBadges.map(badgeId => ({
+        badge: badgeId.replace('assign-badge-', ''),
+        count: 1,
+        lastModified: Date.now(),
+        earnedDate: [new Date().toISOString()],
       }));
-
-      record.badgeCollection = badgeGroupsArray;
-      record.badgeCount += totalNewBadges;
-
-      if (cache.hasCache(`user-${userToBeAssigned}`)) {
-        cache.removeCache(`user-${userToBeAssigned}`);
+    }
+  
+    if (!Array.isArray(userIds) || userIds.length === 0 || !Array.isArray(badgeCollection) || badgeCollection.length === 0) {
+      res.status(400).send('Invalid input. Both userIds and badgeCollection must be non-empty arrays.');
+      return;
+    }
+  
+    try {
+      const results = await Promise.all(
+        userIds.map(async (userId) => {
+          const userToBeAssigned = mongoose.Types.ObjectId(userId);
+          const record = await UserProfile.findById(userToBeAssigned);
+  
+          if (!record) {
+            return { userId, error: 'User not found' };
+          }
+  
+          let totalNewBadges = 0;
+          const existingBadges = {};
+          if (record.badgeCollection && Array.isArray(record.badgeCollection)) {
+            record.badgeCollection.forEach(badgeItem => {
+              existingBadges[badgeItem.badge.toString()] = badgeItem;
+            });
+          }
+  
+          const updatedBadgeCollection = badgeCollection.map(badge => {
+            const existingBadge = existingBadges[badge.badge.toString()];
+            const newCount = (existingBadge ? existingBadge.count : 0) + badge.count;
+            if (!existingBadge) totalNewBadges += badge.count;
+  
+            return {
+              badge: mongoose.Types.ObjectId(badge.badge),
+              count: newCount,
+              lastModified: Date.now(),
+              earnedDate: [
+                ...(existingBadge ? existingBadge.earnedDate : []),
+                ...(badge.earnedDate || [new Date().toISOString()])
+              ],
+            };
+          });
+  
+          record.badgeCollection = updatedBadgeCollection;
+          record.badgeCount += totalNewBadges;
+  
+          if (cache.hasCache(`user-${userToBeAssigned}`)) {
+            cache.removeCache(`user-${userToBeAssigned}`);
+          }
+  
+          await record.save();
+          return { userId, success: true };
+        })
+      );
+  
+      const errors = results.filter(result => result.error);
+      if (errors.length > 0) {
+        res.status(207).send({ message: 'Some users were not assigned badges', errors });
+      } else {
+        res.status(200).send({ message: 'Badges assigned successfully to all users' });
       }
-
-      const results = await record.save();
-      res.status(201).send(results._id);
     } catch (err) {
       res.status(500).send(`Internal Error: Badge Collection. ${err.message}`);
     }

--- a/src/routes/badgeRouter.js
+++ b/src/routes/badgeRouter.js
@@ -11,6 +11,8 @@ const routes = function (badge) {
 
   badgeRouter.route('/badge/:badgeId').delete(controller.deleteBadge).put(controller.putBadge);
 
+  badgeRouter.route('/badge/assign').post(controller.assignBadges);
+
   badgeRouter.route('/badge/assign/:userId').put(controller.assignBadges);
 
   badgeRouter.route('/badge/badgecount/:userId').get(controller.getBadgeCount).put(controller.putBadgecount);

--- a/src/routes/badgeRouter.js
+++ b/src/routes/badgeRouter.js
@@ -13,7 +13,7 @@ const routes = function (badge) {
 
   badgeRouter.route('/badge/assign').post(controller.assignBadges);
 
-  badgeRouter.route('/badge/assign/:userId').put(controller.assignBadges);
+  badgeRouter.route('/badge/assign/:userId').put(controller.assignBadgesToSingleUser);
 
   badgeRouter.route('/badge/badgecount/:userId').get(controller.getBadgeCount).put(controller.putBadgecount);
 


### PR DESCRIPTION
# Description
This functionality will allow the authorized users to assign one or multiple badges to one or multiple at once.

## Related PRS (if any):
To test this backend PR you need to checkout the [#PR2642](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/2642) frontend PR.


## Main changes explained:
- Added Controller function and a new route to handle assigning one or multiple badges to one or multiple users.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to dashboard→ Other Links→ Badge Management→ Badge Assignment tab
6. verify if the user can search and select single or multiple users
7. verify if the user can select and assign one or multiple badges.
8. verify if the user gets a success alert message.
9.  To verify if the badge got assigned go to dashboard→ Other Links→ User Management and search for each user(s) who were assigned badges and check the Featured Badges section of their user profile.
10. Click on the "Select Featured" button and verify if the user can delete one or multiple badges.

## Screenshots or videos of changes:
https://www.loom.com/share/6b0da3c16b6f40de96871af0d8e4eb42?sid=3228f60b-5a00-4cb4-b60b-4f5637519a73

## Note:
There are some memory leaks from other components when you find one please mention the source component so that it will be helpful for me.
