### PR TITLE
Implement Summary Dashboard: Draw Donut Chart showing different types of material used backend

### DIFF
--- a/src/controllers/bmdashboard/bmProjectController.js
+++ b/src/controllers/bmdashboard/bmProjectController.js
@@ -122,7 +122,27 @@ const bmMProjectController = function (BuildingProject) {
       res.json(err);
     }
   };
-  return { fetchAllProjects, fetchSingleProject };
+
+  const fetchProjectsNames = async (req, res) => {
+    try {
+      const projects = await BuildingProject.find(
+        { isActive: true }, // only active projects
+        { _id: 1, name: 1 }, // only select id + name
+      );
+
+      const projectNames = projects.map((proj) => ({
+        projectId: proj._id,
+        projectName: proj.name,
+      }));
+
+      res.status(200).json(projectNames);
+    } catch (error) {
+      console.error('Error in fetchProjectNames:', error);
+      res.status(500).json({ error: 'Internal Server Error' });
+    }
+  };
+
+  return { fetchAllProjects, fetchSingleProject, fetchProjectsNames };
 };
 
 module.exports = bmMProjectController;

--- a/src/routes/bmdashboard/bmMaterialsRouter.js
+++ b/src/routes/bmdashboard/bmMaterialsRouter.js
@@ -13,8 +13,11 @@ const routes = function (buildingMaterial) {
   materialsRouter.route('/updateMaterialRecordBulk')
     .post(controller.bmPostMaterialUpdateBulk);
 
-    materialsRouter.route('/updateMaterialStatus')
+  materialsRouter.route('/updateMaterialStatus')
     .post(controller.bmupdatePurchaseStatus);
+
+  materialsRouter.route('/materials/:projectId')
+    .get(controller.bmGetMaterialSummaryByProject);
 
   return materialsRouter;
 };

--- a/src/routes/bmdashboard/bmProjectRouter.js
+++ b/src/routes/bmdashboard/bmProjectRouter.js
@@ -10,6 +10,9 @@ projectRouter.route('/projects')
 projectRouter.route('/project/:projectId')
   .get(controller.fetchSingleProject);
 
+projectRouter.route('/projectsNames')
+  .get(controller.fetchProjectsNames);
+
   return projectRouter;
 };
 


### PR DESCRIPTION
# Description
![image](https://github.com/user-attachments/assets/a2b101a9-675f-4ef0-826d-b0f6c98aa70a)

## Related PRS (if any):
None
…

## Main changes explained:
- Added GET /api/bm/materials/:projectId API:
Supports materialType query parameter to filter by material type.
Supports increaseOverLastWeek=true to filter materials that have shown usage activity in the last 7 days.
Returns: availableMaterials, usedMaterials, wastedMaterials, increaseOverLastWeek (percentage).
- Added GET /api/bm/projectsNames API:
Returns only project _id and name fields from active projects.

## How to test:
1. check into current branch
2. do `npm install` and `npm run dev` to run this PR locally
3. Get authentication token (normal user)

   - Make a POST request to:
     http://localhost:4500/api/login

   - Request body (replace with your own credentials):
     ```
      { 
         "email": "your-email",
         "password": "your-password"
      }

4. Get authentication token (BM Dashboard user)

   - Make a POST request to:
     http://localhost:4500/api/bm/login

   - Headers:
     Authorization: your-token

   - Request body (replace with your own credentials):
     ```
     {
       "email": "your-email",
       "password": "your-password"
     }

5. Test GET  http://localhost:4500/api/bm/materials/{projectId}

   - Headers:
     Authorization: your-token (BM Dashboard user)

   - Query parameters optional:
     - materialType=material_id (Optional)
     - increaseOverLastWeek=true (Optional)

6. Test GET  http://localhost:4500/api/bm/projectsNames
   - Headers:
     Authorization: your-token (BM Dashboard user)

8. Compare results with frontend UI
 http://localhost:3000/bmdashboard/materials
## Screenshots or videos of changes:
![image](https://github.com/user-attachments/assets/ec81b04c-ad45-4b22-b11a-e229fc574189)
![image](https://github.com/user-attachments/assets/95aadc12-3868-4c66-ba4b-ef3f57d8d40b)

## Note:
Include the information the reviewers need to know.
