### PR TITLE
Strallia - Store weekly summary submission dates in new UserProfile field

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -485,8 +485,24 @@ const userProfileController = function (UserProfile, Project) {
       if (PROTECTED_EMAIL_ACCOUNT.includes(record.email)) {
         originalRecord = objectUtils.deepCopyMongooseObjectWithLodash(record);
       }
-      // validate userprofile pic
 
+      // Capture Weekly Summary Submission Date
+      if (req.body.weeklySummaries && req.body.weeklySummaries.length > 0) {
+        const latestSummary = req.body.weeklySummaries[req.body.weeklySummaries.length - 1];
+
+        // Ensure the user profile has a `summarySubmissionDates` array
+        if (!record.summarySubmissionDates) {
+          record.summarySubmissionDates = [];
+        }
+
+        // Add current date to `summarySubmissionDates`
+        record.summarySubmissionDates.push({
+          date: new Date(),
+          summaryId: latestSummary._id || null,
+        });
+      }
+
+      // validate userprofile pic
       if (req.body.profilePic) {
         const results = userHelper.validateProfilePic(req.body.profilePic);
 
@@ -560,6 +576,7 @@ const userProfileController = function (UserProfile, Project) {
         userIdx = allUserData.findIndex((users) => users._id === userid);
         userData = allUserData[userIdx];
       }
+
       if (await hasPermission(req.body.requestor, 'updateSummaryRequirements')) {
         const summaryFields = ['weeklySummaryNotReq', 'weeklySummaryOption'];
         summaryFields.forEach((fieldName) => {
@@ -1493,8 +1510,6 @@ const userProfileController = function (UserProfile, Project) {
     const currentRefreshToken = jwt.sign(jwtPayload, JWT_SECRET);
     res.status(200).send({ refreshToken: currentRefreshToken });
   };
-
- 
 
   const getUserBySingleName = (req, res) => {
     const pattern = new RegExp(`^${req.params.singleName}`, 'i');


### PR DESCRIPTION
# Description
Creates a new `summarySubmissionDates` field in the UserProfile collection that stores

## Main changes explained:
- Updated UserProfileController.js with new database field

## How to test:
1. check into current branch
2. do `npm install` and `npm run dev` to run this PR locally
3. run the frontend development branch
4. Clear site data/cache
5. log as any user
6. submit a weekly summary from dashboard
7. open mongoDB Compass and confirm your user profile document in UserProfile collection has a `summarySubmissionDates` field with the date you submitted the summary
