### PR TITLE
Fix/hide team members tasks with team toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5392,7 +5392,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "color-string": {
       "version": "1.9.1",
@@ -6102,7 +6102,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w=="
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "1.4.4",
@@ -6251,7 +6251,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
     },
     "eslint": {
       "version": "8.47.0",
@@ -7354,7 +7354,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "safe-buffer": {
           "version": "5.2.1",
@@ -7481,7 +7481,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
@@ -8008,7 +8008,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
     },
     "has-property-descriptors": {
       "version": "1.0.0",
@@ -11378,9 +11378,7 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-
-
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "lodash.defaults": {
       "version": "4.2.0",
@@ -11406,7 +11404,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
       "integrity": "sha512-worNHGKLDetmcEYDvh2stPCrrQRkP20E4l0iIS7F8EvzMqBBi7ltvFN5m1HvTf1P7Jk1txKhvFcmYsCr8O2F1Q=="
-
     },
     "lodash.merge": {
       "version": "4.6.2",
@@ -11635,7 +11632,7 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w=="
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -13044,7 +13041,7 @@
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -13065,7 +13062,7 @@
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "pend": {
       "version": "1.2.0",
@@ -14895,7 +14892,7 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "tmp": {
@@ -14913,7 +14910,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-regex-range": {
       "version": "5.0.1",

--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -276,9 +276,11 @@ const teamcontroller = function (Team) {
       });
   };
   const updateTeamVisibility = async (req, res) => {
-    const { visibility, teamId, userId } = req.body;
+    const { visibility, teamId, userId, requestor } = req.body;
 
     try {
+      const elevatedRoles = ['Owner', 'Admin', 'coreteam'];
+
       Team.findById(teamId, (error, team) => {
         if (error || team === null) {
           res.status(400).send('No valid records found');
@@ -306,12 +308,21 @@ const teamcontroller = function (Team) {
                 return;
               }
 
-              if (visibility) {
+              // if (visibility) {
+              //    console.log(`Assigning user: ${member.userId}`);
+              //   assignlist.push(member.userId);
+              // } else {
+              //   console.log('Visiblity set to false so removing it');
+              //   unassignlist.push(member.userId);
+              // }
+              if (visibility || elevatedRoles.includes(requestor.role)) {
+                console.log(`➕ Assigning user: ${member.userId}`);
                 assignlist.push(member.userId);
-              } else {
-                console.log('Visiblity set to false so removing it');
+              } else if (!elevatedRoles.includes(requestor.role)) {
+                 console.log(`➖ Unassigning user: ${member.userId}`);
                 unassignlist.push(member.userId);
               }
+
             });
 
             const addTeamToUserProfile = userProfile

--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -279,7 +279,7 @@ const teamcontroller = function (Team) {
     const { visibility, teamId, userId, requestor } = req.body;
 
     try {
-      const elevatedRoles = ['Owner', 'Admin', 'coreteam'];
+      const elevatedRoles = ['Owner', 'Admin', 'Core Team'];
 
       Team.findById(teamId, (error, team) => {
         if (error || team === null) {
@@ -308,18 +308,12 @@ const teamcontroller = function (Team) {
                 return;
               }
 
-              // if (visibility) {
-              //    console.log(`Assigning user: ${member.userId}`);
-              //   assignlist.push(member.userId);
-              // } else {
-              //   console.log('Visiblity set to false so removing it');
-              //   unassignlist.push(member.userId);
-              // }
+             
               if (visibility || elevatedRoles.includes(requestor.role)) {
-                console.log(`➕ Assigning user: ${member.userId}`);
+                console.log(`Assigning user: ${member.userId}`);
                 assignlist.push(member.userId);
-              } else if (!elevatedRoles.includes(requestor.role)) {
-                 console.log(`➖ Unassigning user: ${member.userId}`);
+              } else {
+                console.log(` Unassigning user: ${member.userId}`);
                 unassignlist.push(member.userId);
               }
 

--- a/src/helpers/taskHelper.js
+++ b/src/helpers/taskHelper.js
@@ -126,11 +126,8 @@ const taskHelper = function () {
               if (teamMember.userId.equals(userid) && teamMember.visible) hasTeamVisibility = true;
             });
             
-    console.log('➡️ Team Visibility Toggle:', _myTeam.isTeamVisible);
-    console.log('🔍 Has Team Visibility:', hasTeamVisibility);
-    console.log('🧑‍💼 Requestor Role:', requestor.role);
-    if (elevatedRoles.includes(requestor.role) || hasTeamVisibility) {
-      console.log(`✅ Access granted to team members: hasTeamVisibility=${hasTeamVisibility}, requestorRole=${requestor.role}`);
+            if (elevatedRoles.includes(requestor.role) || hasTeamVisibility) {
+              console.log(`✅ Access granted to team members: hasTeamVisibility=${hasTeamVisibility}, requestorRole=${requestor.role}`);
 
               _myTeam.members.forEach((teamMember) => {
                 if (!teamMember.userId.equals(userid)) {
@@ -140,26 +137,7 @@ const taskHelper = function () {
             }
           });
 
-//      const elevatedRoles = ['owner', 'admin', 'coreteam'];
-//      if (hasTeamVisibility || elevatedRoles.includes(requestor.role)) {
-//   _myTeam.members.forEach((teamMember) => {
-//     if (!teamMember.userId.equals(userid)) {
-//       teamMemberIds.push(teamMember.userId);
-//     }
-//   });
-// }
 
-          //   if (hasTeamVisibility) {
-          //     _myTeam.members.forEach((teamMember) => {
-          //       if (!teamMember.userId.equals(userid)) teamMemberIds.push(teamMember.userId);
-          //     });
-          //   }
-          // });
-         
-
-          // if (hasTeamVisibility || elevatedRoles.includes(requestor.role)) {
-
-          
 
           teamMembers = await userProfile
             .find(


### PR DESCRIPTION
# Description
Users with the toggle off should NOT see other team members in the Dashboard or Tasks Tab
Owners (users with admin-level permissions) should STILL be able to see team members' tasks, even if their toggle is off.
![image](https://github.com/user-attachments/assets/67bb0e7a-f9d6-4238-8f22-d3d68234f87c)

## Related PRS (if any):
This pr is not related 
…

## Main changes explained:
Adjust Permissions for Owners: Owners should still be able to see team members' tasks, even if their team toggle is off.
…

## How to test:
Switch to the current branch.
Run npm install and start the project.
Clear site data/cache.
Log in as an admin user.
Navigate to Dashboard → Tasks → Task Tab.
Verify that team members are not hidden for owner  with the toggle off.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/b4e1ae0c-842b-4936-8ddf-fea2361ccfa2



## Note:
Ensure that the visibility logic distinguishes between regular users and Owners.
Test thoroughly to confirm that Owners can view tasks as intended.