### PR TITLE
Huijie fix add lost hours editing deleting

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -866,7 +866,7 @@ const timeEntrycontroller = function (TimeEntry) {
       }
       await timeEntry.save({ session });
       if (userprofile) {
-        await userprofile.save({ session });
+        await userprofile.save({ session, validateModifiedOnly: true });
 
         // since userprofile is updated, need to remove the cache so that the updated userprofile is fetched next time
         removeOutdatedUserprofileCache(userprofile._id.toString());
@@ -939,7 +939,7 @@ const timeEntrycontroller = function (TimeEntry) {
 
       await timeEntry.remove({ session });
       if (userprofile) {
-        await userprofile.save({ session });
+        await userprofile.save({ session, validateModifiedOnly: true });
 
         // since userprofile is updated, need to remove the cache so that the updated userprofile is fetched next time
         removeOutdatedUserprofileCache(userprofile._id.toString());

--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -593,7 +593,7 @@ const timeEntrycontroller = function (TimeEntry) {
 
       await timeEntry.save({ session });
       if (userprofile) {
-        await userprofile.save({ session });
+        await userprofile.save({ session, validateModifiedOnly: true });
         // since userprofile is updated, need to remove the cache so that the updated userprofile is fetched next time
         removeOutdatedUserprofileCache(userprofile._id.toString());
       }


### PR DESCRIPTION
# Description
![1](https://github.com/user-attachments/assets/595c7d08-c489-4f85-851a-775a06821b74)

## Related PRS (if any):
This backend PR is related to the frontend PR 2710.

## Main changes explained:
The error when adding, editing, or deleting lost hours is caused by a Mongoose validation error for users with an empty `jobTitle` field. Setting the `validateModifiedOnly` option to true when saving updates to the user profile can ensure that only modified fields are validated.

## How to test:
1. check into current branch
2. do `npm install`, `run run build` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as admin or owner user (admin user do not have permission for adding lost hours)
5. go to Reports -> Reports -> Add Lost Time, or Show Person Lost Time, verify that the following errors do not occur:
6. owners do not get a 500 error when adding a person's lost time:
    error image before the PR
    <img width="300" alt="2" src="https://github.com/user-attachments/assets/ae4da3cf-915a-49ef-9d19-64d04cf374e3">
7. Do not get an error when updating a person's lost time
    error image before the PR
    <img width="300" alt="2" src="https://github.com/user-attachments/assets/c17307f8-9917-4457-8039-712fdd8b0d58">
8. Do not get an error when deleting a person's lost time
    error image before the PR:
    <img width="300" alt="2" src="https://github.com/user-attachments/assets/ec2de848-3797-4ed6-8b8f-a24913b4c1eb">
9. owners do not get an error when adding a lost time for team or project: 
    error image before the PR:
    <img width="300" alt="2" src="https://github.com/user-attachments/assets/3bdf3fd8-ee08-4b64-a3ee-794884d5bb2f">
Thank you!