### PR TITLE
Zhifan Fixed Trophy Mismatch

### DIFF
--- a/src/controllers/dashBoardController.js
+++ b/src/controllers/dashBoardController.js
@@ -145,20 +145,23 @@ const dashboardcontroller = function () {
   const postTrophyIcon = function (req, res) {
     console.log("API called with params:", req.params);
     const userId = mongoose.Types.ObjectId(req.params.userId);
+    const trophyFollowedUp = req.params.trophyFollowedUp === 'true';
 
-    userProfile.findById(userId, (err, record) => {
-      if (err || !record) {
-        res.status(404).send('No valid records found');
-        return;
-      }
-      record.trophyFollowedUp = req.params.trophyFollowedUp;
-
-      record.save()
-        .then((results) => {
-          res.status(200).send(results);
-        })
-        .catch((error) => res.status(404).send(error));
-    });
+    userProfile.findByIdAndUpdate(
+      userId,
+      { trophyFollowedUp },
+      { new: true }
+    )
+      .then((updatedRecord) => {
+        if (!updatedRecord) {
+          return res.status(404).send('No valid records found');
+        }
+        res.status(200).send(updatedRecord);
+      })
+      .catch((error) => {
+        console.error("Error updating trophy icon:", error);
+        res.status(500).send(error);
+      });
   };
 
   const orgData = function (req, res) {

--- a/src/controllers/dashBoardController.js
+++ b/src/controllers/dashBoardController.js
@@ -1,3 +1,6 @@
+import userProfile from 'models/userProfile';
+import actionItem from 'models/actionItem';
+
 /* eslint-disable quotes */
 const path = require("path");
 const fs = require("fs/promises");
@@ -6,6 +9,7 @@ const dashboardHelperClosure = require("../helpers/dashboardhelper");
 const emailSender = require("../utilities/emailSender");
 const AIPrompt = require("../models/weeklySummaryAIPrompt");
 const User = require("../models/userProfile");
+
 
 const dashboardcontroller = function () {
   const dashboardhelper = dashboardHelperClosure();
@@ -135,6 +139,26 @@ const dashboardcontroller = function () {
         }
       })
       .catch(error => res.status(400).send(error));
+  };
+
+  //6th month and yearly anniversaries
+  const postTrophyIcon = function (req, res) {
+    console.log("API called with params:", req.params);
+    const userId = mongoose.Types.ObjectId(req.params.userId);
+
+    userProfile.findById(userId, (err, record) => {
+      if (err || !record) {
+        res.status(404).send('No valid records found');
+        return;
+      }
+      record.trophyFollowedUp = req.params.trophyFollowedUp;
+
+      record.save()
+        .then((results) => {
+          res.status(200).send(results);
+        })
+        .catch((error) => res.status(404).send(error));
+    });
   };
 
   const orgData = function (req, res) {
@@ -330,6 +354,7 @@ const dashboardcontroller = function () {
     }
   };
 
+
   return {
     dashboarddata,
     getAIPrompt,
@@ -344,6 +369,7 @@ const dashboardcontroller = function () {
     sendMakeSuggestion,
     updateCopiedPrompt,
     getPromptCopiedDate,
+    postTrophyIcon,
   };
 };
 

--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -205,6 +205,7 @@ const dashboardhelper = function () {
             endDate: 1,
             createdDate: 1,
             trophyFollowedUp: 1,
+            startDate: 1,
           }
 
         );
@@ -224,6 +225,7 @@ const dashboardhelper = function () {
             endDate: 1,
             createdDate: 1,
             trophyFollowedUp: 1,
+            startDate: 1,
           },
         );
       }
@@ -291,6 +293,7 @@ const dashboardhelper = function () {
           endDate: teamMember.endDate || null,
           createdDate: teamMember.createdDate || null,
           trophyFollowedUp: teamMember.trophyFollowedUp || false,
+          startDate: teamMember.startDate || null,
         };
         leaderBoardData.push(obj);
       });

--- a/src/helpers/dashboardhelper.js
+++ b/src/helpers/dashboardhelper.js
@@ -203,6 +203,8 @@ const dashboardhelper = function () {
             timeOffFrom: 1,
             timeOffTill: 1,
             endDate: 1,
+            createdDate: 1,
+            trophyFollowedUp: 1,
           }
 
         );
@@ -220,7 +222,8 @@ const dashboardhelper = function () {
             timeOffFrom: 1,
             timeOffTill: 1,
             endDate: 1,
-
+            createdDate: 1,
+            trophyFollowedUp: 1,
           },
         );
       }
@@ -286,6 +289,8 @@ const dashboardhelper = function () {
           timeOffFrom: teamMember.timeOffFrom || null,
           timeOffTill: teamMember.timeOffTill || null,
           endDate: teamMember.endDate || null,
+          createdDate: teamMember.createdDate || null,
+          trophyFollowedUp: teamMember.trophyFollowedUp || false,
         };
         leaderBoardData.push(obj);
       });
@@ -601,6 +606,8 @@ const dashboardhelper = function () {
           personId: userId,
           role: user.role,
           isVisible: user.isVisible,
+          createdDate: user.createdDate,
+          trophyFollowedUp: user.trophyFollowedUp,
           hasSummary: user.weeklySummaries[0].summary !== '',
           weeklycommittedHours: user.weeklycommittedHours,
           name: `${user.firstName} ${user.lastName}`,

--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -85,6 +85,7 @@ const reporthelper = function () {
           weeklySummaryOption: 1,
           adminLinks: 1,
           bioPosted: 1,
+          toggleTrophyIcon: 1,
           badgeCollection: {
             $filter: {
               input: "$badgeCollection",

--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -87,6 +87,7 @@ const reporthelper = function () {
           bioPosted: 1,
           toggleTrophyIcon: 1,
           startDate: 1,
+          trophyFollowedUp: 1,
           badgeCollection: {
             $filter: {
               input: "$badgeCollection",

--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -86,6 +86,7 @@ const reporthelper = function () {
           adminLinks: 1,
           bioPosted: 1,
           toggleTrophyIcon: 1,
+          startDate: 1,
           badgeCollection: {
             $filter: {
               input: "$badgeCollection",

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -229,6 +229,7 @@ const userProfileSchema = new Schema({
   isVisible: { type: Boolean, default: true },
   weeklySummaryOption: { type: String },
   bioPosted: { type: String, default: 'default' },
+  trophyFollowedUp: { type: Boolean, default: false },
   isFirstTimelog: { type: Boolean, default: true },
   badgeCount: { type: Number, default: 0 },
   teamCode: {

--- a/src/routes/dashboardRouter.js
+++ b/src/routes/dashboardRouter.js
@@ -28,6 +28,9 @@ const route = function () {
   Dashboardrouter.route('/dashboard/leaderboard/org/data')
     .get(controller.orgData);
 
+  Dashboardrouter.route('/dashboard/leaderboard/trophyIcon/:userId/:trophyFollowedUp')
+    .post(controller.postTrophyIcon);  
+
   Dashboardrouter.route('/dashboard/suggestionoption/:userId')
     .get(controller.getSuggestionOption);
 


### PR DESCRIPTION
# Description
<img width="673" alt="Screenshot 2025-03-15 at 4 25 40 PM" src="https://github.com/user-attachments/assets/2a3a36ad-3160-4d35-b896-63ef197f909a" />
This PR continued from Aishwarya's work #1180 to resolve the trophy mismatch issue.

## Related PRS (if any):

To test this backend PR you need to checkout the [#3280](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3280) frontend PR.
…

## Main changes explained:
- Replaced the createdDate with the startDate for trophy calculation
- More features were implemented on the weekly summary report
  - Load trophy button
  - Option to filter trophy
  - Follow-up on a trophy
- Trophy on weekly summary report is permanently associated that week

## How to test:
1. see frontend PR

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
