### PR TITLE
Linh - Fix gzip compression issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2773,6 +2773,15 @@
         "@types/node": "*"
       }
     },
+    "@types/compression": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.7.5.tgz",
+      "integrity": "sha512-AAQvK5pxMpaT+nDvhHrsBhLSYG5yQdtkaJE1WYieSNY2mVFKAgmU4ks65rkZD5oqnGCFLyQpUr1CqI4DmUMyDg==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
     "@types/connect": {
       "version": "3.4.35",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
@@ -4930,7 +4939,6 @@
       "dev": true
     },
     "caniuse-lite": {
-
       "version": "1.0.30001697",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001697.tgz",
       "integrity": "sha512-GwNPlWJin8E+d7Gxq96jxM6w0w+VFeyyXRsjU58emtkYqnbwHqXm5uT2uCmO0RQE9htWknOP4xtBlLmM/gWxvQ=="
@@ -5246,6 +5254,53 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
       "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ=="
+    },
+    "compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "requires": {
+        "mime-db": ">= 1.43.0 < 2"
+      }
+    },
+    "compression": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
+      "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
+      "requires": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+        },
+        "negotiator": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+          "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w=="
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
     },
     "concat-map": {
       "version": "0.0.1",
@@ -11119,7 +11174,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
       "integrity": "sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q=="
-
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -12619,6 +12673,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "license": "ISC",
   "devDependencies": {
     "@babel/eslint-parser": "^7.15.0",
+    "@types/compression": "^1.7.5",
     "@types/express": "^4.17.6",
     "@types/jest": "^26.0.0",
     "@types/node": "^8.10.61",
@@ -60,6 +61,7 @@
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.18.3",
     "cheerio": "^0.22.0",
+    "compression": "^1.8.0",
     "cors": "^2.8.4",
     "cron": "^1.8.2",
     "dotenv": "^5.0.1",

--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,7 @@ logger.init();
 // The request handler must be the first middleware on the app
 app.use(Sentry.Handlers.requestHandler());
 
+require('./startup/compression')(app);
 require('./startup/cors')(app);
 require('./startup/bodyParser')(app);
 require('./startup/middleware')(app);

--- a/src/startup/compression.js
+++ b/src/startup/compression.js
@@ -1,0 +1,35 @@
+const compression = require('compression');
+
+module.exports = function (app) {
+  // Remove Brotli to force gzip
+  app.use((req, res, next) => {
+    const enc = req.headers['accept-encoding'];
+    if (enc && enc.includes('br')) {
+      req.headers['accept-encoding'] = enc
+        .split(',')
+        .map((e) => e.trim())
+        .filter((e) => e !== 'br')
+        .join(', ');
+    }
+    next();
+  });
+
+  const compressionOptions = {
+    level: 6, // medium compression level
+    threshold: 0, // compress everything
+    filter: (req, res) => {
+      if (req.headers['x-no-compression']) return false;
+
+      const contentType = res.getHeader && res.getHeader('Content-Type');
+      const compressibleTypes = ['application/json', 'text/', 'application/javascript'];
+
+      if (contentType && !compressibleTypes.some((type) => contentType.includes(type))) {
+        return false;
+      }
+
+      return compression.filter(req, res);
+    },
+  };
+
+  app.use(compression(compressionOptions));
+};


### PR DESCRIPTION
# Description
Fixes #1186 (bug list priority: medium)  
This PR addresses issues found in PR #1186 where gzip compression was not properly applied to all relevant responses. A corrected implementation of the compression middleware is provided with custom configuration for content-type-based filtering and header control.

## Related PRs (if any):
This PR is a follow-up fix to PR #1186.

## Main changes explained:
- Added `"compression"` package to `package.json` and `package-lock.json`.
- Created `src/startup/compression.js` with custom logic:
  - Skips compression for images, videos, and other uncompressible content-types.
  - Honors `x-no-compression` request header.
  - Forces gzip-only compression (Brotli explicitly disabled).
- Applied compression middleware in `src/app.js`.

## How to test:
1. Checkout into branch `linh_fix_bug_1187_gzip_compression`
2. Run `npm install`
3. Start the backend server with `npm run dev`
4. Open browser DevTools (Ctrl + Shift + I) and go to the Network tab
5. Login at `http://localhost:3000/login`
6. Click on any API request (e.g., `/users`)
7. Under the "Headers" tab, confirm `Content-Encoding: gzip` is present

## Screenshots or videos of changes:
https://www.loom.com/share/e32cfefc69a84c7d9025f849aab625f4?sid=aedfb505-623f-4738-b61a-53a43deee669

## Note:
Bug originally introduced in PR #1186. This fix was authorized by Jae and verified locally by Linh.
