### PR TITLE
Strallia: fix some tasks not showing on dashboard

### DIFF
--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -291,12 +291,21 @@ const projectController = function (Project) {
       res.status(400).send('Invalid request');
       return;
     }
-    const getId = await hasPermission(req.body.requestor, 'getProjectMembers');
 
+    const getProjMembers = await hasPermission(req.body.requestor, 'getProjectMembers');
+
+    // If a user has permission to post, edit, or suggest tasks, they also have the ability to assign resources to those tasks. 
+    // Therefore, the _id field must be included when retrieving the user profile for project members (resources).
+    const postTask = await hasPermission(req.body.requestor, 'postTask');
+    const updateTask = await hasPermission(req.body.requestor, 'updateTask');
+    const suggestTask = await hasPermission(req.body.requestor, 'suggestTask');
+
+    const canGetId = (getProjMembers || postTask || updateTask || suggestTask);
+    
     userProfile
       .find(
         { projects: projectId },
-        { firstName: 1, lastName: 1, isActive: 1, profilePic: 1, _id: getId },
+        { firstName: 1, lastName: 1, isActive: 1, profilePic: 1, _id: canGetId },
       )
       .sort({ firstName: 1, lastName: 1 })
       .then((results) => {


### PR DESCRIPTION
# Description
This PR fixes an issue where tasks created by non-owners were not appearing on the assignee's dashboard. The issue stemmed from recent changes to permissions, which this PR reverts to restore the expected behavior.

## Main changes explained:
- Revert file projectController.js so that users who have permissions to post, edit, or suggest tasks can view user id's

## How to test:
1. check into current branch
2. do `npm install` and `npm run dev` to run this PR locally
3. run the frontend locally off the development branch using `npm start`
5. login as owner user
6. update your volunteer account to have permission to post tasks: Other Links -> Permissions Management -> Manage User Permissions -> enter the name of your test volunteer account and select your name -> give the user permission to Add Task
7. logout then login to your volunteer account
8. create a task and assign it to yourself: Other Links -> Projects -> select a WBS on any project -> Add Task -> give the task a name and add your volunteer account as a Resource
9. verify that the task shows up under the tasks list on your dashboard
11. test your volunteer account with the other permissions (edit or suggest tasks) and verify the tasks are updated with the correct information
