### PR TITLE
Strallia - use pacific time in Total Org Summary data

### DIFF
--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -15,7 +15,7 @@ const reportsController = function () {
   const invalidateWeeklySummariesCache = (weekIndex) => {
     const cacheKey = `weeklySummaries_${weekIndex}`;
     cacheUtil.removeCache(cacheKey);
-    
+
     // Also invalidate the "all weeks" cache
     cacheUtil.removeCache('weeklySummaries_all');
   };
@@ -208,14 +208,13 @@ const reportsController = function () {
   };
 
   const getWeeklySummaries = async function (req, res) {
-  
     if (!(await hasPermission(req.body.requestor, 'getWeeklySummaries'))) {
       res.status(403).send('You are not authorized to view all users');
       return;
     }
-      // Extract forceRefresh parameter
+    // Extract forceRefresh parameter
     const forceRefresh = req.query.forceRefresh === 'true';
-      // Extract week parameter (0 = This Week, 1 = Last Week, etc.)
+    // Extract week parameter (0 = This Week, 1 = Last Week, etc.)
     const week = req.query.week !== undefined ? parseInt(req.query.week, 10) : null;
 
     // Generate cache key based on week
@@ -236,7 +235,7 @@ const reportsController = function () {
       res.status(403).send('You are not authorized to view all users');
       return;
     }
-    
+
     // Determine cache duration based on week
     let cacheTTL = 3600; // 1 hour default
     if (week === 0) {
@@ -250,7 +249,7 @@ const reportsController = function () {
     try {
       let results;
       let summaries;
-      
+
       if (week !== null) {
         // Get data for only the requested week
         results = await reporthelper.weeklySummaries(week, week);
@@ -260,13 +259,16 @@ const reportsController = function () {
         results = await reporthelper.weeklySummaries(3, 0);
         summaries = reporthelper.formatSummaries(results);
       }
-      
+
       // Cache the results
       cacheUtil.setCache(cacheKey, summaries);
       cacheUtil.setKeyTimeToLive(cacheKey, cacheTTL);
-      
+
       res.set('Cache-Control', `public, max-age=${cacheTTL}`);
-      res.set('ETag', require('crypto').createHash('md5').update(JSON.stringify(summaries)).digest('hex'));
+      res.set(
+        'ETag',
+        require('crypto').createHash('md5').update(JSON.stringify(summaries)).digest('hex'),
+      );
 
       res.status(200).send(summaries);
     } catch (error) {

--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -81,8 +81,8 @@ const reportsController = function () {
       isoComparisonEndDate = new Date(comparisonEndDate);
     }
 
-    const isoStartDate = new Date(startDate);
-    const isoEndDate = new Date(endDate);
+    const isoStartDate = new Date(`${startDate}T00:00:00-07:00`);
+    const isoEndDate = new Date(`${endDate}T23:59:00-07:00`);
 
     try {
       const [


### PR DESCRIPTION
# Description
This PR implements Pacific Time for the dates used to gather data for the Total Org Summary page.

## Main changes explained:
- Updated dates in reportsController.js 

## How to test:
1. check into current branch
2. do `npm install` and `npm run dev` to run this PR locally
3. use Postman to get an authentication code at `http://localhost:4500/api/login`
4. including the authorization code, send a request to `http://localhost:4500/api/reports/volunteerstats?startDate=2025-05-25&endDate=2025-05-31&comparisonStartDate=2024-01-01&comparisonEndDate=2024-03-01`
6. verify a response is received

## Screenshots or videos of changes:
<img width="683" alt="Screenshot 2025-06-17 at 11 51 59 AM" src="https://github.com/user-attachments/assets/81e53df9-b7ef-4f88-bec0-2faa4b90aedc" />

