### PR TITLE
Crystal fix tasks of members are hidden when teams toggle is off

### DIFF
--- a/src/helpers/taskHelper.js
+++ b/src/helpers/taskHelper.js
@@ -112,9 +112,15 @@ const taskHelper = function () {
           );
 
           sharedTeamsResult.forEach((_myTeam) => {
+            let hasTeamVisibility = false;
             _myTeam.members.forEach((teamMember) => {
-              if (!teamMember.userId.equals(userid)) teamMemberIds.push(teamMember.userId);
+              if (teamMember.userId.equals(userid) && teamMember.visible) hasTeamVisibility = true;
             });
+            if (hasTeamVisibility) {
+              _myTeam.members.forEach((teamMember) => {
+                if (!teamMember.userId.equals(userid)) teamMemberIds.push(teamMember.userId);
+              });
+            }
           });
 
           teamMembers = await userProfile


### PR DESCRIPTION
# Description
<img width="701" alt="image" src="https://github.com/user-attachments/assets/d2b28d61-f18f-4232-9154-61c22a6e67c2">

Bug priority high

## Related PRS (if any):
To test this backend PR you need to checkout the development frontend PR.

## Main changes explained:
- Implement condition so that users (besides Owner/Admin/Core Team) cannot view team's tasks when their team toggle visibility is off

## How to test:
1. Check into current branch:  `git checkout crystal-followup-fix-so-tasks-of-members-are-hidden-with-the-teams-toggle`
2. Do `npm install`, `npm run build` and `npm run start` to run this PR locally
3. Clear site data/cache
4. Log as Admin user
5. Go to Dashboard → Other Links→ Teams →…
6. Add members to the team to test. Verify that user with team visibility toggle off:
  - Owner role -> Can view other members tasks
![User with Owner role visibility toggle off still can view other member’s task](https://github.com/user-attachments/assets/3349c947-ac8c-43fb-bc59-c4c604254c51)

  - Admin role -> Can view other members tasks
![User with Admin role visibility toggle off can still view other member’s task](https://github.com/user-attachments/assets/345c97c2-ffad-4261-9f44-aadd024da1f2)

  - Core Team role -> Can view other members tasks
![User with Core Team role visibility toggle off still can view other member’s task](https://github.com/user-attachments/assets/7b8e6f2b-04ab-4cdf-86e8-869df56f42a9)

  - Manager role -> CANNOT view other members tasks
![User with Manager role visibility toggle off cannot view other member’s task](https://github.com/user-attachments/assets/9ca4311a-374e-4f40-aad4-de5f8aceebac)

  - Volunteer role -> CANNOT view other members tasks
![User with Volunteer role visibility toggle off cannot view other member’s task](https://github.com/user-attachments/assets/c7f9bdd5-3a9a-4bf9-ab07-5f265dede5c5)

  - Volunteer role (user has 2 teams)-> CANNOT view other members tasks 
![User with Volunteer role visibility toggle off cannot view other member’s task, testing with 2 teams](https://github.com/user-attachments/assets/a451d465-604e-471e-b5c5-c62eca4b2440)

## Screenshots or videos of changes:
How to set team member visibility's toggle. (refer to video below)

https://github.com/user-attachments/assets/16770b2e-a7a7-429c-9046-b51347128d01

Example of changes when testing user: Crystal Volunteer with Volunteer role.  (refer to video below)

https://github.com/user-attachments/assets/67a0e531-034b-42c3-8e77-9eebf630196a


