### PR TITLE
Dipti-  Fix Timelog Times Not Totaling Task-Time-Worked on Dashboard>Tasks Tab

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -568,7 +568,7 @@ const timeEntrycontroller = function (TimeEntry) {
           );
           // if the time entry is related to a task, update the task hoursLogged
           if (timeEntry.taskId) {
-            updateTaskLoggedHours(
+            await updateTaskLoggedHours(
               timeEntry.taskId,
               0,
               timeEntry.taskId,
@@ -758,7 +758,7 @@ const timeEntrycontroller = function (TimeEntry) {
           // change from tangible to intangible
           if (initialIsTangible) {
             // subtract initial logged hours from old task (if not null)
-            updateTaskLoggedHours(
+            await updateTaskLoggedHours(
               initialTaskId,
               initialTotalSeconds,
               null,
@@ -784,7 +784,7 @@ const timeEntrycontroller = function (TimeEntry) {
             );
           } else {
             // from intangible to tangible
-            updateTaskLoggedHours(
+            await updateTaskLoggedHours(
               null,
               null,
               newTaskId,
@@ -813,7 +813,7 @@ const timeEntrycontroller = function (TimeEntry) {
           // when timeentry remains tangible, this is usually when timeentry is edited by user in the same day or by owner-like roles
 
           // it doesn't matter if task is changed or not, just update taskLoggedHours and userprofile totalTangibleHours with new and old task ids
-          updateTaskLoggedHours(
+          await updateTaskLoggedHours(
             initialTaskId,
             initialTotalSeconds,
             newTaskId,
@@ -931,7 +931,7 @@ const timeEntrycontroller = function (TimeEntry) {
           await updateUserprofileCategoryHrs(projectId, totalSeconds, null, null, userprofile);
           // if the time entry is related to a task, update the task hoursLogged
           if (taskId) {
-            updateTaskLoggedHours(taskId, totalSeconds, null, null, userprofile, session);
+            await updateTaskLoggedHours(taskId, totalSeconds, null, null, userprofile, session);
           }
         } else {
           updateUserprofileTangibleIntangibleHrs(0, -totalSeconds, userprofile);


### PR DESCRIPTION
Added await before updateTaskLoggedHours

# Description
<img width="730" alt="Screenshot 2025-03-23 at 2 15 53 PM" src="https://github.com/user-attachments/assets/7b9927c2-de76-4568-8566-9226c9aa9164" />


## Related PRS (if any):
development branch of frontend


## Main changes explained:
- **Update file: timeEntryController.js added await in front of updateTaskLoggedHours -**  While testing, inconsistencies were observed such as the progress bar not updating and backend errors occurring during deletion of time entries. The issue was traced to a missing await on the updateTaskLoggedHours() call, which led to race conditions and incomplete updates. Adding await ensures the function completes before proceeding, resolving the inconsistencies and preventing unhandled promise rejections
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run build`  "npm start" to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Time Log at Dashboard>Leaderboard>Click time bar by a person’s name
6. Note: To create a Task for a user, you must be logged in as an Admin or Owner and the individual to be given the task must be assigned the Project the task will be/is a part of. Then go to Other Links—>Projects—>WBS—>Choose the WBS—> Assign the task or “Add Task”
7. I have Uploaded the before and after video that will clarify more how to test

## Screenshots or videos of changes:

### **Note:** While testing the before version, try performing the delete operation multiple times. Since the function is asynchronous, it may sometimes work without await, but other times it may not behave as expected.
**Before**

https://github.com/user-attachments/assets/b3d4e81b-eec4-43eb-89eb-7f2a2284cc6b

**After**

https://github.com/user-attachments/assets/b534cbda-8a56-4bd2-adc1-bb7da58f5b47

