### PR TITLE
pavanswaroop-fix-member-column-filter-added-endpoint-getProjectswithActiveusers

### DIFF
--- a/src/routes/projectRouter.js
+++ b/src/routes/projectRouter.js
@@ -17,6 +17,9 @@ const routes = function (project) {
   projectRouter.route('/projects/user/:userId')
     .get(controller.getUserProjects);
 
+  projectRouter.route('/projects/with-active-users')
+    .get(controller.getProjectsWithActiveUserCounts);
+
   projectRouter.route('/project/:projectId/users/')
     .post(controller.assignProjectToUsers)
     .get(controller.getprojectMembership);


### PR DESCRIPTION
# Description
Fix Member Column filter(WIP Pavan)
Other Links>Projects>Member Column filter
Should calculate and then filter projects by number of active members, most to least
Should have mouseover text to explain this


## Related PRS (if any):
This backend PR is related to the #[3220](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3220) frontend PR.


## Main changes explained:
add route endpoint to fetch projects with active users to facilitate member column filtering
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to other links→ projects → member column filter button →…
6. verify functions mentioned above

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/e0e25889-51fc-4275-a6f9-1bf48daba857

<img width="190" alt="Screenshot 2025-02-28 at 10 38 20 PM" src="https://github.com/user-attachments/assets/d022477c-cf88-4664-b014-d3ceac479f6c" />

