### PR TITLE
Vaibhav Created longest open issues bar chart backend

### DIFF
--- a/src/controllers/bmdashboard/bmIssueController.js
+++ b/src/controllers/bmdashboard/bmIssueController.js
@@ -1,4 +1,6 @@
 const mongoose = require('mongoose');
+// const BuildingIssue = require('../../models/bmdashboard/buildingIssue');
+const BuildingProject = require('../../models/bmdashboard/buildingProject');
 
 const bmIssueController = function (BuildingIssue) {
   const bmGetIssue = async (req, res) => {
@@ -12,76 +14,156 @@ const bmIssueController = function (BuildingIssue) {
     }
   };
 
-    const bmGetIssueChart = async (req, res) => {
-        try {
-            const { issueType, year } = req.query;
-            let matchQuery = {}; // Initialize an empty match query object
-    
-            // Apply filters if provided
-            if (issueType) {
-                matchQuery.issueType = issueType;
-            }
-            if (year) {
-                const startDate = new Date(`${year}-01-01T00:00:00Z`);
-                const endDate = new Date(`${year}-12-31T23:59:59Z`);
-                matchQuery.issueDate = { $gte: startDate, $lte: endDate }; // Filter based on issueDate
-            }
-    
-            const aggregationPipeline = [
-                { $match: matchQuery },  // Match the filtered data
-                {
-                    $group: {
-                        _id: { issueType: "$issueType", year: { $year: "$issueDate" } },
-                        count: { $sum: 1 } // Properly count occurrences
-                    }
-                },
-                {
-                    $group: {
-                        _id: "$_id.issueType",
-                        years: {
-                            $push: {
-                                year: "$_id.year",
-                                count: "$count"
-                            }
-                        }
-                    }
-                },
-                { $sort: { "_id": 1 } }, // Sort by issueType
-            ];
-    
-            const issues = await mongoose.model('buildingIssue').aggregate(aggregationPipeline); // Execute aggregation pipeline
-    
-            // Format the result
-            const result = issues.reduce((acc, item) => {
-                const issueType = item._id;
-                acc[issueType] = {};
-                item.years.forEach(yearData => {
-                    acc[issueType][yearData.year] = yearData.count;
-                });
-                return acc;
-            }, {});
-    
-            res.status(200).json(result); // Return the formatted result
-        } catch (error) {
-            console.error('Error fetching issues:', error);
-            res.status(500).json({ message: 'Server error', error });
+  const bmGetIssueChart = async (req, res) => {
+    try {
+      const { issueType, year } = req.query;
+      const matchQuery = {}; // Initialize an empty match query object
+
+      // Apply filters if provided
+      if (issueType) {
+        matchQuery.issueType = issueType;
+      }
+      if (year) {
+        const startDate = new Date(`${year}-01-01T00:00:00Z`);
+        const endDate = new Date(`${year}-12-31T23:59:59Z`);
+        matchQuery.issueDate = { $gte: startDate, $lte: endDate }; // Filter based on issueDate
+      }
+
+      const aggregationPipeline = [
+        { $match: matchQuery }, // Match the filtered data
+        {
+          $group: {
+            _id: { issueType: '$issueType', year: { $year: '$issueDate' } },
+            count: { $sum: 1 }, // Properly count occurrences
+          },
+        },
+        {
+          $group: {
+            _id: '$_id.issueType',
+            years: {
+              $push: {
+                year: '$_id.year',
+                count: '$count',
+              },
+            },
+          },
+        },
+        { $sort: { _id: 1 } }, // Sort by issueType
+      ];
+
+      const issues = await mongoose.model('buildingIssue').aggregate(aggregationPipeline); // Execute aggregation pipeline
+
+      // Format the result
+      const result = issues.reduce((acc, item) => {
+        const issueTypeKey = item._id;
+        acc[issueTypeKey] = {};
+        item.years.forEach((yearData) => {
+          acc[issueType][yearData.year] = yearData.count;
+        });
+        return acc;
+      }, {});
+
+      res.status(200).json(result); // Return the formatted result
+    } catch (error) {
+      console.error('Error fetching issues:', error);
+      res.status(500).json({ message: 'Server error', error });
+    }
+  };
+
+  const bmPostIssue = async (req, res) => {
+    try {
+      BuildingIssue.create(req.body)
+        .then((result) => res.status(201).send(result))
+        .catch((error) => res.status(500).send(error));
+    } catch (err) {
+      res.json(err);
+    }
+  };
+
+  const getLongestOpenIssues = async (req, res) => {
+    try {
+      const { dates, projects } = req.query;
+      // dates = '2021-10-01,2023-11-03';
+      // projects = '654946c8bc5772e8caf7e963';
+      const query = { status: 'open' };
+      let filteredProjectIds = [];
+
+      // Parse project filter if provided
+      if (projects) {
+        filteredProjectIds = projects.split(',').map((id) => id.trim());
+      }
+
+      // Apply date filtering logic
+      if (dates) {
+        const [startDateStr, endDateStr] = dates.split(',').map((d) => d.trim());
+        const startDate = new Date(startDateStr);
+        const endDate = new Date(endDateStr);
+
+        const matchingProjects = await BuildingProject.find({
+          dateCreated: { $gte: startDate, $lte: endDate },
+          isActive: true,
+        })
+          .select('_id')
+          .lean();
+
+        const dateFilteredIds = matchingProjects.map((p) => p._id.toString());
+
+        if (filteredProjectIds.length > 0) {
+          // Intersection of project filters
+          filteredProjectIds = filteredProjectIds.filter((id) => dateFilteredIds.includes(id));
+        } else {
+          filteredProjectIds = dateFilteredIds;
         }
-    };
-    
-    
+      }
 
-    const bmPostIssue = async (req, res) => {
-        try {
-            const newIssue = BuildingIssue.create(req.body)
-            .then((result) => res.status(201).send(result))
-            .catch((error) => res.status(500).send(error));
-        } catch (err) {
-            res.json(err);
-        }
-    };
+      // If no matching project IDs, return early
+      if (dates && filteredProjectIds.length === 0) {
+        return res.json([]); // No results to return
+      }
 
-    return { bmGetIssue, bmPostIssue, bmGetIssueChart };
+      if (filteredProjectIds.length > 0) {
+        query.projectId = { $in: filteredProjectIds };
+      }
 
+      let issues = await BuildingIssue.find(query)
+        .select('issueTitle issueDate')
+        .populate('projectId')
+        .lean();
+
+      issues = issues.map((issue) => {
+        const durationInMonths = Math.ceil(
+          (new Date() - new Date(issue.issueDate)) / (1000 * 60 * 60 * 24 * 30.44),
+        );
+        const years = Math.floor(durationInMonths / 12);
+        const months = durationInMonths % 12;
+        const durationText =
+          years > 0
+            ? `${years} year${years > 1 ? 's' : ''} ${months} month${months > 1 ? 's' : ''}`
+            : `${months} month${months > 1 ? 's' : ''}`;
+
+        return {
+          issueName: issue.issueTitle[0],
+          durationOpen: durationText,
+          durationInMonths,
+        };
+      });
+
+      const topIssues = issues
+        .sort((a, b) => b.durationInMonths - a.durationInMonths)
+        .slice(0, 7)
+        .map(({ issueName, durationInMonths }) => ({
+          issueName,
+          durationOpen: durationInMonths, // send number only
+        }));
+
+      res.json(topIssues);
+    } catch (error) {
+      console.error('Error fetching longest open issues:', error);
+      res.status(500).json({ message: 'Error fetching longest open issues' });
+    }
+  };
+
+  return { bmGetIssue, bmPostIssue, bmGetIssueChart, getLongestOpenIssues };
 };
 
 module.exports = bmIssueController;

--- a/src/models/bmdashboard/buildingIssue.js
+++ b/src/models/bmdashboard/buildingIssue.js
@@ -3,17 +3,22 @@ const mongoose = require('mongoose');
 const { Schema } = mongoose;
 
 const buildingIssue = new Schema({
-    createdDate: { type: Date, required: true, default: Date.now() },
-    issueDate: { type: Date, required: true },
-    createdBy: { type: mongoose.SchemaTypes.ObjectId, ref: 'userProfile', required: true },
-    staffInvolved: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'userProfile' }],
-    issueTitle: [{ type: String, required: true, maxLength: 50 }],
-    issueText: [{ type: String, required: true, maxLength: 500 }],
-    issueType: { type: String, required: true },
-    projectId: { type: Schema.Types.ObjectId, ref: 'buildingProject', required: true },
-    imageUrl: [{ type: String }],
-    // not sure if we still need related lesson here:
-    // relatedLesson: { type: mongoose.SchemaTypes.ObjectId, ref: 'buildingNewLesson', required: true },
+  createdDate: { type: Date, required: true, default: Date.now() },
+  issueDate: { type: Date, required: true },
+  createdBy: { type: mongoose.SchemaTypes.ObjectId, ref: 'userProfile', required: true },
+  staffInvolved: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'userProfile' }],
+  issueTitle: [{ type: String, required: true, maxLength: 50 }],
+  issueText: [{ type: String, required: true, maxLength: 500 }],
+  issueType: { type: String, required: true },
+  imageUrl: [{ type: String }],
+  projectId: { type: Schema.Types.ObjectId, ref: 'buildingProject', required: true },
+  status: {
+    type: String,
+    enum: ['open', 'closed'],
+    default: 'open',
+  },
+  // not sure if we still need related lesson here:
+  // relatedLesson: { type: mongoose.SchemaTypes.ObjectId, ref: 'buildingNewLesson', required: true },
 });
 
 module.exports = mongoose.model('buildingIssue', buildingIssue, 'buildingIssues');

--- a/src/routes/bmdashboard/bmIssueRouter.js
+++ b/src/routes/bmdashboard/bmIssueRouter.js
@@ -1,15 +1,13 @@
 const express = require('express');
 
 const routes = function (metIssue) {
-    const IssueRouter = express.Router();
-    const controller = require('../../controllers/bmdashboard/bmIssueController')(metIssue);
+  const IssueRouter = express.Router();
+  const controller = require('../../controllers/bmdashboard/bmIssueController')(metIssue);
 
-    IssueRouter.route('/issues')
-        .get(controller.bmGetIssue);
-    IssueRouter.route('/issue/add')
-        .post(controller.bmPostIssue);
-    IssueRouter.route('/issue/issue-chart')
-        .get(controller.bmGetIssueChart); 
-    return IssueRouter;
+  IssueRouter.route('/issues').get(controller.bmGetIssue);
+  IssueRouter.route('/issue/add').post(controller.bmPostIssue);
+  IssueRouter.route('/issue/issue-chart').get(controller.bmGetIssueChart);
+  IssueRouter.route('/issues/longest-open').get(controller.getLongestOpenIssues);
+  return IssueRouter;
 };
 module.exports = routes;

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -168,7 +168,8 @@ const lbWishlistsRouter = require('../routes/lbdashboard/wishlistsRouter')(wishl
 const titleRouter = require('../routes/titleRouter')(title);
 const bmToolRouter = require('../routes/bmdashboard/bmToolRouter')(buildingTool, toolType);
 const bmEquipmentRouter = require('../routes/bmdashboard/bmEquipmentRouter')(buildingEquipment);
-const bmIssueRouter = require('../routes/bmdashboard/bmIssueRouter')(metIssue);
+const buildingIssue = require('../models/bmdashboard/buildingIssue');
+const bmIssueRouter = require('../routes/bmdashboard/bmIssueRouter')(buildingIssue);
 const bmExternalTeam = require('../routes/bmdashboard/bmExternalTeamRouter');
 const bmRentalChart = require('../routes/bmdashboard/bmRentalChartRouter')();
 
@@ -183,14 +184,12 @@ const blueSquareEmailAssignmentRouter = require('../routes/BlueSquareEmailAssign
   userProfile,
 );
 
-
-
 // Automations
 const appAccessRouter = require('../routes/automation/appAccessRouter');
 const dropboxRouter = require('../routes/automation/dropboxRouter');
 const githubRouter = require('../routes/automation/githubRouter');
 const sentryRouter = require('../routes/automation/sentryRouter');
-const slackRouter = require('../routes/automation/slackRouter')
+const slackRouter = require('../routes/automation/slackRouter');
 
 //lbdashboard_bidoverview
 
@@ -286,10 +285,7 @@ module.exports = function (app) {
 
   app.use('/api/bm', bmIssueRouter);
 
-  app.use('/api/bm', bmIssueRouter);
-
   app.use('/api/bm', bmTimeLoggerRouter);
-  app.use('api', bmIssueRouter);
 
   app.use('/api/lb', bidPropertyRouter);
   app.use('/api/lb', userBidRouter);
@@ -299,7 +295,6 @@ module.exports = function (app) {
 
   // lb dashboard
   app.use('/api/lb', lbListingsRouter);
-  app.use('/api/bm', bmIssueRouter);
   // lb dashboard
   app.use('/api/villages', require('../routes/lbdashboard/villages'));
   app.use('/api/lb', lbMessageRouter);


### PR DESCRIPTION
Description
Implements a new dashboard feature to visualize the longest open issues in a horizontal bar chart format, as requested in (PRIORITY HIGH) JAE/JAIWANTH. This feature adds interactive filters for dates and projects, fetches issue durations from the backend, and dynamically renders a chart to help users quickly identify aging tasks.

Related PRs (if any):
This frontend PR is related to the [3772 ](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3732) frontend PR.

How to test:
Check out this branch:
vaibhav-phase2-summary-dashboard-longest-open-issues

Run npm install.
Start the app locally.
Log in as an admin.

Navigate to Dashboard → Report → totalconstructionsummary.

Scroll to find the "Issue Tracking" and expand.

Use the Date and Project dropdown filters to test filtering functionality.

⚠️ Note:
Any date range starting in 2024 or later will return an empty chart, because there are no issues in the database during that period.
To see data populated in the chart, please choose a start date before 2024.

Changes:

![Screenshot 2025-07-06 031330](https://github.com/user-attachments/assets/f1bac016-38f2-4545-8d38-777ae0069f6f)
![Screenshot 2025-07-06 031428](https://github.com/user-attachments/assets/9c2d15cb-bdc9-4bfc-98ee-00590796db4e)
