### PR TITLE
Jaissica -  create donut chart backend for tools available

### DIFF
--- a/src/controllers/bmdashboard/bmToolAvailabilityController.js
+++ b/src/controllers/bmdashboard/bmToolAvailabilityController.js
@@ -1,0 +1,44 @@
+const BuildingTool = require('../../models/bmdashboard/buildingTool');
+
+exports.getToolAvailability = async (req, res) => {
+  const { toolId, projectId } = req.query;
+  const filter = {};
+  if (toolId) filter.itemType = toolId;
+  if (projectId) filter.project = projectId;
+
+  try {
+    const tools = await BuildingTool.find(filter).lean();
+
+    let available = 0;
+    let used = 0;
+    let maintenance = 0;
+
+    for (const tool of tools) {
+      const lastLog = tool.logRecord?.[tool.logRecord.length - 1];
+      const lastUpdate = tool.updateRecord?.[tool.updateRecord.length - 1];
+
+      if (lastUpdate?.condition === 'Out of Order') {
+        maintenance++;
+      } else if (lastLog?.type === 'Check Out') {
+        used++;
+      } else {
+        available++;
+      }
+    }
+
+    const total = available + used + maintenance;
+    const data = [
+      { status: 'Available', count: available },
+      { status: 'Used', count: used },
+      { status: 'Maintenance', count: maintenance },
+    ].map(entry => ({
+      ...entry,
+      percentage: total > 0 ? parseFloat(((entry.count / total) * 100).toFixed(1)) : 0,
+    }));
+
+    return res.status(200).json({ data, total });
+  } catch (err) {
+    console.error('Error calculating tool availability:', err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};

--- a/src/routes/bmdashboard/bmToolAvailabilityRoutes.js
+++ b/src/routes/bmdashboard/bmToolAvailabilityRoutes.js
@@ -1,0 +1,7 @@
+const express = require('express');
+const router = express.Router();
+const controller = require('../../controllers/bmdashboard/bmToolAvailabilityController');
+
+router.get('/tools/availability', controller.getToolAvailability);
+
+module.exports = router;

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -193,7 +193,7 @@ module.exports = function (app) {
   app.use('/api/bm', bmEquipmentRouter);
   app.use('/api/bm', bmConsumablesRouter);
   app.use('/api/bm', bmExternalTeam);
-  app.use('/api', bmIssueRouter);
+  app.use('api', bmIssueRouter);
   app.use('/api', registrationRouter);
   app.use('/api', toolAvailabilityRoutes);
 };

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -121,6 +121,7 @@ const bmInventoryTypeRouter = require('../routes/bmdashboard/bmInventoryTypeRout
   toolType,
   equipmentType,
 );
+const toolAvailabilityRoutes = require('../routes/bmdashboard/bmToolAvailabilityRoutes');
 
 const titleRouter = require('../routes/titleRouter')(title);
 const bmToolRouter = require('../routes/bmdashboard/bmToolRouter')(buildingTool, toolType);
@@ -192,6 +193,7 @@ module.exports = function (app) {
   app.use('/api/bm', bmEquipmentRouter);
   app.use('/api/bm', bmConsumablesRouter);
   app.use('/api/bm', bmExternalTeam);
-  app.use('api', bmIssueRouter);
+  app.use('/api', bmIssueRouter);
   app.use('/api', registrationRouter);
+  app.use('/api', toolAvailabilityRoutes);
 };


### PR DESCRIPTION
# Description

![Task](https://github.com/user-attachments/assets/81e82157-91cf-4fbc-8067-e94f402400c5)


## Related PRS (if any):
- NA

## Main changes explained:
- Created `bmToolAvailabilityController.js` which consists of the logic to calculate Available, Used & maintenance tools.
- Created `bmToolAvailabilityRoutes.js` and linked it to `bmToolAvailabilityController.js` to retrieve Available, Used & maintenance tools.
- `routes.js` added toolAvailabilityRoutes.
 
## How to test:
1. check into current branch
2. do `npm install` and `npm run build` to run this PR locally
3. Clear site data/cache
4. Use postman to test the API (Please refer to the video below for postman setup and backend API testing)
5. Compare the data retrieved from backend API using Postman and MongoDB - `buildingTools`.
6. API(s) testing
   - http://localhost:4500/api/tools/availability : retrieves all the Available, Used, and Maintenance tools. 
   - http://localhost:4500/api/tools/availability?projectId="": Retrieves all the Available, Used, and Maintenance tools with the given projectId. 
   - http://localhost:4500/api/tools/availability?toolId="": Retrieves all the Available, Used, and Maintenance tools with the given toolId. 
   - http://localhost:4500/api/tools/availability?toolId=""&projectId="": Retrieves all the Available, Used, and Maintenance tools with the given toolId and projectId. 

## Screenshots or videos of changes:

## Note:
NA
