### PR TITLE
feat(cache): add support for clearing all LostTeamEntry_* keys dynami…

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -473,15 +473,14 @@ const updateTaskIdInTimeEntry = async (id, timeEntry) => {
  * Controller for timeEntry
  */
 const timeEntrycontroller = function (TimeEntry) {
-
   const invalidateWeeklySummariesCache = (weekIndex) => {
     const cacheKey = `weeklySummaries_${weekIndex}`;
     cacheUtil.removeCache(cacheKey);
-    
+
     // Also invalidate the "all weeks" cache
     cacheUtil.removeCache('weeklySummaries_all');
   };
-  
+
   /**
    * Helper func: Check if this is the first time entry for the given user id
    *
@@ -614,10 +613,10 @@ const timeEntrycontroller = function (TimeEntry) {
         const today = new Date();
         const diffTime = today - dateOfWork;
         const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-        
+
         // Calculate which week this entry belongs to (0 = this week, 1 = last week, etc.)
         const weekIndex = Math.floor(diffDays / 7);
-        
+
         // Only invalidate cache for entries in the last 4 weeks
         if (weekIndex >= 0 && weekIndex <= 3) {
           // Call the invalidation function
@@ -660,6 +659,7 @@ const timeEntrycontroller = function (TimeEntry) {
       wbsId: newWbsId,
       taskId: newTaskId,
       dateOfWork: newDateOfWork,
+      entryType,
     } = req.body;
 
     const newTotalSeconds = newHours * 3600 + newMinutes * 60;
@@ -900,6 +900,10 @@ const timeEntrycontroller = function (TimeEntry) {
       }
 
       pendingEmailCollection.forEach((emailHandler) => emailHandler());
+      if (entryType === 'team') {
+        const lostteamentryCache = cacheClosure();
+        lostteamentryCache.clearByPrefix('LostTeamEntry_');
+      }
       await session.commitTransaction();
       return res.status(200).send(timeEntry);
     } catch (err) {
@@ -962,6 +966,11 @@ const timeEntrycontroller = function (TimeEntry) {
         } else {
           updateUserprofileTangibleIntangibleHrs(0, -totalSeconds, userprofile);
         }
+      }
+
+      if (timeEntry?.entryType === 'team') {
+        const lostteamentryCache = cacheClosure();
+        lostteamentryCache.clearByPrefix('LostTeamEntry_');
       }
 
       await timeEntry.remove({ session });
@@ -1041,7 +1050,6 @@ const timeEntrycontroller = function (TimeEntry) {
     }
   };
 
-  
   /**
    * Get total hours for a specified period for multiple users at once
    */
@@ -1067,20 +1075,20 @@ const timeEntrycontroller = function (TimeEntry) {
         {
           $match: {
             entryType: { $in: ['default', 'person', null] },
-            personId: { $in:  userIds.map(id => mongoose.Types.ObjectId(id)) },
-            dateOfWork: { $gte: startDate, $lte: endDate }
-          }
+            personId: { $in: userIds.map((id) => mongoose.Types.ObjectId(id)) },
+            dateOfWork: { $gte: startDate, $lte: endDate },
+          },
         },
         {
           $group: {
             _id: '$personId',
-            totalHours: { $sum: { $divide: ['$totalSeconds', 3600] } }
-          }
-        }
+            totalHours: { $sum: { $divide: ['$totalSeconds', 3600] } },
+          },
+        },
       ]);
-      const result = userHoursSummary.map(entry => ({
+      const result = userHoursSummary.map((entry) => ({
         userId: entry._id,
-        totalHours: Math.round(entry.totalHours * 10) / 10 //round
+        totalHours: Math.round(entry.totalHours * 10) / 10, // round
       }));
       res.status(200).send(result);
     } catch (error) {

--- a/src/utilities/nodeCache.js
+++ b/src/utilities/nodeCache.js
@@ -50,12 +50,26 @@ const cache = function () {
     cacheStore.ttl(key, ttl);
   }
 
+  function clearByPrefix(prefix) {
+    try {
+      const keys = cacheStore.keys();
+      keys.forEach((key) => {
+        if (key.startsWith(prefix)) {
+          cacheStore.del(key);
+        }
+      });
+    } catch (error) {
+      logger.logException(error);
+    }
+  }
+
   return {
     setCache,
     getCache,
     removeCache,
     hasCache,
     setKeyTimeToLive,
+    clearByPrefix,
   };
 };
 


### PR DESCRIPTION


# Description
<img width="967" height="322" alt="image" src="https://github.com/user-attachments/assets/e1552422-fb58-49be-98fd-5cfb7f2db7d9" />

## Related PRS (if any):

To test this backend PR you need to checkout the [#3824](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3824) frontend PR.
…

## Main changes explained:
- Updated the timeEntryController to clear the cache whenever teamTimentry changes
- Updated the cacheClosure with new func to remove cache based on prefix key
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Please follow given frontend PR instructions



