### PR TITLE
Lalith Create way to save a team code filter set backend

### DIFF
--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -4,6 +4,8 @@ const reporthelperClosure = require('../helpers/reporthelper');
 const overviewReportHelperClosure = require('../helpers/overviewReportHelper');
 const { hasPermission } = require('../utilities/permissions');
 const UserProfile = require('../models/userProfile');
+const logger = require('../startup/logger');
+
 
 const reportsController = function () {
   const overviewReportHelper = overviewReportHelperClosure();
@@ -558,7 +560,7 @@ const reportsController = function () {
       const saveFiltersIntoUserprofiles = await overviewReportHelper.postFiltersIntoUserProfiles(req);
       return res.status(200).json({ saveFiltersIntoUserprofiles });
     } catch (err) {
-      console.log(err);
+      logger.logException(err);
       return res.status(500).send({ msg: 'Error occured while fetching data. Please try again!' });
     }
   };
@@ -566,10 +568,9 @@ const reportsController = function () {
   const getWeeklySummaryFiltersForUser = async function (req, res) {
     try {
       const getFilters = await overviewReportHelper.getWeeklySummaryFilters();
-      console.log(getFilters)
       return res.status(200).json({ getFilters });
     } catch (err) {
-      console.log(err);
+      logger.logException(err);
       return res.status(500).send({ msg: 'Error occured while fetching data. Please try again!' });
     }
 };

--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -540,6 +540,41 @@ const reportsController = function () {
     }
   };
 
+  const postSummaryFilters = async (req, res) => {
+    // request structure from frontend.
+    /**  request = [{
+      codes: "",
+      colors: "",
+      filterName: "",
+      FilterByBioStatus: "",
+      FilterByOverHours: ""
+  }]; */
+
+    if (req?.body?.filter?.length > 0) {
+      return res.status(400).send({ msg: 'Please provide an proper filter' });
+    }
+
+    try {
+      const saveFiltersIntoUserprofiles = await overviewReportHelper.postFiltersIntoUserProfiles(req);
+      return res.status(200).json({ saveFiltersIntoUserprofiles });
+    } catch (err) {
+      console.log(err);
+      return res.status(500).send({ msg: 'Error occured while fetching data. Please try again!' });
+    }
+  };
+
+  const getWeeklySummaryFiltersForUser = async function (req, res) {
+    try {
+      const getFilters = await overviewReportHelper.getWeeklySummaryFilters();
+      console.log(getFilters)
+      return res.status(200).json({ getFilters });
+    } catch (err) {
+      console.log(err);
+      return res.status(500).send({ msg: 'Error occured while fetching data. Please try again!' });
+    }
+};
+
+  
   return {
     getVolunteerStats,
     getVolunteerHoursStats,
@@ -553,6 +588,8 @@ const reportsController = function () {
     getVolunteerStatsData,
     getVolunteerTrends,
     getTeamsWithActiveMembers,
+    postSummaryFilters,
+    getWeeklySummaryFiltersForUser
   };
 };
 

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -1966,9 +1966,8 @@ const overviewReportHelper = function () {
   };
 
   const weeklySummaryFiltersOperations = (req) => {
-    let { recordId, filters: filterData } = req.body; // ✅ Extract once
+    let { recordId, filters: filterData } = req.body; //  Extract once
     recordId = mongoose.Types.ObjectId(recordId);
-    console.log(recordId)
     return {
         updateRecord: async () => {
             const updatedRecord = await WeeklySummaryFilters.findOneAndUpdate(
@@ -1986,7 +1985,6 @@ const overviewReportHelper = function () {
         },
         deleteRecord: async () => {
           const deletedRecord = await WeeklySummaryFilters.findOneAndDelete({ _id: recordId });
-
           if (!deletedRecord) {
               return { message: "No record found for the given recordId" };
           }
@@ -2020,7 +2018,6 @@ const overviewReportHelper = function () {
         }
         
       }   catch (e){
-        console.log(e)
           return {error: e}
       }
     
@@ -2036,7 +2033,6 @@ const overviewReportHelper = function () {
 
         return { records };
     } catch (err) {
-        console.error("Error fetching filters:", err);
         return { msg: 'Internal Server Error' };
     }
 };

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -256,6 +256,19 @@ const userProfileSchema = new Schema({
   timeOffTill: { type: Date, default: undefined },
   getWeeklyReport: { type: Boolean },
   permissionGrantedToGetWeeklySummaryReport: { type: Date, default: undefined },
+  savedWeeklySummaryFilters: [
+    {codes: [
+      {
+          value: { type: String, required: true }, 
+          label: { type: String, required: true },
+          _ids: [{ type: mongoose.Schema.Types.ObjectId, ref: 'SomeModel' }] // Reference to another collection (optional)
+      }
+  ],
+  colors: [{ type: String }], // Array of strings for colors
+  filterName: { type: String, required: true },
+  FilterByBioStatus: { type: Boolean, default: false },
+  FilterByOverHours: { type: Boolean, default: false }}
+  ]
 });
 
 userProfileSchema.pre('save', function (next) {

--- a/src/models/weeklySummaryFilters.js
+++ b/src/models/weeklySummaryFilters.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const weeklySummaryFilters = new Schema({
+      codes: [
+        {
+            value: { type: String, required: true }, 
+            label: { type: String, required: true },
+            _ids: [{ type: mongoose.Schema.Types.ObjectId, ref: 'SomeModel' }] // Reference to another collection (optional)
+        }
+    ],
+    colors: [{ type: String }], // Array of strings for colors
+    filterName: { type: String, required: true },
+    FilterByBioStatus: { type: Boolean, default: false },
+    FilterByOverHours: { type: Boolean, default: false }
+});
+
+module.exports = mongoose.model('weeklySummaryFilters', weeklySummaryFilters, 'weeklySummaryFilters');

--- a/src/routes/reportsRouter.js
+++ b/src/routes/reportsRouter.js
@@ -14,6 +14,10 @@ const route = function () {
   reportsRouter.route('/reports/getrecepients').get(controller.getReportRecipients);
 
   reportsRouter.route('/reports/weeklysummaries').get(controller.getWeeklySummaries);
+  
+  reportsRouter.route('/reports/weeklysummaries/userfilters').post(controller.postSummaryFilters);
+
+  reportsRouter.route('/reports/weeklysummaries/getuserfilters').get(controller.getWeeklySummaryFiltersForUser);
 
   reportsRouter
     .route('/reports/overviewsummaries/volunteerstats')


### PR DESCRIPTION
Description:

Reports>Weekly Summary Reports> Add saved filter to right of Select Team Code (see pic below)
Right now I can click to select team codes I want to view as a group. I need a way though to save filter sets I use frequently. E.g. filtering for all the 20-hour or 10-hour software teams.
I want to be able to save the filter and name it up to 5 characters (including special characters)
I want the saved filters to show up to the right of “Select Team Code” in the picture below
A saved filter should update/still work if a team code is changed
I should have a way to delete these filters
These filters should only be able to be created by an Owner or Admin
These filters should be able to be seen by all users who can view this page
These filters should still work with the toggles on this page

How to Test:
Login as an Admin or Owner.
Navigate to Reports: Click on the "Reports" button in the navigation bar and select the "Weekly Summary Report."

Create a Filter:
Use the dropdown to select groups for filtering.
Once selected, the "Save Filter" button will appear. Click it to save the filter.

Edit a Filter:
Click on the filter you want to modify.
Make the necessary changes and click "Update Filter" to save the updates.

Delete a Filter:
Select the filter you want to remove.
Click the "Delete Filter" button to delete it.

Frontend PR:
https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3281

## Screenshots or videos of changes:


https://github.com/user-attachments/assets/9a5a3049-b2c8-4f5f-89e8-04566efcac77


