### PR TITLE
Yili fix “Edit Task” permission for managers

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -723,6 +723,9 @@ const userProfileController = function (UserProfile, Project) {
       if (PROTECTED_EMAIL_ACCOUNT.includes(record.email)) {
         updatedDiff = record.modifiedPaths();
       }
+      if (req.body.role === 'Administrator') {
+        record.permissions.frontPermissions.push('updateTask');
+      }
       record
         .save()
         .then((results) => {


### PR DESCRIPTION
# Description
<img width="731" alt="Fix “Edit Task” permission for managers " src="https://github.com/user-attachments/assets/492443b7-3e45-4612-bd45-1f772a8319df" />

## Related PRS (if any):
To test this backend PR you need to checkout the frontend [#3101](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3101)

## How to test:
1. check into current branch
2. do npm install and ... to run this PR locally
3. follow the steps on the frontend

## Screenshots or videos of changes:
**log as owner user**

<img width="1412" alt="1" src="https://github.com/user-attachments/assets/8e71267f-7aa7-403a-93f5-89f354ed0317" />

<img width="1410" alt="2" src="https://github.com/user-attachments/assets/068ce27b-b7ac-47b5-9a79-03aad93c40ca" />

<img width="1343" alt="3" src="https://github.com/user-attachments/assets/47e9d6bd-e07c-4dd2-9119-b588eae3ac17" />

**log in as the promoted manager user**

<img width="658" alt="4" src="https://github.com/user-attachments/assets/7d7fde72-7fe1-48b7-8f2a-97dad04842a8" />

<img width="638" alt="5" src="https://github.com/user-attachments/assets/fad802de-84ae-4de5-8473-00900e7cc19d" />
