### PR TITLE
Ambika fix some tasks not appearing in tasks tab or dropdown

### DIFF
--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -291,8 +291,17 @@ const projectController = function (Project) {
       res.status(400).send('Invalid request');
       return;
     }
-    const getId = await hasPermission(req.body.requestor, 'getProjectMembers');
 
+    const getProjMembers = await hasPermission(req.body.requestor, 'getProjectMembers');
+
+    // If a user has permission to post, edit, or suggest tasks, they also have the ability to assign resources to those tasks. 
+    // Therefore, the _id field must be included when retrieving the user profile for project members (resources).
+    const postTask = await hasPermission(req.body.requestor, 'postTask');
+    const updateTask = await hasPermission(req.body.requestor, 'updateTask');
+    const suggestTask = await hasPermission(req.body.requestor, 'suggestTask');
+
+    const getId = (getProjMembers || postTask || updateTask || suggestTask);
+    
     userProfile
       .find(
         { projects: projectId },


### PR DESCRIPTION
# Description

When a user with limited permissions, rather than an owner or admin role, tries to assign tasks, some tasks do not appear in the tasks tab or dropdown, and other team members are unable to log time for those tasks.

Fixes # (bug list priority high)

## Related PRS (if any):
To test this backend PR you need to checkout the development branch of frontend.

## Main changes explained:
- Update file src/controllers/projectController.js to modify the permissions logic when retrieving the IDs of project members.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Create a new user with the role of "volunteer."
6. Navigate to "Other links" > "Permissions management."
7. Click on "Manage user permissions" and search for the newly created volunteer user.
8. Assign the "Add Task" permission to this volunteer user and submit the changes.
9. Log in as the volunteer.
10. Go to "Other links" > "Projects."
11. Open any project that already has members and at least one WBS created.
12. Click on the WBS icon for that project, navigate into one of the WBS and list of task will be visible 
13. Add a task by entering a task name, assigning a resource which will be project member, and providing an estimated time, then click "Save."
14. Verify that the new task is visible in the task list.
15. Go to the user profile of the member who was assigned the task.
16. Notice that the task does appear under the "Projects" tab for this member.

## Screenshots or videos of changes:

## Note:

Follow steps 4 through 15 before pulling from the current branch, and note that the task does not appear under the "Projects" tab for this member.

If there are tasks which are not not visible to members' task tab, take pull on current branch, edit the task by removing the member from the resource field and reassigning them. This will resolve the issue.