### PR TITLE
Yashwanth fix: update password error

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -1035,7 +1035,7 @@ const userProfileController = function (UserProfile, Project) {
     const hasUpdatePasswordPermission = await hasPermission(requestor, 'updatePassword');
 
     // if they're updating someone else's password, they need the 'updatePassword' permission.
-    if (!hasUpdatePasswordPermission) {
+    if (userId !== requestor.requestorId && !hasUpdatePasswordPermission) {
       return res.status(403).send({
         error: "You are unauthorized to update this user's password",
       });


### PR DESCRIPTION
# Description
![reset_password_func_fix](https://github.com/user-attachments/assets/a1aeac9b-c4e3-4a9d-9f48-0711749cfd2c)
Fixed a bug preventing Volunteers to update their own password
…

## Main changes explained:
- Added an extra permission check which allows users update their own password
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as volunteer/admin user
5. Profile Page>Update Password
6. verify user is able to update password

## Screenshots or videos of changes:
After changes:
![bugfix_1](https://github.com/user-attachments/assets/13238594-b9b9-4988-ba5c-e35dbc2a91c8)

## Note:
I’ve tested for both Volunteer and Admin roles. Please let me know if I missed any other user types or if I assigned permissions incorrectly.
