### PR TITLE
Rishwa - HGN Skills Dashboard: Implement UserCard design and Ranked User List

### DIFF
--- a/src/controllers/hgnFormResponseController.js
+++ b/src/controllers/hgnFormResponseController.js
@@ -33,10 +33,83 @@ const hgnFormController = function () {
       res.status(500).json({ error: err.message });
     }
   };
+  const getRankedResponses = async function (req, res) {
+    try {
+      const { skills } = req.query;
+      if (!skills) return res.status(400).json({ error: 'Missing skills query' });
 
+      const selectedSkills = skills.split(',').map((s) => s.trim());
+
+      // Mapping of frontend/backend skill names to schema fields
+      const skillMap = {
+        React: ['frontend', 'React'],
+        Redux: ['frontend', 'Redux'],
+        HTML: ['frontend', 'HTML'],
+        CSS: ['frontend', 'CSS'],
+        MongoDB: ['backend', 'MongoDB'],
+        Database: ['backend', 'Database'],
+        Agile: ['backend', 'AgileDevelopment'],
+        // Add more as needed
+      };
+
+      const responses = await FormResponse.find();
+
+      const scoredUsers = responses.map((user) => {
+        let scoreList = [];
+
+        selectedSkills.forEach((skill) => {
+          const [section, field] = skillMap[skill] || [];
+          if (section && field && user[section]?.[field]) {
+            scoreList.push(parseInt(user[section][field]));
+          }
+        });
+
+        const averageScore = scoreList.length
+          ? scoreList.reduce((a, b) => a + b, 0) / scoreList.length
+          : 0;
+
+        // Get all skills to find top 4
+        const allSkills = [];
+        ['frontend', 'backend'].forEach((section) => {
+          Object.entries(user[section] || {}).forEach(([key, val]) => {
+            const parsed = parseInt(val);
+            if (!isNaN(parsed)) {
+              allSkills.push({ skill: key, score: parsed });
+            }
+          });
+        });
+
+        const topSkills = allSkills
+          .sort((a, b) => b.score - a.score)
+          .slice(0, 4)
+          .map((s) => s.skill);
+
+        return {
+          _id: user._id,
+          name: user.userInfo?.name,
+          email: user.userInfo?.email,
+          slack: user.userInfo?.slack,
+          score: Number(averageScore.toFixed(1)),
+          topSkills,
+          isTeammate: false, // you can replace with actual logic
+          privacy: {
+            email: false,
+            slack: false,
+          },
+        };
+      });
+
+      scoredUsers.sort((a, b) => b.score - a.score);
+      res.json(scoredUsers);
+    } catch (error) {
+      console.error(error);
+      res.status(500).json({ error: 'Failed to calculate ranked responses' });
+    }
+  };
   return {
     getAllFormResponses,
     submitFormResponse,
+    getRankedResponses,
   };
 };
 module.exports = hgnFormController;

--- a/src/routes/hgnFormResponseRouter.js
+++ b/src/routes/hgnFormResponseRouter.js
@@ -7,4 +7,6 @@ hgnFormResponseRouter
   .post(controller.submitFormResponse)
   .get(controller.getAllFormResponses);
 
+hgnFormResponseRouter.route('/ranked').get(controller.getRankedResponses);
+
 module.exports = hgnFormResponseRouter;


### PR DESCRIPTION
Implemented the dynamic scoring and ranking logic for the HGN Help Skills Dashboard. Fetches ranked data from the backend API, updates ranking dynamically when skills are filtered, and ensures responsive design and proper user info display.
<img width="696" alt="Screenshot 2025-04-25 at 10 53 03 PM" src="https://github.com/user-attachments/assets/a53fed7e-878f-45cf-852f-1dceb2813424" />


## Related PRs:
- Frontend PR: [#3449](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3449)

## Main Changes:
- Created RankedUserList and UserCard components.
- Integrated dynamic fetching of ranked users based on selected skills.
- Styled UserCard to match HGN Questionnaire Dashboard Figma.
- Displayed user score, top skills, email, and Slack info.
- Highlighted scores below 5 (red) and 5 and above (green).

## How to Test:
- Switch to this frontend branch.
- Run `npm install` if not already done.
- Start backend and frontend locally (`npm run start:local`).
- Navigate to `/hgnhelp/community`.
- Select skills and observe ranked users update dynamically.
- Verify name, email, Slack info, score, and top skills displayed properly.