### PR TITLE
Handling null comparision start and end dates

### DIFF
--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -430,8 +430,8 @@ const overviewReportHelper = function () {
         },
       ]);
       const data = {};
-      data.current = res[0].current[0].activeTeams;
-      data.comparison = res[0].comparison[0].activeTeams;
+      data.current = res[0]?.current[0]?.activeTeams || 0;
+      data.comparison = res[0]?.comparison[0]?.activeTeams || 0;
       data.percentage = calculateGrowthPercentage(data.current, data.comparison);
       return data;
     }
@@ -447,7 +447,7 @@ const overviewReportHelper = function () {
       },
     ]);
 
-    return { current: res[0].activeTeams };
+    return { current: res[0]?.activeTeams || 0 };
   }
 
   /**


### PR DESCRIPTION
# Description
These changes are made to provide a functionality to see the voluntary stats on the TotalOrgSummary page for a given date range and a comparison range filter. On the TotalOrgSummary page, a new drop-down is being added which has two filters. One is the date range filter and the comparison filter. Upon selecting each of these filters, it will provide a way to see the volunteer stats for the given date range and you have comparison filters drop-down which has by default no comparison and three other options which compares with the week over week(which means compared to the previous week) month over month(which means compared to the same week last month) and year over year(which means compared to the same week last year) and it will update the Comparison text as well.Or Implements 

## Related PRS (if any):
To test this backend PR you need to checkout the #3408 frontend PR.
…

## Main changes explained:
- Added functionality to handle the null values for the comparison start and end dates.
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run build && npm start` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→Total Org Summary 
6. Verify that the page is not breaking when no comparison filter is selected.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/f3e85423-3571-46f1-886f-a54693c7dc70



