### PR TITLE
Koushica - Fix: quick setup title code Save and Accepts special characters

### DIFF
--- a/src/controllers/titleController.js
+++ b/src/controllers/titleController.js
@@ -209,6 +209,7 @@ const titlecontroller = function (Title) {
         const result = await Title.findById(filter);
         result.titleName = req.body.titleName;
         result.teamCode = req.body.teamCode;
+        result.titleCode = req.body.titleCode;
         result.projectAssigned = req.body.projectAssigned;
         result.mediaFolder = req.body.mediaFolder;
         result.teamAssiged = req.body.teamAssiged;


### PR DESCRIPTION
# Description
<img width="802" alt="Screenshot 2025-02-20 at 9 20 59 PM" src="https://github.com/user-attachments/assets/2a33a15b-c308-4ecf-b5bd-e6d445902cce" />
<img width="800" alt="Screenshot 2025-02-20 at 9 20 30 PM" src="https://github.com/user-attachments/assets/f0394532-6e00-449d-a0f9-001506f56ea1" />


## Related PRS (if any):
This backend is related to PR#3180 frontend PR.
To test this backend PR you need to checkout the #3180 frontend PR.

## Main changes explained:
- Re-added the titleCode field, which was previously missing and preventing QST from being saved.
- Modified the regex to allow special characters and spaces in between while ensuring at least one uppercase or lowercase character.

## How to test:
1. check into current branch
2. do `npm run build` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to User Profile→ Quick Setup Codes
6. Navigate to User Profile → Quick Setup Codes.
7. Edit or add a new title and verify that it:
- Accepts special characters.
- Allows spaces between characters.
- Requires at least one uppercase or lowercase letter.

## Screenshots or videos of changes:

