### PR TITLE
Dipti_Yadav_Make_WBS_content_save_and_auto-populate_during_auto-refresh_popup

### DIFF
--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -431,15 +431,13 @@ const taskController = function (Task) {
 
   const postTask = async (req, res) => {
     if (!(await hasPermission(req.body.requestor, 'postTask'))) {
-      res.status(403).send({ error: 'You are not authorized to create new Task.' });
-      return;
+      return res.status(403).send({ error: 'You are not authorized to create new Task.' });
     }
 
     if (!req.body.taskName || !req.body.isActive) {
-      res.status(400).send({
-        error: 'Task Name, Active status, Task Number are mandatory fields',
+      return res.status(400).send({
+        error: 'Task Name, Active status are mandatory fields',
       });
-      return;
     }
 
     const wbsId = req.params.id;
@@ -447,31 +445,69 @@ const taskController = function (Task) {
     const createdDatetime = Date.now();
     const modifiedDatetime = Date.now();
 
-    const _task = new Task({
-      ...task,
-      wbsId,
-      createdDatetime,
-      modifiedDatetime,
-    });
+    const parentId = task.mother; 
+    let level = 1;
+    let num = '';
 
-    const saveTask = _task.save();
-    const saveWbs = WBS.findById(wbsId).then((currentwbs) => {
-      currentwbs.modifiedDatetime = Date.now();
-      return currentwbs.save();
-    });
-    // Posting a task will update the related project - Sucheta
-    const saveProject = WBS.findById(wbsId).then((currentwbs) => {
-      Project.findById(currentwbs.projectId).then((currentProject) => {
-        currentProject.modifiedDatetime = Date.now();
-        return currentProject.save();
-      });
-    });
+    try {
+      if (parentId) {
+        // This is a subtask — find its parent
+        const parentTask = await Task.findById(parentId);
+        if (!parentTask) {
+          return res.status(400).send({ error: 'Invalid parent task ID provided.' });
+        }
 
-    Promise.all([saveTask, saveWbs, saveProject])
-      .then((results) => res.status(201).send(results[0]))
-      .catch((errors) => {
-        res.status(400).send(errors);
+        level = parentTask.level + 1;
+        // Find siblings under same parent to generate WBS number
+        const siblings = await Task.find({ mother: parentId });
+        const nextIndex = siblings.length
+          ? Math.max(...siblings.map((s) => parseInt(s.num.split('.')[level - 1] || 0))) + 1
+          : 1;
+
+        const baseNum = parentTask.num
+          .split('.')
+          .slice(0, level - 1)
+          .join('.');
+        num = baseNum ? `${baseNum}.${nextIndex}` : `${nextIndex}`;
+      } else {
+        const topTasks = await Task.find({ wbsId, level: 1 });
+        const nextTopNum = topTasks.length
+          ? Math.max(...topTasks.map((t) => parseInt(t.num.split('.')[0] || 0))) + 1
+          : 1;
+        num = `${nextTopNum}`;
+      }
+
+      const _task = new Task({
+        ...task,
+        wbsId,
+        num, // Assign calculated num
+        level,
+        createdDatetime,
+        modifiedDatetime,
       });
+
+      const saveTask = _task.save();
+      const saveWbs = WBS.findById(wbsId).then((currentwbs) => {
+        currentwbs.modifiedDatetime = Date.now();
+        return currentwbs.save();
+      });
+      // Posting a task will update the related project - Sucheta
+      const saveProject = WBS.findById(wbsId).then((currentwbs) => {
+        Project.findById(currentwbs.projectId).then((currentProject) => {
+          currentProject.modifiedDatetime = Date.now();
+          return currentProject.save();
+        });
+      });
+
+      Promise.all([saveTask, saveWbs, saveProject])
+        .then((results) => res.status(201).send(results[0])) // send task with generated num
+        .catch((errors) => {
+          res.status(400).send(errors);
+        });
+    } catch (err) {
+      console.error('Error creating task:', err);
+      return res.status(500).send({ error: 'Internal server error.', details: err.message });
+    }
   };
 
   const updateNum = async (req, res) => {


### PR DESCRIPTION
# Description
Please focus on f point
<img width="655" alt="Screenshot 2025-03-06 at 10 45 08 PM" src="https://github.com/user-attachments/assets/2079fd3c-4b1e-4fa8-9611-7676707c856c" />

## Related PRS (if any):
This backend PR is related to the #3346 (https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3346)frontend PR.
To test this backend PR you need to checkout the https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3346  frontend PR.
…

## Main changes explained:
- In this update, I have modified the logic for generating the num field to ensure more accurate and consistent hierarchical numbering of tasks and subtasks. The new implementation dynamically calculates the next available index based on the number of existing sibling tasks and constructs the num using the parent’s num value. This helps maintain a clear and structured WBS format.
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run build` and then `npm start` to run this PR locally
3. Clear site data/cache
4.Other Links>Projects>WBS Icon>Choose WBS
5.Keep the above tab open and do this process on a private browser with another account and same WBS: Other Links>Projects>WBS Icon>Choose WBS>Add Task
6. Then go back to the tab from “a” and add task without refreshing 

## Screenshots or videos of changes:

##### Before

https://github.com/user-attachments/assets/0737279b-eb5c-4c91-ab19-d9c5f430cae1

##### After

https://github.com/user-attachments/assets/66bfd6ea-150b-4c21-909d-7ffb7c2f2f26
