### PR TITLE
added new field `removedDefaultPermissions` in userProfile's permissions obj

### DIFF
--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -37,6 +37,10 @@ const userProfileSchema = new Schema({
   permissions: {
     frontPermissions: [String],
     backPermissions: [String],
+    removedDefaultPermissions: {
+      front: [String],  // Default permissions removed for this user
+      back: [String]
+    }
   },
   firstName: {
     type: String,

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -37,10 +37,7 @@ const userProfileSchema = new Schema({
   permissions: {
     frontPermissions: [String],
     backPermissions: [String],
-    removedDefaultPermissions: {
-      front: [String],  // Default permissions removed for this user
-      back: [String]
-    }
+    removedDefaultPermissions: [String]
   },
   firstName: {
     type: String,


### PR DESCRIPTION
# Description
Added a new field in userProfile's permissions object.
![image](https://github.com/user-attachments/assets/bfbb27d0-7808-4a78-9693-5f13b0f3ef45)

## Related PRS (if any):
This backend PR is realted to [frontend PR3099](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3099)
…

## Main changes explained:
- Added `removedDefaultPermissions` field in permissions object to keep track of defualt role permissions that were removed.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. follow instruction on frontend.

## Screenshots or videos of changes:

## Note:
- check into current branch
