### PR TITLE
Vinay Fixed Automatic User reactivation on reactivation date 

### DIFF
--- a/src/cronjobs/userProfileJobs.js
+++ b/src/cronjobs/userProfileJobs.js
@@ -19,7 +19,6 @@ const userProfileJobs = () => {
         await userhelper.deleteExpiredTokens();
       }
       await userhelper.awardNewBadges();
-      await userhelper.reActivateUser();
     },
     null,
     false,
@@ -28,15 +27,16 @@ const userProfileJobs = () => {
 
   // Job to run every day, 1 minute past midnight to deactivate the user
   const dailyUserDeactivateJobs = new CronJob(
+    // '* * * * *', // Comment out for testing. Run Every minute.
     '1 0 * * *', // Every day, 1 minute past midnight
     async () => {
       await userhelper.deActivateUser();
+      await userhelper.reActivateUser();
     },
     null,
     false,
     'America/Los_Angeles',
   );
-  
   allUserProfileJobs.start();
   dailyUserDeactivateJobs.start();
 };

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -1075,7 +1075,8 @@ const userHelper = function () {
       );
       for (let i = 0; i < users.length; i += 1) {
         const user = users[i];
-        if (moment().isSameOrAfter(moment(user.reactivationDate))) {
+        const canActivate = moment().isSameOrAfter(moment(user.reactivationDate))
+        if (canActivate) { // Use '!' to invert the boolean value for testing
           await userProfile.findByIdAndUpdate(
             user._id,
             {


### PR DESCRIPTION
# Description
Bug: The user paused till the reactivation day is not being made active on reactivation date
[Video](https://www.loom.com/share/72f4068aa4fe4c6ab1b72313b22e58bd?sid=852d1efc-814e-4f5a-a0fe-b978ec8dc8f5)
Fix: fixed the cron job time for the reactivation function.
 
## Related PRS (if any):
None
…

## Main changes explained:
- Update file userProfileJobs for reActiveUser function to execute everyday at 12:01 AM PST.
…

## How to test:
1. check into current branch: vinay_fix_user_auto_reactivation
2. do `npm install` and `npm start` to run this PR locally
3. make 2 changes for immediate testing of code
    1. userProfileJobs.js, comment out line 30 and comment line 31. to use '* * * * *' as cron time so the jobs runs every minute.
    2. userHelper.js, As the reactivationDate will always be greater than current Date,  At line 1079 negate canActivate variable to bypass the current>=reactivationDate.  
4. Clear site data/cache
5. log as admin user
6. go to other links -> user management and pause a user for certain date.
7. now wait till for 1 minute for the cron jobs to excute, you see the console log "Job for activating users based on scheduled re-activation date starting at ${currentFormattedDate}"
9. Now refresh the user list in the user management page, wait untill the result is fetched. then you can see the user status changed to active from inactive.
 
## Screenshots or videos of changes:
https://github.com/user-attachments/assets/bdb11550-cc1f-4ecd-96bd-ed88b8056f9f