### PR TITLE
Ambika implement set final day function to deactivate user

### DIFF
--- a/src/cronjobs/userProfileJobs.js
+++ b/src/cronjobs/userProfileJobs.js
@@ -19,6 +19,16 @@ const userProfileJobs = () => {
       }
       await userhelper.awardNewBadges();
       await userhelper.reActivateUser();
+    },
+    null,
+    false,
+    'America/Los_Angeles',
+  );
+
+  // Job to run every day, 1 minute past midnight to deactivate the user
+  const dailyUserDeactivateJobs = new CronJob(
+    '1 0 * * *', // Every day, 1 minute past midnight
+    async () => {
       await userhelper.deActivateUser();
     },
     null,
@@ -27,5 +37,6 @@ const userProfileJobs = () => {
   );
 
   allUserProfileJobs.start();
+  dailyUserDeactivateJobs.start();
 };
 module.exports = userProfileJobs;


### PR DESCRIPTION
# Description
**This implementation addresses the following issue:**
- Users are not being deactivated after the final end date has passed, and they remain active.

![image](https://github.com/user-attachments/assets/ce842537-4540-40ef-a4cc-a2ac27f5cbde)

Fixes # (bug list priority high)

## Related PRS (if any):
N/A

## Main changes explained:
- **Prior to this implementation, user profiles were deactivated only on Sundays at 12:01 AM, regardless of the final day set.**
- UserProfileJobs.js file was updated by adding another cron job that triggers daily at 12:01 AM to deactivate users.
- Explanation of "1 0 * * *" in cronJob: [Link](https://crontab.guru/#1_0_*_*_*)

## How to test:
1. check into current branch
3. do `npm install` and `...` to run this PR locally
4. Clear site data/cache
5. Log in as the owner user.
6. Navigate to the dashboard and open the user profile of a volunteer role user from the Leaderboard/User Management section.
7. Set the final day for the volunteer role user.
8. Verify that the user is deactivated after the final day has passed. For example, if the final day is set to October 7 (tomorrow) and today is October 6, the user's last working day will be October 7, and their profile will be deactivated at 12:01 AM on October 8.

## Screenshots or videos of changes:
After implementation:
https://drive.google.com/file/d/1I2VftIqfEW7SXuvhnZXoiLiMHgzwM_ni/view?usp=sharing

## Note:

