### PR TITLE
Dipti create separate subscribe and unsubscribe pages linked to the app

### DIFF
--- a/src/controllers/emailController.js
+++ b/src/controllers/emailController.js
@@ -159,33 +159,35 @@ const addNonHgnEmailSubscription = async (req, res) => {
     if (!email) {
       return res.status(400).send('Email is required');
     }
-    const emailList = await EmailSubcriptionList.find({
-      email: { $eq: email },
-    });
+
+    const emailList = await EmailSubcriptionList.find({ email: { $eq: email } });
     if (emailList.length > 0) {
       return res.status(400).send('Email already exists');
     }
-    const payload = { email };
 
-    const token = jwt.sign(payload, jwtSecret, {
-      expiresIn: 360,
-    });
-    const emailContent = ` <!DOCTYPE html>
-    <html>
-      <head>
-        <meta charset="utf-8">
-      </head>
-      <body>
-        <p>Thank you for subscribing to our email updates!</p>
-        <p><a href="${frontEndUrl}/email-subscribe?token=${token}">Click here to confirm your email</a></p>
-      </body>
-      `;
-    // console.log('email', email);
+    // Save to DB immediately
+    const newEmailList = new EmailSubcriptionList({ email });
+    await newEmailList.save();
+
+    // Optional: Still send confirmation email
+    const payload = { email };
+    const token = jwt.sign(payload, jwtSecret, { expiresIn: 360 });
+    const emailContent = `
+      <!DOCTYPE html>
+      <html>
+        <head><meta charset="utf-8"></head>
+        <body>
+          <p>Thank you for subscribing to our email updates!</p>
+          <p><a href="${frontEndUrl}/email-subscribe?token=${token}">Click here to confirm your email</a></p>
+        </body>
+      </html>
+    `;
+
     emailSender(email, 'HGN Email Subscription', emailContent);
-    return res.status(200).send('Email subsribed successfully');
+    return res.status(200).send('Email subscribed successfully');
   } catch (error) {
-    console.error('Error updating email subscriptions:', error);
-    res.status(500).send('Error updating email subscriptions');
+    console.error('Error adding email subscription:', error);
+    res.status(500).send('Error adding email subscription');
   }
 };
 


### PR DESCRIPTION
# Description
<img width="535" alt="Screenshot 2025-05-23 at 3 15 58 PM" src="https://github.com/user-attachments/assets/928445da-0b4b-4785-b7e2-0f238274fc1e" />


## Related PRS (if any):
To test this backend PR you need to checkout the #[3566](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3566)  frontend PR.
…

## Main changes explained:
- Modified add and remove email function.
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run build` and "npm start" to run this PR locally
3. Clear site data/cache
4. Don't need to Login, just go to localhost:3000/subscribe and  localhost:3000/unsubscribe and just check the functionality as shown in the video


## Screenshots or videos of changes:


https://github.com/user-attachments/assets/8c6c7bff-6b21-4e8f-99d2-85ef054cc767




