### PR TITLE
Newell - fix resolve issue with BCC functionality

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -764,8 +764,8 @@ const userProfileController = function (UserProfile, Project) {
       }
       record
         .save()
-        .then((results) => {
-          userHelper.notifyInfringements(
+        .then(async (results) => {
+          await userHelper.notifyInfringements(
             originalinfringements,
             results.infringements,
             results.firstName,
@@ -1678,8 +1678,8 @@ const userProfileController = function (UserProfile, Project) {
 
       record
         .save()
-        .then((results) => {
-          userHelper.notifyInfringements(
+        .then(async (results) => {
+          await userHelper.notifyInfringements(
             originalinfringements,
             results.infringements,
             results.firstName,
@@ -1730,8 +1730,8 @@ const userProfileController = function (UserProfile, Project) {
 
       record
         .save()
-        .then((results) => {
-          userHelper.notifyInfringements(
+        .then(async (results) => {
+          await userHelper.notifyInfringements(
             originalinfringements,
             results.infringements,
             results.firstName,
@@ -1771,8 +1771,8 @@ const userProfileController = function (UserProfile, Project) {
 
       record
         .save()
-        .then((results) => {
-          userHelper.notifyInfringements(
+        .then(async (results) => {
+          await userHelper.notifyInfringements(
             originalinfringements,
             results.infringements,
             results.firstName,

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -1265,7 +1265,7 @@ const userHelper = function () {
           administrativeContent,
         ),
         null, // attachments
-        emailAddress, // cc
+        [emailAddress, "jae@onecommunityglobal.org"], // cc
         emailAddress, // reply-to
       );
     });

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -1161,7 +1161,7 @@ const userHelper = function () {
     }
   };
 
-  const notifyInfringements = function (
+  const notifyInfringements = async (
     original,
     current,
     firstName,
@@ -1170,7 +1170,7 @@ const userHelper = function () {
     role,
     startDate,
     jobTitle,
-  ) {
+  ) => {
     if (!current) return;
     const newOriginal = original.toObject();
     const newCurrent = current.toObject();
@@ -1247,9 +1247,12 @@ const userHelper = function () {
     newInfringements = _.differenceWith(newCurrent, newOriginal, (arrVal, othVal) =>
       arrVal._id.equals(othVal._id),
     );
-    newInfringements.forEach((element) => {
+
+    const assignments = await BlueSquareEmailAssignment.find().populate('assignedTo').exec();
+    const bccEmails = assignments.map(a => a.email);
+    newInfringements.forEach(async (element) => {
       emailSender(
-        emailAddress,
+        [...bccEmails, 'onecommunityglobal@gmail.com'], // bcc
         'New Infringement Assigned',
         getInfringementEmailBody(
           firstName,
@@ -1261,9 +1264,9 @@ const userHelper = function () {
           undefined,
           administrativeContent,
         ),
-        null,
-        'onecommunityglobal@gmail.com',
-        emailAddress,
+        null, // attachments
+        emailAddress, // cc
+        emailAddress, // reply-to
       );
     });
   };


### PR DESCRIPTION
# Description
The email BCC functionality was not working as expected. The fix ensures that emails are correctly sent with the intended BCC recipients, resolving issues where BCC recipients were not included in the outgoing emails. 

## Related PRs (if any):
N/A

## Main changes explained:
- Fixed the email composition logic to correctly handle BCC addresses
- Fixed user not showing in Reply-To

## How to test:
1. Check into the current branch
2. Run `npm install` to install dependencies
3. Clear browser cache and site data
4. Log in as an admin user
5. Go to the Profile -> Add BCC recipients
6. Verify that the BCC recipients are correctly included and the email is sent without issues
7. Check that no errors appear in the console and that the email is received by the BCC recipients

## Screenshots or videos of changes:
(Include any screenshots or videos demonstrating the fix or testing process)

## Note:
Ensure that the backend email service is up and running, as this fix also interacts with server-side logic to send the emails.
