### PR TITLE
fix: handled empty permission additions or removal

### DIFF
--- a/src/controllers/permissionChangeLogsController.js
+++ b/src/controllers/permissionChangeLogsController.js
@@ -1,6 +1,6 @@
 const UserProfile = require('../models/userProfile');
 
-const permissionChangeLogController = function (PermissionChangeLog,userPermissionChangeLog) {
+const permissionChangeLogController = function (PermissionChangeLog, userPermissionChangeLog) {
   const getPermissionChangeLogs = async function (req, res) {
     try {
       const userProfile = await UserProfile.findOne({ _id: req.params.userId }).exec();
@@ -12,19 +12,20 @@ const permissionChangeLogController = function (PermissionChangeLog,userPermissi
           const userChangeLogs = await userPermissionChangeLog.find();
           const rolePermissionChangeLogs = await PermissionChangeLog.find();
 
-          const formattedUserChangeLogs = userChangeLogs.map(log => ({
+          const formattedUserChangeLogs = userChangeLogs.map((log) => ({
             ...log.toObject(),
             name: log.individualName,
           }));
 
-          const formattedRolePermissionChangeLogs = rolePermissionChangeLogs.map(log => ({
+          const formattedRolePermissionChangeLogs = rolePermissionChangeLogs.map((log) => ({
             ...log.toObject(),
             name: log.roleName,
           }));
 
-          const mergedLogs = [...formattedUserChangeLogs, ...formattedRolePermissionChangeLogs].sort(
-            (a, b) => new Date(b.logDateTime) - new Date(a.logDateTime)
-          );
+          const mergedLogs = [
+            ...formattedUserChangeLogs,
+            ...formattedRolePermissionChangeLogs,
+          ].sort((a, b) => new Date(b.logDateTime) - new Date(a.logDateTime));
 
           res.status(200).json(mergedLogs);
         }

--- a/src/utilities/logUserPermissionChangeByAccount.js
+++ b/src/utilities/logUserPermissionChangeByAccount.js
@@ -11,12 +11,15 @@ const logUserPermissionChangeByAccount = async (req) => {
     let permissionsRemoved = [];
     const { userId } = req.params;
     const Permissions = permissions.frontPermissions;
-    const requestorEmailId = await UserProfile.findById(requestor.requestorId).select('email').exec();
+    const requestorEmailId = await UserProfile.findById(requestor.requestorId)
+      .select('email')
+      .exec();
     const document = await findLatestRelatedLog(userId);
 
     if (document) {
       const docPermissions = Array.isArray(document.permissions) ? document.permissions : [];
-      if(JSON.stringify(docPermissions) === JSON.stringify(Permissions)) {
+      // no new changes in permissions list from last update
+      if (JSON.stringify(docPermissions.sort()) === JSON.stringify(Permissions.sort())) {
         return;
       }
       permissionsRemoved = docPermissions.filter((item) => !Permissions.includes(item));
@@ -25,6 +28,10 @@ const logUserPermissionChangeByAccount = async (req) => {
       permissionsAdded = Permissions;
     }
 
+    // no permission added nor removed
+    if (permissionsRemoved.length === 0 && permissionsAdded.length === 0) {
+      return;
+    }
     const logEntry = new UserPermissionChangeLog({
       logDateTime: dateTime,
       userId,
@@ -43,16 +50,17 @@ const logUserPermissionChangeByAccount = async (req) => {
   }
 };
 
-const findLatestRelatedLog = (userId) => new Promise((resolve, reject) => {
-  UserPermissionChangeLog.findOne({ userId })
-    .sort({ logDateTime: -1 })
-    .exec((err, document) => {
-      if (err) {
-        reject(err);
-        return;
-      }
-      resolve(document);
-    });
-});
+const findLatestRelatedLog = (userId) =>
+  new Promise((resolve, reject) => {
+    UserPermissionChangeLog.findOne({ userId })
+      .sort({ logDateTime: -1 })
+      .exec((err, document) => {
+        if (err) {
+          reject(err);
+          return;
+        }
+        resolve(document);
+      });
+  });
 
 module.exports = logUserPermissionChangeByAccount;


### PR DESCRIPTION
# Description
**Improve Permissions Management tracking** 
Permssion Managment logs is tracking blanks that are something other than just changes too. I want it to only track changes.
It should also auto-refresh the table when saving changes
It should show the change name as it is shown on the frontend, not as it is on the backend
[Video of what I mean](https://www.loom.com/share/82c80495b91e474da93e67aa1890cdfc?sid=4b14cee7-fb3b-45a9-810e-edb5a4c23509)

## Related PRS (if any):
This PR is related to the - frontend PR.

The bug is caused due to 2 issues
1. no check if none of permission is added nor removed.
2. change in sequence of recent list of permissions.

## Main changes explained:
1. src/utilities/logUserPermissionChangeByAccount.js: Added a check for no permission is added nor removed, also to check change in the sequence of the permission. in both of these cases the controller returns without creating the log. 
…

## How to test:
1. check into "fix-permission-management-log" branch
4. do `npm install` and `npm start` to run this PR locally
5. Clear site data/cache
6. login as owner user
7. go to Other Links>Permissions Management>Manage User Permissions
8. verify by adding or removing the permissions

## Screenshots or videos of changes:
![image](https://github.com/user-attachments/assets/b9bc7e1d-08dd-4f2c-a00b-f57aec4b90b9)
