### PR TITLE
Denish - Add comparison percentage logic to volunteer stats based on abi-volunteer_trends

### DIFF
--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -991,7 +991,17 @@ const overviewReportHelper = function () {
     const comparison = data[0].comparisonTotalHours[0].totalHours;
     return { current, comparison, percentage: calculateGrowthPercentage(current, comparison) };
   }
-
+/**
+   * returns the number of:
+   * 1. Active volunteers
+   * 2. Volunteers that deactivated in the current week
+   * 3. New volunteers in the current week
+   *
+   * @param {string} startDate
+   * @param {string} endDate
+   * @param {string} comparisonStartDate
+   * @param {string} comparisonEndDate
+   */
 
   const getVolunteerNumberStats = async (
     startDate,

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -991,18 +991,18 @@ const overviewReportHelper = function () {
     const comparison = data[0].comparisonTotalHours[0].totalHours;
     return { current, comparison, percentage: calculateGrowthPercentage(current, comparison) };
   }
-/**
+
+  /**
    * returns the number of:
    * 1. Active volunteers
-   * 2. Volunteers that deactivated in the current week
-   * 3. New volunteers in the current week
-   *
-   * @param {string} startDate
-   * @param {string} endDate
-   * @param {string} comparisonStartDate
-   * @param {string} comparisonEndDate
+   * 2. New volunteers
+   * 3. Deactivated volunteers
+   * all within a given time range.
+   * @param {Date} startDate
+   * @param {Date} endDate
+   * @param {Date} comparisonStartDate
+   * @param {Date} comparisonEndDate
    */
-
   const getVolunteerNumberStats = async (
     startDate,
     endDate,

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -992,15 +992,7 @@ const overviewReportHelper = function () {
     return { current, comparison, percentage: calculateGrowthPercentage(current, comparison) };
   }
 
-  /**
-   * returns the number of:
-   * 1. Active volunteers
-   * 2. Volunteers that deactivated in the current week
-   * 3. New volunteers in the current week
-   *
-   * @param {string} startDate
-   * @param {string} endDate
-   */
+
   const getVolunteerNumberStats = async (
     startDate,
     endDate,
@@ -1046,35 +1038,36 @@ const overviewReportHelper = function () {
           },
         },
       ]);
-
+  
       const activeVolunteers = data[0].activeVolunteers[0]?.count || 0;
       const newVolunteers = data[0].newVolunteers[0]?.count || 0;
       const deactivatedVolunteers = data[0].deactivatedVolunteers[0]?.count || 0;
       const totalVolunteers = activeVolunteers + newVolunteers + deactivatedVolunteers;
-
+  
       return {
         activeVolunteers,
         newVolunteers,
         deactivatedVolunteers,
         totalVolunteers
       };
-    }
-
+    };
+  
+    // Get data for the current time range
     const {
       activeVolunteers: currentActiveVolunteers,
       newVolunteers: currentNewVolunteers,
       deactivatedVolunteers: currentDeactivatedVolunteers,
       totalVolunteers: currentTotalVolunteers
     } = await getVolunteerData(startDate, endDate);
-
+  
     const res = {
       activeVolunteers: {
         count: currentActiveVolunteers,
-        percentageOutOfTotal:  Math.round((currentActiveVolunteers / currentTotalVolunteers) * 100) / 100,
+        percentageOutOfTotal: Math.round((currentActiveVolunteers / currentTotalVolunteers) * 100) / 100,
       },
       newVolunteers: {
         count: currentNewVolunteers,
-        percentageOutOfTotal:  Math.round((currentNewVolunteers / currentTotalVolunteers) * 100) / 100,
+        percentageOutOfTotal: Math.round((currentNewVolunteers / currentTotalVolunteers) * 100) / 100,
       },
       deactivatedVolunteers: {
         count: currentDeactivatedVolunteers,
@@ -1082,21 +1075,38 @@ const overviewReportHelper = function () {
       },
       totalVolunteers: { count: currentTotalVolunteers },
     };
-
-    // Modifies response to include comparison percentage if given comparison dates
+  
+    // Add comparison percentage if comparison dates are provided
     if (comparisonStartDate && comparisonEndDate) {
       const {
+        activeVolunteers: comparisonActiveVolunteers,
+        newVolunteers: comparisonNewVolunteers,
+        deactivatedVolunteers: comparisonDeactivatedVolunteers,
         totalVolunteers: comparisonTotalVolunteers
       } = await getVolunteerData(comparisonStartDate, comparisonEndDate);
-
+  
+      // Add comparison percentage using calculateGrowthPercentage function
+      res.activeVolunteers.comparisonPercentage = calculateGrowthPercentage(
+        currentActiveVolunteers,
+        comparisonActiveVolunteers
+      );
+      res.newVolunteers.comparisonPercentage = calculateGrowthPercentage(
+        currentNewVolunteers,
+        comparisonNewVolunteers
+      );
+      res.deactivatedVolunteers.comparisonPercentage = calculateGrowthPercentage(
+        currentDeactivatedVolunteers,
+        comparisonDeactivatedVolunteers
+      );
       res.totalVolunteers.comparisonPercentage = calculateGrowthPercentage(
         currentTotalVolunteers,
-        comparisonTotalVolunteers,
+        comparisonTotalVolunteers
       );
     }
-
+  
     return res;
   };
+  
 
   /**
    *


### PR DESCRIPTION
# Overview of Changes in `getVolunteerNumberStats` Function

## Purpose of the Update
The `getVolunteerNumberStats` function was updated to include `comparisonPercentage` fields for the `activeVolunteers`, `newVolunteers`, and `deactivatedVolunteers` metrics. This enhancement provides a clear comparison between the current period's data and the comparison period's data, offering insights into growth or decline for each metric.

## Key Features Added

1. **`comparisonPercentage` Field**:
   - Added to `activeVolunteers`, `newVolunteers`, and `deactivatedVolunteers`.
   - Shows the percentage change relative to the comparison period.
   - Uses the `calculateGrowthPercentage` function for consistent calculation.

2. **Edge Case Handling**:
   - If `comparisonStartDate` and `comparisonEndDate` are not provided, the function behaves as before, returning only current values.
   - If the comparison value is `0` and the current value is greater than `0`, the result is labeled as **"No Comparison Data"**.
   - If both current and comparison values are `0`, the comparison percentage is `0%`.

## Updated Function Logic

- The function calculates the `comparisonPercentage` for each field by comparing the current and comparison period values.
- If comparison dates are provided, the function retrieves data for both the current and comparison periods.
- The `calculateGrowthPercentage` function is used to compute the percentage change.
- The response object now includes the `comparisonPercentage` field when comparison data is available.

## Example Responses
### Without Comparison Data

<img width="462" alt="Without Comparison Data" src="https://github.com/user-attachments/assets/27b98edf-402c-4cfa-979a-d98c0170a5da" />

The response includes only the current values and their percentage out of the total.

### With Comparison Data
<img width="710" alt="With Comparison Data" src="https://github.com/user-attachments/assets/e938a30d-bdf4-4934-b808-75c54fd7c617" />


The response includes both the current values and their percentage change relative to the comparison period.

## Testing Scenarios

1. **No Comparison Data**:
   - Pass only `startDate` and `endDate`.
   - Verify that the response includes `count` and `percentageOutOfTotal` fields only.

2. **With Comparison Data**:
   - Pass both `startDate`/`endDate` and `comparisonStartDate`/`comparisonEndDate`.
   - Verify that the response includes `comparisonPercentage` for each field.

3. **Edge Cases**:
   - Test with `comparisonValue = 0` and verify the output shows "No Comparison Data".
   - Test with both `currentValue = 0` and `comparisonValue = 0` and verify the percentage is `0%`.
   - Test with negative growth (e.g., `currentValue < comparisonValue`) and verify a negative percentage.

## Files Modified

- **File:** `overviewReportHelper.js`
  - Updated the `getVolunteerNumberStats` function.

## Notes for Reviewers

- Ensure that the logic for edge case handling aligns with the expected behavior.
- Verify the accuracy of `comparisonPercentage` calculations by testing various input combinations.
- Confirm that existing behavior is retained when comparison dates are not provided.
