### PR TITLE
Vamsi Krishna - Added 'viewTaskExtensionCount' permission to Owner & Admin

### DIFF
--- a/src/test/createTestPermissions.js
+++ b/src/test/createTestPermissions.js
@@ -29,6 +29,7 @@ const permissionsRoles = [
       'updateTask',
       'swapTask',
       'deleteTask',
+      'viewTaskExtensionCount',  //to view task extension count
       'updateNum',
       // Teams
       'postTeam',
@@ -186,6 +187,7 @@ const permissionsRoles = [
       'assignProjectToUsers',
       'importTask',
       'postTask',
+      'viewTaskExtensionCount' // to view task extension count
       'updateNum',
       'updateTask',
       'swapTask',

--- a/src/utilities/createInitialPermissions.js
+++ b/src/utilities/createInitialPermissions.js
@@ -31,6 +31,7 @@ const permissionsRoles = [
       'updateTask',
       'swapTask',
       'deleteTask',
+      'viewTaskExtensionCount', // to view task extension count
       'updateNum',
       // Teams
       'postTeam',
@@ -216,6 +217,7 @@ const permissionsRoles = [
       'assignProjectToUsers',
       'importTask',
       'postTask',
+      'viewTaskExtensionCount', // to view task extension count
       'updateNum',
       'updateTask',
       'swapTask',


### PR DESCRIPTION
# Description
![PR](https://github.com/user-attachments/assets/8c3f4767-d677-4ef4-936f-f4dd12b563ff)


## Related PRS (if any):
This backend PR is related to the [#3402](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3402) frontend PR.
To test this backend PR you need to checkout the [#3402](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3402) frontend PR.
…

## Main changes explained:
- Added the permission 'viewTaskExtensionCount' to Owner and Admin initial permissions list.
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run build `.
3. `npm start` to run this PR locally
4. Clear site data/cache
5. log as admin/owner user
6. go to Other links -> PermissionsManagement -> Select Owner/Admin role ->See # of Times Time Added to Task added.


## Screenshots or videos of changes:

https://github.com/user-attachments/assets/ad6deba2-5efe-4250-ac94-47b4efc3d228

