### PR TITLE
Akanksha - Fix the ‘X’ button on the dashboard under task name

### DIFF
--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -721,7 +721,8 @@ const taskController = function (Task) {
   const updateTask = async (req, res) => {
     if (
       !(await hasPermission(req.body.requestor, 'updateTask')) &&
-      !(await hasPermission(req.body.requestor, 'removeUserFromTask'))
+      !(await hasPermission(req.body.requestor, 'removeUserFromTask')) &&
+      !(await hasPermission(req.body.requestor, 'putReviewStatus'))
     ) {
       res.status(403).send({ error: 'You are not authorized to update Task.' });
       return;


### PR DESCRIPTION
# Description:
Fix the ‘X’ button on the dashboard under task name. The Owner account is able to delete a task, but other accounts that are assigned the ‘Interact with Task’ permission are not able to delete the task. 

## Related PRS:
To test this backend PR you need to checkout the #XXX frontend PR.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as owner user
5. go to Other Links → Permissions Management → Manage User Permissions → Choose your volunteer account → click on 
Add button beside the ‘Interact with Task "Ready for Review"’ permission → Scroll down then submit
6. Log in to your volunteer account, try to click the red ‘X’ button beside tasks. You will see the error message below: 
<img width="659" alt="Screenshot 2025-05-08 at 1 15 14 PM" src="https://github.com/user-attachments/assets/a3fa6b8a-6d51-4812-a2c3-dde0095fa5aa" />

## Screenshots or videos of changes:
After the fix:

