### PR TITLE
Newell - Fix projectId not being correctly returned

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -984,7 +984,6 @@ const timeEntrycontroller = function (TimeEntry) {
         dateOfWork: { $gte: fromdate, $lte: todate },
         // include the time entries for the archived projects
       })
-      .populate('projectId')
       .populate('taskId')
       .populate('wbsId')
       .sort('-lastModifiedDateTime');


### PR DESCRIPTION
Fix projectId not being correctly returned to the frontend.

# Description
Fix projectId not being correctly returned to the frontend.

## Related PRS (if any):
#1215 

## Main changes explained:
Fix projectId not being correctly returned to the frontend.

## How to test:
Check if editing old timelog on frontend still works.
