### PR TITLE
Zhifan-hotfix task controller tests

### DIFF
--- a/src/controllers/taskController.spec.js
+++ b/src/controllers/taskController.spec.js
@@ -1,11 +1,13 @@
-const mongoose = require('mongoose');
-
 // Utility to aid in testing
 jest.mock('../utilities/permissions', () => ({
   hasPermission: jest.fn(),
 }));
 
 jest.mock('../utilities/emailSender', () => jest.fn());
+
+jest.mock('../middleware/taskChangeTracker', () => ({
+  logChanges: jest.fn(),
+}));
 
 const taskHelperMethods = {
   getTasksForTeams: jest.fn(),
@@ -839,7 +841,7 @@ describe('Unit Tests for taskController.js', () => {
       assertResMock(403, error, response, mockRes);
     });
 
-    test('Return 200 on successful update', async () => {
+    test('Return 201 on successful update', async () => {
       const { updateTask } = makeSut();
 
       hasPermission.mockResolvedValueOnce(true);
@@ -848,21 +850,31 @@ describe('Unit Tests for taskController.js', () => {
         ...mockReq.params,
         taskId: 456,
       };
+      mockReq.body = {
+        ...mockReq.body,
+        requestor: {
+          requestorId: 'userId123',
+        },
+      };
 
-      const taskFindByIdSpy = jest.spyOn(Task, 'findById').mockResolvedValue(mockedTask);
+      const mockUser = { _id: 'userId123', firstName: 'Test', lastName: 'User' };
+      const mockUpdatedTask = { ...mockedTask, toObject: () => mockedTask };
+
+      const taskFindByIdSpy = jest.spyOn(Task, 'findById').mockResolvedValue({ ...mockedTask, toObject: () => mockedTask });
+      const userProfileFindByIdSpy = jest.spyOn(UserProfile, 'findById').mockResolvedValue(mockUser);
       const taskFindOneAndUpdateSpy = jest
         .spyOn(Task, 'findOneAndUpdate')
-        .mockResolvedValueOnce(true);
+        .mockResolvedValueOnce(mockUpdatedTask);
       const wbsFindByIdSpy = jest.spyOn(WBS, 'findById').mockResolvedValue(mockedWBS);
       const projectFindByIdSpy = jest.spyOn(Project, 'findById').mockResolvedValue(mockedProject);
 
       const response = await updateTask(mockReq, mockRes);
       await flushPromises();
 
-      // assertResMock(201, null, response, mockRes);
       expect(mockRes.status).toBeCalledWith(201);
       expect(response).toBeUndefined();
       expect(taskFindByIdSpy).toHaveBeenCalled();
+      expect(userProfileFindByIdSpy).toHaveBeenCalled();
       expect(taskFindOneAndUpdateSpy).toHaveBeenCalled();
       expect(wbsFindByIdSpy).toHaveBeenCalled();
       expect(projectFindByIdSpy).toHaveBeenCalled();
@@ -871,15 +883,22 @@ describe('Unit Tests for taskController.js', () => {
     test('Return 404 on encountering error', async () => {
       const { updateTask } = makeSut();
 
-      const error = { error: 'No valid records found' };
       hasPermission.mockResolvedValueOnce(true);
 
       mockReq.params = {
         ...mockReq.params,
         taskId: 456,
       };
+      mockReq.body = {
+        ...mockReq.body,
+        requestor: {
+          requestorId: 'userId123',
+        },
+      };
 
-      const taskFindByIdSpy = jest.spyOn(Task, 'findById').mockResolvedValue(mockedTask);
+      const error = { error: 'No valid records found' };
+      const taskFindByIdSpy = jest.spyOn(Task, 'findById').mockResolvedValue({ ...mockedTask, toObject: () => mockedTask });
+      const userProfileFindByIdSpy = jest.spyOn(UserProfile, 'findById').mockResolvedValue({ _id: 'userId123' });
       const taskFindOneAndUpdateSpy = jest
         .spyOn(Task, 'findOneAndUpdate')
         .mockRejectedValueOnce(error);
@@ -891,9 +910,11 @@ describe('Unit Tests for taskController.js', () => {
 
       assertResMock(404, error, response, mockRes);
       expect(taskFindByIdSpy).toHaveBeenCalled();
+      expect(userProfileFindByIdSpy).toHaveBeenCalled();
       expect(taskFindOneAndUpdateSpy).toHaveBeenCalled();
-      expect(wbsFindByIdSpy).toHaveBeenCalled();
-      expect(projectFindByIdSpy).toHaveBeenCalled();
+      // WBS and Project operations only happen on successful update, not on error
+      expect(wbsFindByIdSpy).not.toHaveBeenCalled();
+      expect(projectFindByIdSpy).not.toHaveBeenCalled();
     });
   });
 
@@ -1526,9 +1547,9 @@ describe('Unit Tests for taskController.js', () => {
       expect(projectFindByIdSpy).toHaveBeenCalled();
     });
 
-    test('Returns 400 on error', async () => {
+    test('Returns 404 on error', async () => {
       const { updateTaskStatus } = makeSut();
-      const error = new Error('some error');
+      const error = { error: 'No valid records found' };
 
       mockReq.params = {
         ...mockReq.params,


### PR DESCRIPTION
# Description
The tests were failing because they weren't properly mocking the new dependencies that the updateTask function requires:
    - UserProfile.findById for user lookup
    - TaskChangeTracker.logChanges for change logging

## Related PRS (if any):
This backend PR is related to the #XXX backend PR.

…

## Main changes explained:
    - Added mock for TaskChangeTracker.logChanges
    - Added proper mocks for UserProfile.findById in the failing tests
    - Added proper mock objects with toObject() method for Mongoose models
    - Updated test title from "Return 200" to "Return 201" to match actual behavior
    - Fixed error tests to not expect WBS/Project operations when errors occur during
  task updates
    - Added proper requestor object in request body that the controller expects
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Tasks→ task→…
6. verify function “A” (feel free to include screenshot here)

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
