### PR TITLE
Reina create tracking button for advanced management backend

### DIFF
--- a/src/utilities/createInitialPermissions.js
+++ b/src/utilities/createInitialPermissions.js
@@ -197,6 +197,7 @@ const permissionsRoles = [
       'highlightEligibleBios',
       'manageTimeOffRequests',
       'changeUserRehireableStatus',
+      'setTrackingManagement',
       'changeUserStatus',
       'viewTrackingOverview',
       'issueTrackingWarnings',
@@ -282,6 +283,7 @@ const permissionsRoles = [
       'seeUsersInDashboard',
 
       'changeUserRehireableStatus',
+      'setTrackingManagement',
       'toggleInvisibility',
       'manageAdminLinks',
       'removeUserFromTask',

--- a/src/utilities/createInitialPermissions.js
+++ b/src/utilities/createInitialPermissions.js
@@ -283,7 +283,6 @@ const permissionsRoles = [
       'seeUsersInDashboard',
 
       'changeUserRehireableStatus',
-      'setTrackingManagement',
       'toggleInvisibility',
       'manageAdminLinks',
       'removeUserFromTask',


### PR DESCRIPTION
# Description
Gave owner's default permission to edit warning list. 

## Related PRS (if any):
To test this backend PR you need to checkout the [#3610 frontend PR.](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3610)
…

## Main changes explained:
- Added 'setTrackingManagement' key to permissions list under "Owners"
…

## How to test:
1. check into current branch
2. do `npm install` and `npm run start` to run this PR locally
3. See frontend steps for more details.
