### PR TITLE
Newell - move cc recipients to bcc for privacy

### DIFF
--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -843,8 +843,8 @@ const userHelper = function () {
               'New Infringement Assigned',
               emailBody,
               null,
-              emailsBCCs,
-              'onecommunityglobal@gmail.com',
+              null,
+              [...new Set([...emailsBCCs, 'onecommunityglobal@gmail.com'])],
             );
           } else if (isNewUser && !timeNotMet && !hasWeeklySummary) {
             usersRequiringBlueSqNotification.push(personId);
@@ -1250,7 +1250,7 @@ const userHelper = function () {
     const bccEmails = assignments.map(a => a.email);
     newInfringements.forEach(async (element) => {
       emailSender(
-        [...bccEmails, 'onecommunityglobal@gmail.com'], // bcc
+        emailAddress,
         'New Infringement Assigned',
         getInfringementEmailBody(
           firstName,
@@ -1262,9 +1262,11 @@ const userHelper = function () {
           undefined,
           administrativeContent,
         ),
-        null, // attachments
-        [emailAddress, "jae@onecommunityglobal.org"], // cc
-        emailAddress, // reply-to
+        null,
+        null,
+        emailAddress,
+        // Don't change this is to CC!
+        [...new Set([...bccEmails, 'onecommunityglobal@gmail.com', "jae@onecommunityglobal.org"])],
       );
     });
   };


### PR DESCRIPTION
# Description
Move cc recipients, which was intended for BCC, to bcc for privacy.

## Related PRS (if any):
N/A

## Main changes explained:
- Move cc recipients, which was intended for BCC, to bcc for privacy.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. send blue square email and check for its headers

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
