### PR TITLE
Humemah: fix - prevent deactivated managers from receiving notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5206,7 +5206,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "color-string": {
       "version": "1.9.1",
@@ -5858,7 +5858,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -6007,7 +6007,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
     },
     "eslint": {
       "version": "8.47.0",
@@ -7105,7 +7105,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "safe-buffer": {
           "version": "5.2.1",
@@ -7224,7 +7224,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -7751,7 +7751,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
     },
     "has-property-descriptors": {
       "version": "1.0.0",
@@ -11092,7 +11092,7 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -11346,7 +11346,7 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -12726,7 +12726,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -12747,7 +12747,7 @@
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "pend": {
       "version": "1.2.0",
@@ -14560,7 +14560,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "tmp": {
@@ -14578,7 +14578,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/src/routes/taskRouter.js
+++ b/src/routes/taskRouter.js
@@ -3,7 +3,7 @@ const express = require('express');
 const routes = function (task, userProfile) {
   const controller = require('../controllers/taskController')(task, userProfile);
   const taskRouter = express.Router();
-
+  taskRouter.route('/tasks/reviewreq/:userId').post(controller.sendReviewReq);
   taskRouter
     .route('/tasks/:wbsId/:level/:mother')
     .get(controller.getTasks)
@@ -35,7 +35,7 @@ const routes = function (task, userProfile) {
 
   taskRouter.route('/user/:userId/teams/tasks').get(controller.getTasksForTeamsByUser);
 
-  taskRouter.route('/tasks/reviewreq/:userId').post(controller.sendReviewReq);
+  // taskRouter.route('/tasks/reviewreq/:userId').post(controller.sendReviewReq);
 
   return taskRouter;
 };

--- a/src/routes/taskRouter.js
+++ b/src/routes/taskRouter.js
@@ -3,7 +3,7 @@ const express = require('express');
 const routes = function (task, userProfile) {
   const controller = require('../controllers/taskController')(task, userProfile);
   const taskRouter = express.Router();
-  taskRouter.route('/tasks/reviewreq/:userId').post(controller.sendReviewReq);
+ 
   taskRouter
     .route('/tasks/:wbsId/:level/:mother')
     .get(controller.getTasks)
@@ -35,7 +35,7 @@ const routes = function (task, userProfile) {
 
   taskRouter.route('/user/:userId/teams/tasks').get(controller.getTasksForTeamsByUser);
 
-  // taskRouter.route('/tasks/reviewreq/:userId').post(controller.sendReviewReq);
+  taskRouter.route('/tasks/reviewreq/:userId').post(controller.sendReviewReq);
 
   return taskRouter;
 };


### PR DESCRIPTION


# Description
![image](https://github.com/user-attachments/assets/f990c5c6-526c-4c80-a3ec-26c24aba5ba6)


## Related PRS (if any):
Not related 
…

## Main changes explained:
Main change was to add a condition to stop deactivated from geting emails in task controllers.js
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Log into the frontend as an owner.
4. Create a test manager account and a test user account, and assign both to the same team.
5. Trigger the sendReviewReq API (e.g., by requesting a task review).
6. 
![99279833-8e79-4179-92a9-e9b65b0ea113](https://github.com/user-attachments/assets/a71ae369-73c9-40d7-a68d-186a003971b0)

7.Check the console to confirm the manager's email appears in the recipients list or that an email is sent to them


## Note:
Include the information the reviewers need to know.
