### PR TITLE
Backend: implement longest open issues API

### DIFF
--- a/src/controllers/bmdashboard/bmIssueController.js
+++ b/src/controllers/bmdashboard/bmIssueController.js
@@ -1,4 +1,6 @@
 const mongoose = require('mongoose');
+const BuildingIssue = require('../../models/bmdashboard/buildingIssue');
+const BuildingProject = require('../../models/bmdashboard/buildingProject');
 
 const bmIssueController = function (BuildingIssue) {
     const bmGetIssue = async (req, res) => {
@@ -23,7 +25,90 @@ const bmIssueController = function (BuildingIssue) {
         }
     };
 
-    return { bmGetIssue, bmPostIssue };
+    const getLongestOpenIssues = async (req, res) => {
+        try {
+            const { dates, projects } = req.query;
+            // dates = '2021-10-01,2023-11-03';
+            // projects = '654946c8bc5772e8caf7e963';
+            const query = { status: 'open' };
+            let filteredProjectIds = [];
+    
+            // Parse project filter if provided
+            if (projects) {
+                filteredProjectIds = projects.split(',').map(id => id.trim());
+            }
+    
+            // Apply date filtering logic
+            if (dates) {
+                const [startDateStr, endDateStr] = dates.split(',').map(d => d.trim());
+                const startDate = new Date(startDateStr);
+                const endDate = new Date(endDateStr);
+    
+                const matchingProjects = await BuildingProject.find({
+                    dateCreated: { $gte: startDate, $lte: endDate },
+                    isActive: true
+                }).select('_id').lean();
+    
+                const dateFilteredIds = matchingProjects.map(p => p._id.toString());
+    
+                if (filteredProjectIds.length > 0) {
+                    // Intersection of project filters
+                    filteredProjectIds = filteredProjectIds.filter(id =>
+                        dateFilteredIds.includes(id)
+                    );
+                } else {
+                    filteredProjectIds = dateFilteredIds;
+                }
+            }
+    
+            // If no matching project IDs, return early
+            if (dates && filteredProjectIds.length === 0) {
+                return res.json([]); // No results to return
+            }
+    
+            if (filteredProjectIds.length > 0) {
+                query.projectId = { $in: filteredProjectIds };
+            }
+    
+            let issues = await BuildingIssue.find(query)
+                .select('issueTitle issueDate')
+                .populate('projectId')
+                .lean();
+    
+            issues = issues.map(issue => {
+                const durationInMonths = Math.ceil(
+                    (new Date() - new Date(issue.issueDate)) / (1000 * 60 * 60 * 24 * 30.44)
+                );
+                const years = Math.floor(durationInMonths / 12);
+                const months = durationInMonths % 12;
+                const durationText = years > 0
+                    ? `${years} year${years > 1 ? 's' : ''} ${months} month${months > 1 ? 's' : ''}`
+                    : `${months} month${months > 1 ? 's' : ''}`;
+    
+                return {
+                    issueName: issue.issueTitle[0],
+                    durationOpen: durationText,
+                    durationInMonths
+                };
+            });
+    
+            const topIssues = issues
+                .sort((a, b) => b.durationInMonths - a.durationInMonths)
+                .slice(0, 7)
+                .map(({ issueName, durationInMonths }) => ({
+                    issueName,
+                    durationOpen: durationInMonths, // send number only
+                  }));
+                  
+    
+            res.json(topIssues);
+        } catch (error) {
+            console.error('Error fetching longest open issues:', error);
+            res.status(500).json({ message: 'Error fetching longest open issues' });
+        }
+    };
+
+    return { bmGetIssue, bmPostIssue, getLongestOpenIssues};
 };
 
 module.exports = bmIssueController;

--- a/src/models/bmdashboard/buildingIssue.js
+++ b/src/models/bmdashboard/buildingIssue.js
@@ -10,8 +10,15 @@ const buildingIssue = new Schema({
     issueTitle: [{ type: String, required: true, maxLength: 50 }],
     issueText: [{ type: String, required: true, maxLength: 500 }],
     imageUrl: [{ type: String }],
+    projectId: { type: Schema.Types.ObjectId, ref: 'buildingProject', required: true },
+    status: {
+        type: String,
+        enum: ['open', 'closed'],
+        default: 'open'
+    },
     // not sure if we still need related lesson here:
     // relatedLesson: { type: mongoose.SchemaTypes.ObjectId, ref: 'buildingNewLesson', required: true },
 });
 
 module.exports = mongoose.model('buildingIssue', buildingIssue, 'buildingIssues');
+

--- a/src/routes/bmdashboard/bmIssueRouter.js
+++ b/src/routes/bmdashboard/bmIssueRouter.js
@@ -8,6 +8,8 @@ const routes = function (buildingIssue) {
         .get(controller.bmGetIssue);
     IssueRouter.route('/issue/add')
         .post(controller.bmPostIssue);
+    IssueRouter.route('/issues/longest-open')
+        .get(controller.getLongestOpenIssues);
     return IssueRouter;
 };
 module.exports = routes;

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -197,7 +197,7 @@ module.exports = function (app) {
   app.use('/api/bm', bmEquipmentRouter);
   app.use('/api/bm', bmConsumablesRouter);
   app.use('/api/bm', bmExternalTeam);
-  app.use('api', bmIssueRouter);
+  app.use('/api/bm', bmIssueRouter);
   app.use('/api/villages', require('../routes/lb_dashboard/villages'));
   app.use('/api', registrationRouter);
 };


### PR DESCRIPTION
Description
Implements a new dashboard feature to visualize the longest open issues in a horizontal bar chart format, as requested in (PRIORITY HIGH) JAE/JAIWANTH. This feature adds interactive filters for dates and projects, fetches issue durations from the backend, and dynamically renders a chart to help users quickly identify aging tasks.

Related PRs (if any):
This frontend PR is related to the #3702 Frontend PR.

How to test:
Check out this branch:
vaibhav-phase2-summary-dashboard-longest-open-issues

Run npm install.
Start the app locally.
Log in as an admin.

Navigate to Dashboard → Report → totalconstructionsummary.

Scroll to find the "Issue Tracking" and expand.

Use the Date and Project dropdown filters to test filtering functionality.

Chnages:

![Screenshot 2025-06-26 184443](https://github.com/user-attachments/assets/2a6f96a4-d25d-40bd-8956-a67e8447277c)
