### PR TITLE
Zhifan - Improve loading speed of Weekly Summaries Report via tab data fix

### DIFF
--- a/src/models/timeentry.js
+++ b/src/models/timeentry.js
@@ -19,5 +19,7 @@ const TimeEntry = new Schema({
 });
 TimeEntry.index({ personId: 1, dateOfWork: 1 });
 TimeEntry.index({ entryType: 1, teamId: 1, dateOfWork: 1, isActive: 1 });
+TimeEntry.index({ personId: 1, dateOfWork: 1 });
+
 
 module.exports = mongoose.model('timeEntry', TimeEntry, 'timeEntries');

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -275,5 +275,17 @@ userProfileSchema.pre('save', function (next) {
 userProfileSchema.index({ teamCode: 1 });
 userProfileSchema.index({ email: 1 });
 userProfileSchema.index({ isActive: 1 });
+// Add index for weeklySummaries.dueDate to speed up filtering
+userProfileSchema.index({ 'weeklySummaries.dueDate': 1 });
+// Add compound index for isActive and createdDate
+userProfileSchema.index({ isActive: 1, createdDate: 1 });
+// Index for weekly summaries date filtering
+userProfileSchema.index({ 'weeklySummaries.dueDate': 1 });
+// Compound index for isActive and createdDate (for filtering and sorting)
+userProfileSchema.index({ isActive: 1, createdDate: 1 });
+// Index for total hours calculation and filtering
+userProfileSchema.index({ totalTangibleHrs: 1 });
+// Index to help with bio status filtering
+userProfileSchema.index({ bioPosted: 1 });
 
 module.exports = mongoose.model('userProfile', userProfileSchema, 'userProfiles');


### PR DESCRIPTION
# Description


## Related PRS (if any):
To test this backend PR you need to checkout the [#3447](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3447) frontend PR.
…

## Main changes explained:
- Modified the getWeeklySummaries endpoint to accept a week parameter
- Updated the controller to fetch data for only the requested week
- Implemented server-side caching with different durations based on week
- Added a cache invalidation function to clear cache when data changes
- Added caching headers for HTTP-level caching
…

## How to test:
1. check into current branch
2. do `npm run build` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports → Weekly Summaries Report
6. switch tabs for different week and compare the loading speed between initial fetch and subsequent fetch

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
