### PR TITLE
Peterson_fixed_the_bug_that_prevented_the_user_from_deleting_the_blue…

### DIFF
--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -128,7 +128,7 @@ const userProfileSchema = new Schema({
         required: true,
         default: 'white',
       },
-      iconId: { type: String, required: true },
+      iconId: { type: String, required: false },
     },
   ],
   location: {


### PR DESCRIPTION
# Description
This PR has been to fix the bug that prevents users from deleting the blue square.

## Related PRS (if any):
None

## Main changes explained: 
The bug has been fixed after modifying the archive userProfile.js.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Log in as an admin or owner user
5. Go to Welcome → View Profile → Choose a blue square
6. Click in red button named delete and should to appears a green toast with a message Blue Square Deleted.

## Screenshots or videos of changes:
Before fixing a bug:
![Before fixing a bug](https://github.com/user-attachments/assets/01a61d83-8cda-42cf-8e15-3f5f9af5a882)

After fixing a bug:
![After fixing a bug](https://github.com/user-attachments/assets/de429829-06d2-44a1-8f03-bbe1114b395c)

## Note:
None
