### PR TITLE
fix(backend): create donut chart for applicant experience breakdown

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -4,23 +4,27 @@ const Sentry = require('@sentry/node');
 const app = express();
 const logger = require('./startup/logger');
 const globalErrorHandler = require('./utilities/errorHandling/globalErrorHandler');
-const experienceRoutes = require('./routes/applicantAnalyticsRoutes');
+
 logger.init();
 
-// The request handler must be the first middleware on the app
 app.use(Sentry.Handlers.requestHandler());
+app.use(express.json());
 
+// ✅ Mount analytics routes
+const analyticsRoutes = require('./routes/applicantAnalyticsRoutes');
+
+app.use('/api/applicants', analyticsRoutes);
+
+// Then load all other setup
 require('./startup/compression')(app);
 require('./startup/cors')(app);
 require('./startup/bodyParser')(app);
 require('./startup/middleware')(app);
+
+// ⚠ This must come *after* your custom /api routes
 require('./startup/routes')(app);
 
-// The error handler must be before any other error middleware and after all controllers
 app.use(Sentry.Handlers.errorHandler());
-
-// Make it the last middleware since it returns a response and do not call next()
 app.use(globalErrorHandler);
-app.use(express.json());
-app.use('/api', experienceRoutes); // Mounts at /api
+
 module.exports = { app, logger };

--- a/src/controllers/applicantAnalyticsController.js
+++ b/src/controllers/applicantAnalyticsController.js
@@ -2,61 +2,81 @@ const experienceBreakdownController = function (Applicant) {
   const getExperienceBreakdown = async (req, res) => {
     try {
       const { startDate, endDate, roles } = req.query;
-      const match = {};
 
-      // Filter by startDate range
-      if (startDate || endDate) {
-        match.startDate = {};
-        if (startDate) match.startDate.$gte = new Date(startDate);
-        if (endDate) match.startDate.$lte = new Date(endDate);
+      const pipeline = [];
+
+      // Match users whose startDate falls within given range
+      if (startDate && endDate) {
+        pipeline.push({
+          $match: {
+            $expr: {
+              $and: [
+                {
+                  $gte: [{ $dateFromString: { dateString: '$startDate' } }, new Date(startDate)],
+                },
+                {
+                  $lte: [{ $dateFromString: { dateString: '$startDate' } }, new Date(endDate)],
+                },
+              ],
+            },
+          },
+        });
       }
 
-      // Filter by roles
+      // Optional: filter by roles
       if (roles) {
         const rolesArray = Array.isArray(roles) ? roles : roles.split(',');
-        match.roles = { $in: rolesArray };
+        pipeline.push({
+          $match: {
+            roles: { $in: rolesArray },
+          },
+        });
       }
 
-      const breakdown = await Applicant.aggregate([
-        { $match: match },
-        {
-          $addFields: {
-            experienceCategory: {
-              $switch: {
-                branches: [
-                  { case: { $lte: ['$experience', 1] }, then: '0-1 years' },
-                  {
-                    case: {
-                      $and: [{ $gt: ['$experience', 1] }, { $lte: ['$experience', 3] }],
-                    },
-                    then: '1-3 years',
+      // Add experience category
+      pipeline.push({
+        $addFields: {
+          experienceCategory: {
+            $switch: {
+              branches: [
+                { case: { $lte: ['$experience', 1] }, then: '0-1 years' },
+                {
+                  case: {
+                    $and: [{ $gt: ['$experience', 1] }, { $lte: ['$experience', 3] }],
                   },
-                  {
-                    case: {
-                      $and: [{ $gt: ['$experience', 3] }, { $lte: ['$experience', 5] }],
-                    },
-                    then: '3-5 years',
+                  then: '1-3 years',
+                },
+                {
+                  case: {
+                    $and: [{ $gt: ['$experience', 3] }, { $lte: ['$experience', 5] }],
                   },
-                ],
-                default: '5+ years',
-              },
+                  then: '3-5 years',
+                },
+              ],
+              default: '5+ years',
             },
           },
         },
-        {
-          $group: {
-            _id: '$experienceCategory',
-            count: { $sum: 1 },
-          },
+      });
+
+      // Group by category
+      pipeline.push({
+        $group: {
+          _id: '$experienceCategory',
+          count: { $sum: 1 },
         },
-        {
-          $project: {
-            _id: 0,
-            experience: '$_id',
-            count: 1,
-          },
+      });
+
+      // Final format
+      pipeline.push({
+        $project: {
+          _id: 0,
+          experience: '$_id',
+          count: 1,
         },
-      ]);
+      });
+
+      const breakdown = await Applicant.aggregate(pipeline);
 
       if (!breakdown.length) {
         return res.status(404).json({ message: 'No Data Available' });
@@ -75,9 +95,7 @@ const experienceBreakdownController = function (Applicant) {
     }
   };
 
-  return {
-    getExperienceBreakdown,
-  };
+  return { getExperienceBreakdown };
 };
 
 module.exports = experienceBreakdownController;

--- a/src/models/jobApplicants.js
+++ b/src/models/jobApplicants.js
@@ -3,8 +3,8 @@ const mongoose = require('mongoose');
 const applicantSchema = new mongoose.Schema({
   experience: { type: Number, required: true },
   roles: [String],
-  startDate: Date,
-  endDate: Date,
+  startDate: String,
+  endDate: String,
 });
 
-module.exports = mongoose.model('jobapplicants', applicantSchema);
+module.exports = mongoose.model('Applicant', applicantSchema, 'jobapplicants');


### PR DESCRIPTION
# Description
<img width="1066" height="582" alt="Screenshot 2025-07-26 223107" src="https://github.com/user-attachments/assets/d65df4dc-3d8c-4e92-a456-01c0b4ee3807" />


## Related PRS (if any):
Front end PR needs to be created

## Main changes explained:
- Updated jobApplicants model
- Updated app.js to include applicants route
- Updated applicant analytics controller
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to postman and obtain a valid token by sending a POST request to http://localhost:4500/api/login
6. Use the token and send a GET request to http://localhost:4500/api/applicants/experience-breakdown to obtain the breakdown of applicants based on experience.
7.  Also test it by sending start date and end date params like http://localhost:4500/api/applicants/experience-breakdown?startDate=2020-01-01&endDate=2025-01-01

## Screenshots or videos of changes:

## Note:
This backend PR needs some work regarding filtering by role. So don't test it for now. Front end also should be completed by next week.
