### PR TITLE
Yili - Hide Delete Task option  on Dashboard Tasks for people without the permission

### DIFF
--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -685,7 +685,8 @@ const taskController = function (Task) {
   const updateTask = async (req, res) => {
     if (
       !(await hasPermission(req.body.requestor, 'updateTask')) &&
-      !(await hasPermission(req.body.requestor, 'removeUserFromTask'))
+      !(await hasPermission(req.body.requestor, 'removeUserFromTask')) && 
+      !(await hasPermission(req.body.requestor, 'deleteTask'))
     ) {
       res.status(403).send({ error: 'You are not authorized to update Task.' });
       return;


### PR DESCRIPTION
# Description
<img width="731" alt="Hide Delete Task option  on Dashboard Tasks for people without the permission" src="https://github.com/user-attachments/assets/eea13f67-4c9c-4329-a517-2ca2724491c7" />


## Related PRS (if any):
To test this backend PR you need to checkout the frontend [#3038](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3038)

## How to test:
1. check into current branch
2. do npm install and ... to run this PR locally
3. follow the steps on the frontend

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/0a137b57-1df2-4bbd-9654-10aab66bb44d

<img width="806" alt="0" src="https://github.com/user-attachments/assets/db948047-0c80-47c6-9986-6ba95e87bee5" />
<img width="806" alt="1" src="https://github.com/user-attachments/assets/cc89171e-fcb8-47a9-8227-78af4c4cfa3d" />
<img width="806" alt="2" src="https://github.com/user-attachments/assets/8e2879c8-d9dc-49be-813a-dc5b301e1ebe" />
