### PR TITLE
Zhifan - Implement more robust edit logs for Tasks

### DIFF
--- a/src/middleware/taskChangeTracker.js
+++ b/src/middleware/taskChangeTracker.js
@@ -1,0 +1,204 @@
+const TaskChangeLog = require('../models/taskChangeLog');
+
+class TaskChangeTracker {
+  static async logChanges(taskId, oldTask, newTask, user, req) {
+    try {
+      const changes = this.detectChanges(oldTask, newTask);
+
+      const changePromises = changes.map(async (change) => {
+        const entry = await TaskChangeLog.create({
+          taskId,
+          userId: user._id,
+          userName: `${user.firstName} ${user.lastName}`,
+          userEmail: user.email,
+          changeType: change.type,
+          field: change.field,
+          oldValue: change.oldValue,
+          newValue: change.newValue,
+          oldValueFormatted: change.oldValueFormatted,
+          newValueFormatted: change.newValueFormatted,
+          changeDescription: change.description,
+          metadata: {
+            source: 'web_ui',
+            reason: req.body.changeReason, // Optional field from frontend
+          },
+        });
+        return entry;
+      });
+
+      const changeEntries = await Promise.all(changePromises);
+
+      // Link related changes
+      if (changeEntries.length > 1) {
+        const entryIds = changeEntries.map((e) => e._id);
+        await TaskChangeLog.updateMany(
+          { _id: { $in: entryIds } },
+          { $set: { 'metadata.relatedChanges': entryIds } },
+        );
+      }
+
+      return changeEntries;
+    } catch (error) {
+      console.error('Error logging task changes:', error);
+      return [];
+    }
+  }
+
+  static detectChanges(oldTask, newTask) {
+    const changes = [];
+
+    // Define fields to track
+    const fieldsToTrack = [
+      {
+        field: 'taskName',
+        type: 'field_change',
+        formatter: (val) => val || 'Not set',
+      },
+      {
+        field: 'priority',
+        type: 'priority_change',
+        formatter: (val) => val || 'Not set',
+      },
+      {
+        field: 'status',
+        type: 'status_change',
+        formatter: (val) => val || 'Not started',
+      },
+      {
+        field: 'dueDatetime',
+        type: 'deadline_change',
+        formatter: (val) => (val ? new Date(val).toLocaleDateString() : 'No due date'),
+      },
+      {
+        field: 'estimatedHours',
+        type: 'hours_change',
+        formatter: (val) => (val ? `${val} hours` : '0 hours'),
+      },
+      {
+        field: 'hoursBest',
+        type: 'hours_change',
+        formatter: (val) => (val ? `${val} hours` : '0 hours'),
+      },
+      {
+        field: 'hoursWorst',
+        type: 'hours_change',
+        formatter: (val) => (val ? `${val} hours` : '0 hours'),
+      },
+      {
+        field: 'hoursMost',
+        type: 'hours_change',
+        formatter: (val) => (val ? `${val} hours` : '0 hours'),
+      },
+      {
+        field: 'hoursLogged',
+        type: 'hours_change',
+        formatter: (val) => (val ? `${val} hours` : '0 hours'),
+      },
+      {
+        field: 'resources',
+        type: 'assignment_change',
+        formatter: (resources) => {
+          if (!resources || resources.length === 0) return 'None assigned';
+          return resources.map((r) => r.name || 'Unknown').join(', ');
+        },
+      },
+      {
+        field: 'startedDatetime',
+        type: 'deadline_change',
+        formatter: (val) => (val ? new Date(val).toLocaleDateString() : 'No start date'),
+      },
+      {
+        field: 'whyInfo',
+        type: 'field_change',
+        formatter: (val) => val || 'Not set',
+      },
+      {
+        field: 'intentInfo',
+        type: 'field_change',
+        formatter: (val) => val || 'Not set',
+      },
+      {
+        field: 'endstateInfo',
+        type: 'field_change',
+        formatter: (val) => val || 'Not set',
+      },
+      {
+        field: 'classification',
+        type: 'field_change',
+        formatter: (val) => val || 'Not set',
+      },
+    ];
+
+    fieldsToTrack.forEach((fieldConfig) => {
+      const oldValue = oldTask[fieldConfig.field];
+      const newValue = newTask[fieldConfig.field];
+
+      // Special handling for arrays (resources)
+      if (fieldConfig.field === 'resources' && !this.arraysEqual(oldValue, newValue)) {
+        changes.push({
+          type: fieldConfig.type,
+          field: fieldConfig.field,
+          oldValue,
+          newValue,
+          oldValueFormatted: fieldConfig.formatter(oldValue),
+          newValueFormatted: fieldConfig.formatter(newValue),
+          description: `Changed ${fieldConfig.field} from "${fieldConfig.formatter(oldValue)}" to "${fieldConfig.formatter(newValue)}"`,
+        });
+      } else if (fieldConfig.field !== 'resources' && oldValue !== newValue) {
+        // Regular field comparison
+        changes.push({
+          type: fieldConfig.type,
+          field: fieldConfig.field,
+          oldValue,
+          newValue,
+          oldValueFormatted: fieldConfig.formatter(oldValue),
+          newValueFormatted: fieldConfig.formatter(newValue),
+          description: `Changed ${fieldConfig.field} from "${fieldConfig.formatter(oldValue)}" to "${fieldConfig.formatter(newValue)}"`,
+        });
+      }
+    });
+
+    return changes;
+  }
+
+  static arraysEqual(arr1, arr2) {
+    // Handle null/undefined cases
+    if (!arr1 && !arr2) return true;
+    if (!arr1 || !arr2) return false;
+    if (arr1.length !== arr2.length) return false;
+
+    // For resources, compare by userID with better error handling
+    try {
+      const ids1 = arr1
+        .map((r) => {
+          if (!r) return null;
+          // Convert ObjectId to string for comparison
+          const id = r.userID || r._id;
+          return id ? id.toString() : null;
+        })
+        .filter((id) => id !== null)
+        .sort();
+
+      const ids2 = arr2
+        .map((r) => {
+          if (!r) return null;
+          // Convert ObjectId to string for comparison
+          const id = r.userID || r._id;
+          return id ? id.toString() : null;
+        })
+        .filter((id) => id !== null)
+        .sort();
+
+      // If different number of valid IDs, arrays are different
+      if (ids1.length !== ids2.length) return false;
+
+      return ids1.every((id, index) => id === ids2[index]);
+    } catch (error) {
+      console.error('Error comparing resource arrays:', error);
+      // Fallback to JSON comparison if ID comparison fails
+      return JSON.stringify(arr1) === JSON.stringify(arr2);
+    }
+  }
+}
+
+module.exports = TaskChangeTracker;

--- a/src/models/taskChangeLog.js
+++ b/src/models/taskChangeLog.js
@@ -1,0 +1,70 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const taskChangeLogSchema = new Schema(
+  {
+    taskId: {
+      type: mongoose.SchemaTypes.ObjectId,
+      ref: 'task',
+      required: true,
+      index: true,
+    },
+    userId: {
+      type: mongoose.SchemaTypes.ObjectId,
+      ref: 'userProfile',
+      required: true,
+      index: true,
+    },
+    userName: {
+      type: String,
+      required: true,
+    },
+    userEmail: String,
+    timestamp: {
+      type: Date,
+      default: Date.now,
+      index: true,
+    },
+    changeType: {
+      type: String,
+      enum: [
+        'field_change',
+        'status_change',
+        'assignment_change',
+        'deadline_change',
+        'priority_change',
+        'hours_change',
+        'task_created',
+        'task_deleted',
+      ],
+      required: true,
+    },
+    field: String,
+    oldValue: Schema.Types.Mixed,
+    newValue: Schema.Types.Mixed,
+    oldValueFormatted: String,
+    newValueFormatted: String,
+    changeDescription: String,
+    ipAddress: String,
+    userAgent: String,
+    sessionId: String,
+    metadata: {
+      source: {
+        type: String,
+        default: 'web_ui',
+      },
+      reason: String,
+      relatedChanges: [mongoose.SchemaTypes.ObjectId],
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+// Compound indexes for efficient queries
+taskChangeLogSchema.index({ taskId: 1, timestamp: -1 });
+taskChangeLogSchema.index({ userId: 1, timestamp: -1 });
+
+module.exports = mongoose.model('TaskChangeLog', taskChangeLogSchema, 'taskChangeLogs');

--- a/src/routes/taskRouter.js
+++ b/src/routes/taskRouter.js
@@ -3,7 +3,7 @@ const express = require('express');
 const routes = function (task, userProfile) {
   const controller = require('../controllers/taskController')(task, userProfile);
   const taskRouter = express.Router();
- 
+
   taskRouter
     .route('/tasks/:wbsId/:level/:mother')
     .get(controller.getTasks)
@@ -36,6 +36,11 @@ const routes = function (task, userProfile) {
   taskRouter.route('/user/:userId/teams/tasks').get(controller.getTasksForTeamsByUser);
 
   taskRouter.route('/tasks/reviewreq/:userId').post(controller.sendReviewReq);
+
+  // New routes for task change logs
+  taskRouter.route('/task/:taskId/changeLogs').get(controller.getTaskChangeLogs);
+
+  taskRouter.route('/user/:userId/taskChanges').get(controller.getUserTaskChangeLogs);
 
   return taskRouter;
 };


### PR DESCRIPTION
# Description
<img width="559" height="685" alt="Screenshot 2025-07-12 at 12 39 39 PM" src="https://github.com/user-attachments/assets/9cc6bed8-0b13-458a-8f7f-aaf9583f8b74" />

## Related PRS (if any):
To test this backend PR you need to checkout the [#3743](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3743) frontend PR.
…

## Main changes explained:
- Added new pop up when clicking the red dot of tasks to display edit history
- Fixed the edit counts in the red dot
…

## How to test:
1. check into current branch
2. do `npm run build` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Other Links→ Projects → create a new task → assign it to yourself
6. verify the task correctly displays next to your name on the dashboard
7. go back to Projects and edit the task
8. verify the edit history are correctly documented when clicking the red dot on dashboard

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/17fb0dd9-78d3-4934-9272-457077bd157e


## Note:
Include the information the reviewers need to know.
