### PR TITLE
Denish - New Filed Added for gettotalsummariessubmitted

### DIFF
--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -91,6 +91,7 @@ const reportsController = function () {
         taskAndProjectStats,
         volunteersOverAssignedTime,
         completedAssignedHours,
+        totalSummariesSubmitted,
       ] = await Promise.all([
         overviewReportHelper.getVolunteerNumberStats(
           isoStartDate,
@@ -158,6 +159,12 @@ const reportsController = function () {
           isoComparisonStartDate,
           isoComparisonEndDate,
         ),
+        overviewReportHelper.getTotalSummariesSubmitted(
+          isoStartDate,
+          isoEndDate,
+          isoComparisonStartDate,
+          isoComparisonEndDate,
+        ),
       ]);
       res.status(200).send({
         volunteerNumberStats,
@@ -176,6 +183,7 @@ const reportsController = function () {
         taskAndProjectStats,
         volunteersOverAssignedTime,
         completedAssignedHours,
+        totalSummariesSubmitted,
       });
     } catch (err) {
       console.log(err);

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -12,6 +12,8 @@ const SALT_ROUNDS = 10;
 const today = new Date();
 
 const userProfileSchema = new Schema({
+  // Updated filed
+  summarySubmissionDates: [{ type: Date }],
   password: {
     type: String,
     required: true,


### PR DESCRIPTION
# Description

This PR introduces a new functionality to retrieve volunteers who logged hours exceeding their committed weekly hours by 1 hour or more, while filtering out volunteers with committed hours less than 10. The changes include adding a new function `getVolunteersOverAssignedTime` in `overviewReportHelper.js` and integrating it into the API endpoint `/api/reports/volunteerstats`.

### Summary of Changes
- **Added Functionality:**
  - Created `getTotalSummariesSubmitted` function in `overviewReportHelper.js`. This function filters volunteers based on the specified criteria and integrates seamlessly with other reporting helpers.
- **Updated API Controller:**
  - Modified `getVolunteerStatsData` function in `reportsController.js` to call the new helper function and return its results in the API response.

---

## Related PRs (if any)
This PR is based on Backend PR : Abi weekly summary reports page #1062.

---

## Main Changes Explained
- **File Updates:**
  - **`overviewReportHelper.js`:**
    - Added `getTotalSummariesSubmitted` function to compute volunteers exceeding their committed hours by 1 or more.
  - **`reportsController.js`:**
    - Integrated the new helper function into the `getVolunteerStatsData` endpoint, ensuring it returns the appropriate data in the API response.

---

## How to Test
1. **Check into the Current Branch:**
   ```bash
   git checkout add-getVolunteersOverAssignedTime
   ```

2.**Install Dependencies:**
 ```bash
  npm install
  ```

3. **Run the Application:**
```bash
npm run dev
```

4. **Login Using Postman:**
-Endpoint: POST http://localhost:4500/api/login
-Use Owner Credentials to log in.
-Copy the JWT token from the response and paste it into the Postman headers tab under Authorization.

5. **Query the Endpoint:**
API Call:
```bash
GET http://localhost:4500/api/reports/volunteerstats?startDate=2024-05-26&endDate=2024-06-02](http://localhost:4500/api/reports/volunteerstats?startDate=2024-05-26&endDate=2024-06 02&comparisonStartDate=2024-05-18&comparisonEndDate=2024-05-25
```

## Screenshot
<img width="368" alt="getTotalSummariesSubmitted" src="https://github.com/user-attachments/assets/97559272-8b37-48f2-8b0f-31b2ba905097" />


## Notes
- Ensure that the date range (`startDate` and `endDate`) provided in the API query reflects a valid period with active volunteers.
- Also TO Compare You need to provide the comaprison Dates as well.
- Verify that the JWT token used in Postman is from an **Owner** account to access restricted data.
- Feel free to include screenshots or logs to confirm the data integrity during testing.

