### PR TITLE
Jaissica - added array of reasons to infringements

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -1622,9 +1622,8 @@ const userProfileController = function (UserProfile, Project) {
       res.status(403).send('You are not authorized to add blue square');
       return;
     }
-    console.log(req.body.requestor);
+    
     const userid = req.params.userId;
-    console.log(userid);
 
     cache.removeCache(`user-${userid}`);
 

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -1622,7 +1622,9 @@ const userProfileController = function (UserProfile, Project) {
       res.status(403).send('You are not authorized to add blue square');
       return;
     }
+    console.log(req.body.requestor);
     const userid = req.params.userId;
+    console.log(userid);
 
     cache.removeCache(`user-${userid}`);
 
@@ -1636,6 +1638,13 @@ const userProfileController = function (UserProfile, Project) {
         res.status(404).send('No valid records found');
         return;
       }
+      if (!Array.isArray(req.body.blueSquare.reasons) || req.body.blueSquare.reasons.length === 0) {
+        res.status(400).send('Invalid Data: Reasons must be a non-empty array');
+        return;
+    }
+      req.body.blueSquare.reasons = req.body.blueSquare.reasons || [];
+
+
       // find userData in cache
       const isUserInCache = cache.hasCache('allusers');
       let allUserData;
@@ -1684,7 +1693,7 @@ const userProfileController = function (UserProfile, Project) {
       return;
     }
     const { userId, blueSquareId } = req.params;
-    const { dateStamp, summary } = req.body;
+    const { dateStamp, summary, reasons } = req.body;
 
     UserProfile.findById(userId, async (err, record) => {
       if (err || !record) {
@@ -1698,6 +1707,9 @@ const userProfileController = function (UserProfile, Project) {
         if (blueSquare._id.equals(blueSquareId)) {
           blueSquare.date = dateStamp ?? blueSquare.date;
           blueSquare.description = summary ?? blueSquare.description;
+          if (Array.isArray(reasons)) {
+            blueSquare.reasons = reasons;
+        }
         }
         return blueSquare;
       });
@@ -1730,7 +1742,6 @@ const userProfileController = function (UserProfile, Project) {
       return;
     }
     const { userId, blueSquareId } = req.params;
-
     UserProfile.findById(userId, async (err, record) => {
       if (err || !record) {
         res.status(404).send('No valid records found');

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -1638,12 +1638,8 @@ const userProfileController = function (UserProfile, Project) {
         res.status(404).send('No valid records found');
         return;
       }
-      if (!Array.isArray(req.body.blueSquare.reasons) || req.body.blueSquare.reasons.length === 0) {
-        res.status(400).send('Invalid Data: Reasons must be a non-empty array');
-        return;
-    }
-      req.body.blueSquare.reasons = req.body.blueSquare.reasons || [];
 
+      req.body.blueSquare.reasons = ['other'];
 
       // find userData in cache
       const isUserInCache = cache.hasCache('allusers');

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -1217,7 +1217,7 @@ const userHelper = function () {
           lastName,
           {
             ...element,
-            reasonsText: element.reasons?.length ? element.reasons.join(', ') : 'No specific reasons provided',
+            reasonsText: element.reasons,
           },
           totalInfringements,
           undefined,

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -203,6 +203,7 @@ const userHelper = function () {
         <p>Oops, it looks like something happened and you’ve managed to get a blue square.</p>
         <p><b>Date Assigned:</b> ${moment(infringement.date).format('M-D-YYYY')}</p>\
         <p><b>Description:</b> ${emailDescription}</p>
+        ${infringement.reasons?.length ? `<p><b>Reasons:</b> ${infringement.reasons.join(', ')}</p>` : ''}
         ${descrInfringement}
         ${finalParagraph}
         <p>Thank you,<p>
@@ -1214,7 +1215,10 @@ const userHelper = function () {
         getInfringementEmailBody(
           firstName,
           lastName,
-          element,
+          {
+            ...element,
+            reasonsText: element.reasons?.length ? element.reasons.join(', ') : 'No specific reasons provided',
+          },
           totalInfringements,
           undefined,
           undefined,

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -112,6 +112,7 @@ const userProfileSchema = new Schema({
       date: { type: String, required: true },
       description: { type: String, required: true },
       createdDate: { type: String },
+      reasons: {type: [String], default: []},
     },
   ],
   warnings: [


### PR DESCRIPTION
# Description
![Screenshot 2025-02-27 at 8 42 13 PM](https://github.com/user-attachments/assets/dd631406-8c9a-416e-af2c-8e6c8b13fffe)
These changes are made so that while building charts for evaluating different reasons for the blue square, the manually created blue square would be in the "others" category as the rest are updated through CRON jobs.

## Related PRS (if any):
NA


## Main changes explained:
- userProfileController.js - Updated API endpoints to correctly handle the reasons field when retrieving and updating Blue Squares.
- userHelper.js - Ensured reasons is always an array, preventing UI inconsistencies and fixing database update logic.
- userProfile.js: Updated the schema/model to ensure reasons is always included when storing or fetching Blue Square data.

## How to test:
1. check into current branch
2. do `npm install`, `npm run build`, and `npm start` to run this PR locally
4. Use the development branch in [HighestGoodNetworkApp](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp) to test the changes.
5. Once you have the HGN dashboard running go to View Profile -> manually click on the blue square to add a new blue square. You can follow the steps as shown in the video below.
6. Once you add a blue square you should be able to see in the userProfiles in local db an infringement entry created with "others" in the reason section.
7. Try deleting the square too. 

## Screenshots or videos of changes:


https://github.com/user-attachments/assets/da6b6924-a621-41fb-9ef7-c5f0fbe5e932





## Note:
NA