### PR TITLE
Denish - get volunteers over assigned time

### DIFF
--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -83,6 +83,8 @@ const reportsController = function () {
         // volunteerTrends,
         completedHours,
         taskAndProjectStats,
+        volunteersOverAssignedTime,
+
       ] = await Promise.all([
         overviewReportHelper.getVolunteerNumberStats(
           isoStartDate,
@@ -142,6 +144,7 @@ const reportsController = function () {
           comparisonStartDate,
           comparisonEndDate,
         ),
+        overviewReportHelper.getVolunteersOverAssignedTime(isoStartDate, isoEndDate),
       ]);
       res.status(200).send({
         volunteerNumberStats,
@@ -159,6 +162,7 @@ const reportsController = function () {
         // volunteerTrends,
         completedHours,
         taskAndProjectStats,
+        volunteersOverAssignedTime,
       });
     } catch (err) {
       console.log(err);

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -1559,7 +1559,8 @@ const overviewReportHelper = function () {
 
     return { count: totalTeams }
   }
-  async function getVolunteersOverAssignedTime(startDate, endDate) {
+
+  async function getVolunteersOverAssignedTime(isoStartDate, isoEndDate) {
     const volunteersOverAssignedTime = await UserProfile.aggregate([
       {
         $match: {
@@ -1582,9 +1583,9 @@ const overviewReportHelper = function () {
       },
       {
         $match: {
-          'timeEntries.dateOfWork': {
-            $gte: moment(startDate).format('YYYY-MM-DD'),
-            $lte: moment(endDate).format('YYYY-MM-DD'),
+          'timeEntries.createdDateTime': {
+            $gte: isoStartDate,
+            $lte: isoEndDate,
           },
         },
       },
@@ -1618,9 +1619,8 @@ const overviewReportHelper = function () {
       },
     ]);
   
-    return volunteersOverAssignedTime[0]?.volunteersOverAssignedTime || 0;
+    return { count: volunteersOverAssignedTime[0]?.volunteersOverAssignedTime || 0 };
   }
-  
 
   return {
     getVolunteerTrends,


### PR DESCRIPTION
# Description

This PR introduces a new functionality to retrieve volunteers who logged hours exceeding their committed weekly hours by 1 hour or more, while filtering out volunteers with committed hours less than 10. The changes include adding a new function `getVolunteersOverAssignedTime` in `overviewReportHelper.js` and integrating it into the API endpoint `/api/reports/volunteerstats`.

### Summary of Changes
- **Added Functionality:**
  - Created `getVolunteersOverAssignedTime` function in `overviewReportHelper.js`. This function filters volunteers based on the specified criteria and integrates seamlessly with other reporting helpers.
- **Updated API Controller:**
  - Modified `getVolunteerStatsData` function in `reportsController.js` to call the new helper function and return its results in the API response.

---

## Related PRs (if any)
This PR is based on Backend PR : Abi weekly summary reports page #1062.

---

## Main Changes Explained
- **File Updates:**
  - **`overviewReportHelper.js`:**
    - Added `getVolunteersOverAssignedTime` function to compute volunteers exceeding their committed hours by 1 or more.
  - **`reportsController.js`:**
    - Integrated the new helper function into the `getVolunteerStatsData` endpoint, ensuring it returns the appropriate data in the API response.

---

## How to Test
1. **Check into the Current Branch:**
   ```bash
   git checkout add-getVolunteersOverAssignedTime
   ```

2.**Install Dependencies:**
 ```bash
  npm install
  ```

3. **Run the Application:**
```bash
npm run dev
```

4. **Login Using Postman:**
-Endpoint: POST http://localhost:4500/api/login
-Use Owner Credentials to log in.
-Copy the JWT token from the response and paste it into the Postman headers tab under Authorization.

5. **Query the Endpoint:**
API Call:
```bash
GET http://localhost:4500/api/reports/volunteerstats?startDate=2024-05-26&endDate=2024-06-02
```

## Screenshot
<img width="631" alt="Postman API Response" src="https://github.com/user-attachments/assets/34490d44-76f3-4d5b-970c-5ad7675cb097" />

## Notes
- Ensure that the date range (`startDate` and `endDate`) provided in the API query reflects a valid period with active volunteers.
- Verify that the JWT token used in Postman is from an **Owner** account to access restricted data.
- Feel free to include screenshots or logs to confirm the data integrity during testing.

