### PR TITLE
Huijie - fix recalculation for tangible hours

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -1380,7 +1380,7 @@ const timeEntrycontroller = function (TimeEntry) {
       res.setHeader('Transfer-Encoding', 'chunked');
       keepAliveInterval = setInterval(() => {
         res.write('Processing... keep connection alive\n');
-      }, 100 * 1000); // interval of 100 seconds
+      }, 150 * 1000); // interval of 150 seconds
 
       const userprofiles = await UserProfile.find({}, '_id').lean();
 
@@ -1392,9 +1392,6 @@ const timeEntrycontroller = function (TimeEntry) {
       await Promise.all(recalculationPromises);
 
       await session.commitTransaction();
-      // return res.status(200).send({
-      //   message: 'finished the recalculation for hoursByCategory for all users',
-      // });
       clearInterval(keepAliveInterval);
       res.write('finished the recalculation for hoursByCategory for all users\n');
       return res.end();
@@ -1405,7 +1402,6 @@ const timeEntrycontroller = function (TimeEntry) {
       }
       logger.logException(err);
       res.write(`error: ${err.toString()}\n`);
-      // return res.status(500).send({ error: err.toString() });
       return res.end();
     } finally {
       session.endSession();

--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -1373,8 +1373,15 @@ const timeEntrycontroller = function (TimeEntry) {
   const recalculateHoursByCategoryAllUsers = async function (req, res) {
     const session = await mongoose.startSession();
     session.startTransaction();
+    let keepAliveInterval;
 
     try {
+      res.setHeader('Content-Type', 'text/plain');
+      res.setHeader('Transfer-Encoding', 'chunked');
+      keepAliveInterval = setInterval(() => {
+        res.write('Processing... keep connection alive\n');
+      }, 100 * 1000); // interval of 100 seconds
+
       const userprofiles = await UserProfile.find({}, '_id').lean();
 
       const recalculationPromises = userprofiles.map(async (userprofile) => {
@@ -1385,13 +1392,21 @@ const timeEntrycontroller = function (TimeEntry) {
       await Promise.all(recalculationPromises);
 
       await session.commitTransaction();
-      return res.status(200).send({
-        message: 'finished the recalculation for hoursByCategory for all users',
-      });
+      // return res.status(200).send({
+      //   message: 'finished the recalculation for hoursByCategory for all users',
+      // });
+      clearInterval(keepAliveInterval);
+      res.write('finished the recalculation for hoursByCategory for all users\n');
+      return res.end();
     } catch (err) {
       await session.abortTransaction();
+      if (keepAliveInterval) {
+        clearInterval(keepAliveInterval);
+      }
       logger.logException(err);
-      return res.status(500).send({ error: err.toString() });
+      res.write(`error: ${err.toString()}\n`);
+      // return res.status(500).send({ error: err.toString() });
+      return res.end();
     } finally {
       session.endSession();
     }


### PR DESCRIPTION
# Description
the API for recalculating tangible hours for all users in PR #1004 got errors due to Azure's time limit for idle TCP connections. This PR sends "keep-alive" messages every 150 seconds to the connection active.

## Related PRS (if any):
This backend PR is a fix for #1004 

## How to test:
1. check into current branch
2. do `npm install`, `npm run build` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as any user
5. (before merging)  use Postman to send POST request to `http://localhost:4500/api/TimeEntry/recalculateHoursAllUsers/tangible`
6. (after merging) use Postman to send POST request to `https://hgn-rest-dev.azurewebsites.net/api/TimeEntry/recalculateHoursAllUsers/tangible` for Dev or `https://hgn-rest-beta.azurewebsites.net/api/TimeEntry/recalculateHoursAllUsers/tangible` for Prod and check the response messages
