### PR TITLE
Sunil - updated to Fetch all Users data

### DIFF
--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -36,7 +36,7 @@ const reporthelper = function () {
 
     const results = await userProfile.aggregate([
       {
-        $match: { isActive: true },
+        $match: { isActive: { $in: [true, false] } } // Fetch both active and inactive users
       },
       {
         $lookup: {
@@ -75,12 +75,13 @@ const reporthelper = function () {
           },
           firstName: 1,
           lastName: 1,
-          role: 1,
+          role: 1,    
           email: 1,
           mediaUrl: 1,
           createdDate: 1,
           weeklycommittedHours: 1,
           weeklycommittedHoursHistory: 1,
+          isActive: 1,
           weeklySummaryNotReq: 1,
           weeklySummaryOption: 1,
           adminLinks: 1,
@@ -130,7 +131,6 @@ const reporthelper = function () {
           timeOffTill: {
             $ifNull: ['$timeOffTill', null],
           },
-          role: 1,
           weeklySummaries: {
             $filter: {
               input: "$weeklySummaries",
@@ -182,7 +182,7 @@ const reporthelper = function () {
 
       delete result.timeEntries;
     });
-
+    
     return results;
   };
   const getReportReceipents = () => {


### PR DESCRIPTION
# Description
Create way to see deactivated people’s last week on the Weekly Summaries Reports page,

deactivated people’s show up in the “last week” tab, but with an obvious indicator in the “Name” and “Role” row shown that says: “FINAL WEEK REPORTING: This team members is no longer active”

Fixes # ( priority high)
Or Implements # (WBS) 

## Related PRS (if any):
To test this backend PR you need to check out the #[3213](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3213) frontend PR.
…

## Main changes explained:
Modified  aggregate reportHelper.js to get both active and inactive users list
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
