### PR TITLE
Kristin add defaultpassword field for create new user form

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -445,7 +445,7 @@ const userProfileController = function (UserProfile, Project) {
         _id: up._id,
       });
     } catch (error) {
-      res.status(501).send(error);
+      res.status(400).send(error);
     }
   };
 

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -380,6 +380,12 @@ const userProfileController = function (UserProfile, Project) {
     up.actualEmail = req.body.actualEmail;
     up.isVisible = !['Mentor'].includes(req.body.role);
 
+    // Handle defaultPassword
+    if (req.body.defaultPassword) {
+      const salt = await bcrypt.genSalt(10);
+      up.defaultPassword = await bcrypt.hash(req.body.defaultPassword, salt);
+    }
+
     try {
       const requestor = await UserProfile.findById(req.body.requestor.requestorId)
         .select('firstName lastName email role')
@@ -506,6 +512,18 @@ const userProfileController = function (UserProfile, Project) {
       !(await hasPermission(req.body.requestor, 'addDeleteEditOwners'))
     ) {
       res.status(403).send('You are not authorized to update this user');
+      return;
+    }
+
+        // Prevent modification of defaultPassword
+    if (req.body.defaultPassword && record.defaultPassword) {
+      res.status(403).send('defaultPassword cannot be modified once it is set.');
+      return;
+    }
+
+    // Prevent modification of defaultPassword
+    if (req.body.defaultPassword && record.defaultPassword) {
+      res.status(403).send('defaultPassword cannot be modified.');
       return;
     }
 

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -14,6 +14,19 @@ const today = new Date();
 const userProfileSchema = new Schema({
   // Updated filed
   summarySubmissionDates: [{ type: Date }],
+  defaultPassword: {
+    type: String,
+    required: false, // Not required since it's optional
+    validate: {
+      validator(v) {
+        if (!v) return true; // Allow empty values
+        const passwordregex = /(?=^.{8,}$)((?=.*\d)|(?=.*\W+))(?![.\n])(?=.*[A-Z])(?=.*[a-z]).*$/;
+        return passwordregex.test(v);
+      },
+      message:
+        '{VALUE} is not a valid password! Password should be at least 8 characters long with uppercase, lowercase, and number/special character.',
+    },
+  },
   password: {
     type: String,
     required: true,


### PR DESCRIPTION
# Description
Add functions in user profile schema and controller to match changes in the frontend

## Related PRS (if any):
This frontend PR is related to the [#1272](https://github.com/OneCommunityGlobal/HGNRest/pull/1272) backend PR.
To test this backend PR you need to checkout the [#3279](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3279) frontend PR.

## Main changes explained:
- Update userProfile.js for adding a new defaultPassword field
- Update userProfileController.js for handing defaultPassword

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin/owner user
5. go to dashboard→ User Management→ Create New User
6. fill out the form to create an new user
7. verify there is no "Unexpected Error" in the process (and in the console)

## Screenshots or videos of changes:
<img width="1517" alt="Wednesday - Test for PR" src="https://github.com/user-attachments/assets/dc11fff6-e093-4f59-adea-4832be2aed0f" />


## Note:
Skipped router since the default password field is designed not to be modifies in the frontend.
