### PR TITLE
Taariq fix weekly summary reports team code changes on refresh Backend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2985,7 +2985,6 @@
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.2.4.tgz",
       "integrity": "sha512-SG23E3JDH6y8qF20a4G9txLuUl+TCV16gxsKyntmGiJez2V9VBJr1Y8WxTBBD6OgBVcvspQ7sxgdNMkXFVcaEA==",
-      "dev": true,
       "requires": {
         "bson": "*"
       }
@@ -3110,7 +3109,6 @@
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.20.tgz",
       "integrity": "sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==",
-      "dev": true,
       "requires": {
         "@types/bson": "*",
         "@types/node": "*"
@@ -5057,8 +5055,7 @@
     "bluebird": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
-      "dev": true
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "body-parser": {
       "version": "1.19.2",
@@ -11343,8 +11340,7 @@
     "kareem": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
-      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ==",
-      "dev": true
+      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
     },
     "kind-of": {
       "version": "6.0.3",
@@ -12102,7 +12098,6 @@
       "version": "5.13.23",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.13.23.tgz",
       "integrity": "sha512-Q5bo1yYOcH2wbBPP4tGmcY5VKsFkQcjUDh66YjrbneAFB3vNKQwLvteRFLuLiU17rA5SDl3UMcMJLD9VS8ng2Q==",
-      "dev": true,
       "requires": {
         "@types/bson": "1.x || 4.0.x",
         "@types/mongodb": "^3.5.27",
@@ -12124,7 +12119,6 @@
           "version": "4.0.5",
           "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.5.tgz",
           "integrity": "sha512-vVLwMUqhYJSQ/WKcE60eFqcyuWse5fGH+NMAXHuKrUAPoryq3ATxk5o4bgYNtg5aOM4APVg7Hnb3ASqUYG0PKg==",
-          "dev": true,
           "requires": {
             "@types/node": "*"
           }
@@ -12133,7 +12127,6 @@
           "version": "3.7.4",
           "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.4.tgz",
           "integrity": "sha512-K5q8aBqEXMwWdVNh94UQTwZ6BejVbFhh1uB6c5FKtPE9eUMZPUO3sRZdgIEcHSrAWmxzpG/FeODDKL388sqRmw==",
-          "dev": true,
           "requires": {
             "bl": "^2.2.1",
             "bson": "^1.1.4",
@@ -12147,7 +12140,6 @@
               "version": "1.1.8",
               "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
               "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
-              "dev": true,
               "requires": {
                 "require-at": "^1.0.6"
               }
@@ -12157,22 +12149,19 @@
         "optional-require": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz",
-          "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==",
-          "dev": true
+          "integrity": "sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA=="
         },
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
     "mongoose-legacy-pluralize": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
-      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
-      "dev": true
+      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
     },
     "mongoose-validator": {
       "version": "2.1.0",
@@ -12186,14 +12175,12 @@
     "mpath": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
-      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g==",
-      "dev": true
+      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g=="
     },
     "mquery": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.5.tgz",
       "integrity": "sha512-VjOKHHgU84wij7IUoZzFRU07IAxd5kWJaDmyUzQlbjHjyoeK5TNeeo8ZsFDtTYnSgpW6n/nMNIHvE3u8Lbrf4A==",
-      "dev": true,
       "requires": {
         "bluebird": "3.5.1",
         "debug": "3.1.0",
@@ -12206,7 +12193,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -12214,8 +12200,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-          "dev": true
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
         }
       }
     },
@@ -13669,8 +13654,7 @@
     "regexp-clone": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
-      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw==",
-      "dev": true
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
     },
     "regexp.prototype.flags": {
       "version": "1.5.0",
@@ -14235,8 +14219,7 @@
     "sift": {
       "version": "13.5.2",
       "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
-      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA==",
-      "dev": true
+      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
     },
     "signal-exit": {
       "version": "3.0.7",
@@ -14322,8 +14305,7 @@
     "sliced": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
-      "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==",
-      "dev": true
+      "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA=="
     },
     "socket.io": {
       "version": "4.8.1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "This module is the REST module built on NodeJS to support MongoDB activities, Since EmberData has no direct adapters for MongoDB. This module will later be intergrated with EmberJS HGN project to maintain singularity.",
   "main": "restapp",
-    "engines": {
+  "engines": {
     "node": ">=14.0.0 <15"
   },
   "scripts": {

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -2045,35 +2045,72 @@ const userProfileController = function (UserProfile, Project) {
 
       const updatedUsersInfo = await Promise.all(
         usersToUpdate.map(async (user) => {
-          user.teamCode = newTeamCode;
-          let { teamCodeWarning } = user;
+          // if (!user || !user._id || !newTeamCode) {
+          //   console.warn('Skipping invalid user or missing newTeamCode:', user);
+          //   return null;
+          // }
+          // user.teamCode = newTeamCode;
+          // let { teamCodeWarning } = user;
+          let teamCodeWarning = user.teamCodeWarning ?? false;
 
           if (warningUsers && warningUsers.includes(user._id.toString())) {
             teamCodeWarning = await userHelper.checkTeamCodeMismatch(user);
           }
 
+          // return {
+          //   updateOne: {
+          //     // filter: { _id: user._id },
+          //     filter: { _id: new mongoose.Types.ObjectId(user._id)},
+          //     update: {
+          //       $set: {
+          //         teamCode: newTeamCode,
+          //         // teamCodeWarning: teamCodeWarning ?? false,
+          //         teamCodeWarning,
+          //       },
+          //     },
+          //   },
+          //   userInfo: {
+          //     userId: user._id,
+          //     teamCodeWarning,
+          //   },
+          // };
           return {
-            updateOne: {
-              filter: { _id: user._id },
-              update: {
-                $set: {
-                  teamCode: newTeamCode,
-                  teamCodeWarning,
-                },
-              },
-            },
-            userInfo: {
-              userId: user._id,
-              teamCodeWarning,
-            },
+            userId: user._id,
+            teamCodeWarning,
           };
         }),
       );
 
+      // Filter out null entries
+      // const filteredUpdates = updatedUsersInfo.filter(Boolean);
       // Then split into bulkOps and result set
-      const bulkOps = updatedUsersInfo.map((x) => x.updateOne);
+      // const bulkOps = filteredUpdates.map((x) => x.updateOne);
+      // const bulkOps = updatedUsersInfo.map((x) => x.updateOne);
 
+      // console.log('bulkOps to execute:', JSON.stringify(bulkOps, null, 2));
       // 2. Execute all updates at once
+      // if (bulkOps.length > 0) {
+      //   await UserProfile.bulkWrite(bulkOps);
+      // } else {
+      //   console.warn('Invalid bulkOps detected. Aborting write.');
+      // }
+
+      // ✅ Build the proper bulkWrite payload
+      const bulkOps = updatedUsersInfo.map(({ userId, teamCodeWarning }) => ({
+        updateOne: {
+          filter: { _id: mongoose.Types.ObjectId(userId) }, // IMPORTANT: ObjectId
+          update: {
+            $set: {
+              teamCode: newTeamCode,
+              teamCodeWarning,
+            },
+          },
+        },
+      }));
+
+      // // ✅ Log structure
+      // console.log('bulkOps to execute:', JSON.stringify(bulkOps, null, 2));
+
       if (bulkOps.length > 0) {
         await UserProfile.bulkWrite(bulkOps);
       }


### PR DESCRIPTION
# Description
Fixed backend bulkWrite errors by wrapping updates in updateOne and casting _id to ObjectId, ensuring reliable team code updates and supporting frontend bug fixes for Weekly Summaries.

## Related PRS (if any):
This backend PR is related to the [#3688](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3688) frontend PR.
To test this backend PR you need to checkout the #3688 frontend PR.


## Main changes explained:
- Fixed bulkWrite() operations by properly wrapping updates with updateOne.
- Cast all _id values to ObjectId to ensure correct MongoDB queries.
- Corrected bulk update logic to handle large batches reliably without errors.
- Improved stability and consistency of team code updates on the backend.


## How to test:
1. Checkout this backend branch and the above mentioned frontend PR #3688.
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→ Weekly Summaries Report Page.
6. Perform multiple updates to Weekly Summaries team codes from the frontend or API calls.
7. Verify that updates no longer fail or behave inconsistently due to invalid bulk operations.
8. Confirm that replaced team codes persist correctly after refreshes and multiple rapid updates.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/05c558bd-b072-407e-8f06-e2c5b33397e1



## Note:
Don't forget to checkout the respective frontend and backend branches.
