### PR TITLE
Newell - Fix blue squares not being deleted

### DIFF
--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -119,14 +119,7 @@ const userProfileSchema = new Schema({
       date: { type: String, required: true },
       description: {
         type: String,
-        required: true,
-        enum: [
-          'Better Descriptions',
-          'Log Time to Tasks',
-          'Log Time as You Go',
-          'Log Time to Action Items',
-          'Intangible Time Log w/o Reason',
-        ],
+        required: true
       },
       color: {
         type: String,


### PR DESCRIPTION
# Description
Delete warning description enum to fix blue squares not being deleted issue.

## Related PRS (if any):
N/A

## Main changes explained:
- Delete warning description enum to fix blue squares not being deleted issue.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. try delete blue squares for other users.