### PR TITLE
Jaydeep- Fix restore automated blue square email order to oldest-to-newest

### DIFF
--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -510,6 +510,7 @@ const userHelper = function () {
       while (true) {
         const users = await userProfile
           .find({ isActive: true }, '_id weeklycommittedHours weeklySummaries missedHours')
+          .sort({ createdDate: 1 }) // Ensure oldest-to-newest order
           .skip(skip)
           .limit(batchSize);
 


### PR DESCRIPTION
# Description
Restores the order of automated blue square emails to send from oldest-to-newest, based on user creation date. This matches the original behavior, which helped with admin replies and workflow.
**Issue**
The automated blue square emails used to send out from oldest-to-newest. They were based on who had been in the system the longest and that helped me a lot with my replies to all of them. I’d like this restored.
Fixes 
PRIORITY URGENT

## Related PRS (if any):
None

## Main changes explained:
- - Add .sort({ createdDate: 1 }) to user query in assignBlueSquareForTimeNotMet
…

## How to test:
**Testing NOT performed for this PR.**
**Reason:**
This is a query-only change.
Running the function in dev or staging would send real emails to Jae and onecommunityglobal, and would process all users in the dev database.
Running this function would also affect the data/state for the next scheduled cron job (which runs on Sunday), potentially causing duplicate or incorrect blue square assignments.
**Recommendation:**
Please review the code change for correctness.
If testing is required, coordinate with the admin team to avoid impacting production or dev data.

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
