### PR TITLE
added infringements to userprofile while getting all users

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -173,7 +173,7 @@ const userProfileController = function (UserProfile, Project) {
 
     await UserProfile.find(
       {},
-      '_id firstName lastName role weeklycommittedHours jobTitle email permissions isActive reactivationDate startDate createdDate endDate timeZone',
+      '_id firstName lastName role weeklycommittedHours jobTitle email permissions isActive reactivationDate startDate createdDate endDate infringements timeZone',
     )
       .sort({
         lastName: 1,


### PR DESCRIPTION
# Description
<img width="742" alt="image" src="https://github.com/user-attachments/assets/e44bc880-3c2a-415f-92bd-9b07368196f7" />

## Related PRS (if any):
This backend PR is related to the #3526 frontend PR.
To test this backend PR you need to checkout the #3526 frontend PR.
…

## Main changes explained:
- While getting the userProfile data for all the users, we get infringements, the length of which is the number of blue squares.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Go to user profile page of the user and assign blue squares
6. Go to the user management page and verify.

## Screenshots or videos of changes:
<img width="1440" alt="Screenshot 2025-05-18 at 2 29 58 AM" src="https://github.com/user-attachments/assets/492bbafc-9dc1-499a-83df-d88e3d5afbb1" />
