### PR TITLE
Zhifan - Fix email notification for setting last day saying the next day is their last day

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -1242,10 +1242,19 @@ const userProfileController = function (UserProfile, Project) {
     const isSet = req.body.isSet === 'FinalDay';
     let activeStatus = status;
     let emailThreeWeeksSent = false;
+
+    console.log(`[changeUserStatus] Input endDate: ${endDate}`);
+    console.log(`[changeUserStatus] Input endDate as object:`, new Date(endDate));
+
+
     if (endDate && status) {
       const dateObject = new Date(endDate);
       dateObject.setHours(dateObject.getHours() + 7);
       const setEndDate = dateObject;
+
+      console.log(`[changeUserStatus] setEndDate after 7 hour adjustment: ${setEndDate}`);
+
+
       if (moment().isAfter(moment(setEndDate).add(1, 'days'))) {
         activeStatus = false;
       } else if (moment().isBefore(moment(endDate).subtract(3, 'weeks'))) {
@@ -1321,6 +1330,10 @@ const userProfileController = function (UserProfile, Project) {
               allUserData.splice(userIdx, 1, userData);
               cache.setCache('allusers', JSON.stringify(allUserData));
             }
+
+            console.log(`[changeUserStatus] endDate being passed to sendDeactivateEmailBody: ${endDate}`);
+            console.log(`[changeUserStatus] endDate as object:`, new Date(endDate));
+
             userHelper.sendDeactivateEmailBody(
               user.firstName,
               user.lastName,

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -1243,19 +1243,12 @@ const userProfileController = function (UserProfile, Project) {
     let activeStatus = status;
     let emailThreeWeeksSent = false;
 
-    console.log(`[changeUserStatus] Input endDate: ${endDate}`);
-    console.log(`[changeUserStatus] Input endDate as object:`, new Date(endDate));
-
-
     if (endDate && status) {
       const dateObject = new Date(endDate);
       dateObject.setHours(dateObject.getHours() + 7);
       const setEndDate = dateObject;
 
-      console.log(`[changeUserStatus] setEndDate after 7 hour adjustment: ${setEndDate}`);
-
-
-      if (moment().isAfter(moment(setEndDate).add(1, 'days'))) {
+      if (moment().isAfter(moment(setEndDate))) {
         activeStatus = false;
       } else if (moment().isBefore(moment(endDate).subtract(3, 'weeks'))) {
         emailThreeWeeksSent = true;

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -2268,67 +2268,107 @@ const userHelper = function () {
   };
 
   const deActivateUser = async () => {
-    try {
-      const emailReceivers = await userProfile.find(
-        { isActive: true, role: { $in: ['Owner'] } },
-        '_id isActive role email',
-      );
-      const recipients = emailReceivers.map((receiver) => receiver.email);
-      const users = await userProfile.find(
-        { isActive: true, endDate: { $exists: true } },
-        '_id isActive endDate isSet finalEmailThreeWeeksSent reactivationDate',
-      );
-      for (let i = 0; i < users.length; i += 1) {
-        const user = users[i];
-        const { endDate, finalEmailThreeWeeksSent } = user;
-        endDate.setHours(endDate.getHours() + 7);
-        // notify reminder set final day before 2 weeks
-        if (
-          finalEmailThreeWeeksSent &&
-          moment().isBefore(moment(endDate).subtract(2, 'weeks')) &&
-          moment().isAfter(moment(endDate).subtract(3, 'weeks'))
-        ) {
-          const id = user._id;
-          const person = await userProfile.findById(id);
-          const lastDay = moment(person.endDate).format('YYYY-MM-DD');
-          logger.logInfo(`User with id: ${user._id}'s final Day is set at ${moment().format()}.`);
-          person.teams.map(async (teamId) => {
-            const managementEmails = await userHelper.getTeamManagementEmail(teamId);
-            if (Array.isArray(managementEmails) && managementEmails.length > 0) {
-              managementEmails.forEach((management) => {
-                recipients.push(management.email);
-              });
-            }
-          });
-          sendDeactivateEmailBody(
-            person.firstName,
-            person.lastName,
-            lastDay,
-            person.email,
-            recipients,
-            person.isSet,
-            person.reactivationDate,
-            false,
-            true,
-          );
-        } else if (moment().isAfter(moment(endDate).add(1, 'days'))) {
-          try {
-            await userProfile.findByIdAndUpdate(
-              user._id,
-              user.set({
-                isActive: false,
-              }),
-              { new: true },
-            );
-          } catch (err) {
-            // Log the error and continue to the next user
-            logger.logException(err, `Error in deActivateUser. Failed to update User ${user._id}`);
-            continue;
+  try {
+    const emailReceivers = await UserProfile.find(
+      { isActive: true, role: { $in: ['Owner'] } },
+      '_id isActive role email',
+    );
+    const recipients = emailReceivers.map((receiver) => receiver.email);
+    
+    // Find users with set end dates who are still active
+    const users = await UserProfile.find(
+      { isActive: true, endDate: { $exists: true } },
+      '_id isActive endDate isSet finalEmailThreeWeeksSent reactivationDate',
+    );
+    
+    for (let i = 0; i < users.length; i += 1) {
+      const user = users[i];
+      const { endDate, finalEmailThreeWeeksSent } = user;
+      endDate.setHours(endDate.getHours() + 7);
+
+      // Notify reminder set final day before 2 weeks
+      if (
+        finalEmailThreeWeeksSent &&
+        moment().isBefore(moment(endDate).subtract(2, 'weeks')) &&
+        moment().isAfter(moment(endDate).subtract(3, 'weeks'))
+      ) {
+        const id = user._id;
+        const person = await UserProfile.findById(id);
+        const lastDay = moment(person.endDate).format('YYYY-MM-DD');
+        logger.logInfo(`User with id: ${user._id}'s final Day is set at ${moment().format()}.`);
+        person.teams.map(async (teamId) => {
+          const managementEmails = await userHelper.getTeamManagementEmail(teamId);
+          if (Array.isArray(managementEmails) && managementEmails.length > 0) {
+            managementEmails.forEach((management) => {
+              recipients.push(management.email);
+            });
           }
-          const id = user._id;
-          const person = await userProfile.findById(id);
-          const lastDay = moment(person.endDate).format('YYYY-MM-DD');
+        });
+        sendDeactivateEmailBody(
+          person.firstName,
+          person.lastName,
+          lastDay,
+          person.email,
+          recipients,
+          person.isSet,
+          person.reactivationDate,
+          false,
+          true,
+        );
+      } 
+      // Check if today is after their end date 
+      // This is the key change - removed adding an extra day
+      else if (moment().isAfter(moment(endDate))) {
+        try {
+          // Before deactivation, check when they last logged time
+          const lastTimeEntry = await TimeEntry.findOne(
+            { personId: user._id, isTangible: true },
+            {},
+            { sort: { 'dateOfWork': -1 } }
+          );
+          
+          let updatedEndDate = endDate; // Default to the original end date
+          let earlyDeactivation = false;
+          
+          // If they have a time entry and it's before their final day
+          if (lastTimeEntry) {
+            const lastActivityDate = moment(lastTimeEntry.dateOfWork);
+            const finalDayDate = moment(endDate);
+            
+            // If their last activity was more than 1 day before their final day
+            if (lastActivityDate.isBefore(finalDayDate, 'day') && 
+                finalDayDate.diff(lastActivityDate, 'days') >= 1) {
+              
+              // Update their end date to their last activity date
+              updatedEndDate = lastActivityDate.toDate();
+              earlyDeactivation = true;
+              
+              // Update the user record with the adjusted end date
+              await UserProfile.findByIdAndUpdate(
+                user._id,
+                { $set: { endDate: updatedEndDate } },
+                { new: true }
+              );
+              
+              logger.logInfo(
+                `User with id: ${user._id} had their end date adjusted from ${finalDayDate.format('YYYY-MM-DD')} to ${lastActivityDate.format('YYYY-MM-DD')} because that was their last active day.`
+              );
+            }
+          }
+
+          await UserProfile.findByIdAndUpdate(
+            user._id,
+            {
+              $set: {
+                isActive: false,
+              },
+            },
+            { new: true },
+          );
           logger.logInfo(`User with id: ${user._id} was de-activated at ${moment().format()}.`);
+          const id = user._id;
+          const person = await UserProfile.findById(id);
+
           person.teams.map(async (teamId) => {
             const managementEmails = await userHelper.getTeamManagementEmail(teamId);
             if (Array.isArray(managementEmails) && managementEmails.length > 0) {
@@ -2337,22 +2377,30 @@ const userHelper = function () {
               });
             }
           });
+
+          // Use the potentially adjusted end date for the email
+          const formattedEndDate = moment(updatedEndDate).format('YYYY-MM-DD');
           sendDeactivateEmailBody(
             person.firstName,
             person.lastName,
-            lastDay,
+            formattedEndDate, // Use adjusted end date if applicable
             person.email,
             recipients,
             person.isSet,
             person.reactivationDate,
             undefined,
+            earlyDeactivation // Flag for early deactivation if applicable
           );
+        } catch (err) {
+          logger.logException(err, `Error in deActivateUser. Failed to update User ${user._id}`);
+          continue;
         }
       }
-    } catch (err) {
-      logger.logException(err, 'Unexpected error in deActivateUser');
     }
-  };
+  } catch (err) {
+    logger.logException(err, 'Unexpected error in deActivateUser');
+  }
+};
 
   // Update by Shengwei/Peter PR767:
   /**

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -2172,11 +2172,22 @@ const userHelper = function () {
     let emailBody;
     recipients.push('onecommunityglobal@gmail.com');
     recipients = recipients.toString();
+
+    console.log(`[sendDeactivateEmailBody] Received endDate: ${endDate}`);
+    console.log(`[sendDeactivateEmailBody] endDate as object:`, new Date(endDate));
+
+
     if (reactivationDate) {
+
+      const formattedDate = moment(endDate).format('M-D-YYYY');
+      console.log(`[sendDeactivateEmailBody] Formatted date (M-D-YYYY): ${formattedDate}`);
+      console.log(`[sendDeactivateEmailBody] Formatted with UTC (M-D-YYYY): ${moment.utc(endDate).format('M-D-YYYY')}`);
+
+
       subject = `IMPORTANT: ${firstName} ${lastName} has been PAUSED in the Highest Good Network`;
       emailBody = `<p>Management, </p>
 
-      <p>Please note that ${firstName} ${lastName} has been PAUSED in the Highest Good Network as ${moment(endDate).format('M-D-YYYY')}.</p>
+      <p>Please note that ${firstName} ${lastName} has been PAUSED in the Highest Good Network as ${moment.utc(endDate).format('M-D-YYYY')}.</p>
       <p>For a smooth transition, Please confirm all your work with this individual has been wrapped up and nothing further is needed on their part until they return on ${moment(reactivationDate).format('M-D-YYYY')}. </p>
 
       <p>With Gratitude, </p>
@@ -2184,10 +2195,16 @@ const userHelper = function () {
       <p>One Community</p>`;
       emailSender(email, subject, emailBody, null, recipients, email);
     } else if (endDate && isSet && sendThreeWeeks) {
+
+      const formattedDate = moment(endDate).format('M-D-YYYY');
+      console.log(`[sendDeactivateEmailBody] Formatted date (M-D-YYYY): ${formattedDate}`);
+      console.log(`[sendDeactivateEmailBody] Formatted with UTC (M-D-YYYY): ${moment.utc(endDate).format('M-D-YYYY')}`);
+
+
       const subject = `IMPORTANT: The last day for ${firstName} ${lastName} has been set in the Highest Good Network`;
       const emailBody = `<p>Management, </p>
 
-      <p>Please note that the final day for ${firstName} ${lastName} has been set in the Highest Good Network as ${moment(endDate).format('M-D-YYYY')}.</p>
+      <p>Please note that the final day for ${firstName} ${lastName} has been set in the Highest Good Network as ${moment.utc(endDate).format('M-D-YYYY')}.</p>
       <p>This is more than 3 weeks from now, but you should still start confirming all your work is being wrapped up with this individual and nothing further will be needed on their part after this date. </p>
 
       <p>An additional reminder email will be sent in their final 2 weeks.</p>
@@ -2197,10 +2214,16 @@ const userHelper = function () {
       <p>One Community</p>`;
       emailSender(email, subject, emailBody, null, recipients, email);
     } else if (endDate && isSet && followup) {
+
+      const formattedDate = moment(endDate).format('M-D-YYYY');
+      console.log(`[sendDeactivateEmailBody] Formatted date (M-D-YYYY): ${formattedDate}`);
+      console.log(`[sendDeactivateEmailBody] Formatted with UTC (M-D-YYYY): ${moment.utc(endDate).format('M-D-YYYY')}`);
+
+
       subject = `IMPORTANT: The last day for ${firstName} ${lastName} has been set in the Highest Good Network`;
       emailBody = `<p>Management, </p>
 
-      <p>Please note that the final day for ${firstName} ${lastName} has been set in the Highest Good Network as ${moment(endDate).format('M-D-YYYY')}.</p>
+      <p>Please note that the final day for ${firstName} ${lastName} has been set in the Highest Good Network as ${moment.utc(endDate).format('M-D-YYYY')}.</p>
       <p> This is coming up soon. For a smooth transition, please confirm all your work is wrapped up with this individual and nothing further will be needed on their part after this date. </p>
 
       <p>With Gratitude, </p>
@@ -2208,10 +2231,16 @@ const userHelper = function () {
       <p>One Community</p>`;
       emailSender(email, subject, emailBody, null, recipients, email);
     } else if (endDate && isSet) {
+
+      const formattedDate = moment(endDate).format('M-D-YYYY');
+      console.log(`[sendDeactivateEmailBody] Formatted date (M-D-YYYY): ${formattedDate}`);
+      console.log(`[sendDeactivateEmailBody] Formatted with UTC (M-D-YYYY): ${moment.utc(endDate).format('M-D-YYYY')}`);
+
+
       subject = `IMPORTANT: The last day for ${firstName} ${lastName} has been set in the Highest Good Network`;
       emailBody = `<p>Management, </p>
 
-      <p>Please note that the final day for ${firstName} ${lastName} has been set in the Highest Good Network as ${moment(endDate).format('M-D-YYYY')}.</p>
+      <p>Please note that the final day for ${firstName} ${lastName} has been set in the Highest Good Network as ${moment.utc(endDate).format('M-D-YYYY')}.</p>
       <p> For a smooth transition, Please confirm all your work with this individual has been wrapped up and nothing further is needed on their part. </p>
 
       <p>With Gratitude, </p>
@@ -2219,10 +2248,16 @@ const userHelper = function () {
       <p>One Community</p>`;
       emailSender(email, subject, emailBody, null, recipients, email);
     } else if (endDate) {
+
+      const formattedDate = moment(endDate).format('M-D-YYYY');
+      console.log(`[sendDeactivateEmailBody] Formatted date (M-D-YYYY): ${formattedDate}`);
+      console.log(`[sendDeactivateEmailBody] Formatted with UTC (M-D-YYYY): ${moment.utc(endDate).format('M-D-YYYY')}`);
+
+
       subject = `IMPORTANT: ${firstName} ${lastName} has been deactivated in the Highest Good Network`;
       emailBody = `<p>Management, </p>
 
-      <p>Please note that ${firstName} ${lastName} has been made inactive in the Highest Good Network as ${moment(endDate).format('M-D-YYYY')}.</p>
+      <p>Please note that ${firstName} ${lastName} has been made inactive in the Highest Good Network as ${moment.utc(endDate).format('M-D-YYYY')}.</p>
       <p>For a smooth transition, Please confirm all your work with this individual has been wrapped up and nothing further is needed on their part. </p>
 
       <p>With Gratitude, </p>


### PR DESCRIPTION
# Description
<img width="702" alt="Screenshot 2025-05-17 at 4 55 15 PM" src="https://github.com/user-attachments/assets/e8aaa06c-d8cb-48a3-85e1-a82f43a04fae" />



## Related PRS (if any):
To test this backend PR you need to checkout the [#3547](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3547) frontend PR.
…

## Main changes explained:
- streamlined the process with UTC time to ensure accuracy
…

## How to test:
1. check into current branch
2. do `npm run build` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. follow instructions in frontend PR

## Screenshots or videos of changes:

## Note:
There are logging added in 
`changeUserStatus` function of _src/controllers/userProfileController.js_ 
and
`sendDeactivateEmailBody` of _src/helpers/userHelper.js_ 
to track end date as it received by backend and passed into email generation.
