### PR TITLE
feat(badges): allow assigning badges to multiple users

### DIFF
--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -3,7 +3,7 @@ const UserProfile = require('../models/userProfile');
 const helper = require('../utilities/permissions');
 const escapeRegex = require('../utilities/escapeRegex');
 const cacheClosure = require('../utilities/nodeCache');
-//const userHelper = require('../helpers/userHelper')();
+// const userHelper = require('../helpers/userHelper')();
 
 const badgeController = function (Badge) {
   /**
@@ -74,6 +74,109 @@ const badgeController = function (Badge) {
    */
 
   const assignBadges = async function (req, res) {
+    if (!(await helper.hasPermission(req.body.requestor, 'assignBadges'))) {
+      res.status(403).send('You are not authorized to assign badges.');
+      return;
+    }
+
+    let userIds;
+    let badgeCollection;
+
+    if (req.params.userId) {
+      // Single user update case
+      userIds = [req.params.userId];
+      badgeCollection = req.body.badgeCollection;
+    } else {
+      // Multi-user assign case
+      userIds = req.body.userIds;
+      console.log('userIDs:', userIds);
+      badgeCollection = req.body.selectedBadges.map((badgeId) => ({
+        badge: badgeId.replace('assign-badge-', ''),
+        count: 1,
+        lastModified: Date.now(),
+        earnedDate: [new Date().toISOString()],
+      }));
+      console.log('badgeCollections', badgeCollection);
+    }
+
+    if (
+      !Array.isArray(userIds) ||
+      userIds.length === 0 ||
+      !Array.isArray(badgeCollection) ||
+      badgeCollection.length === 0
+    ) {
+      res
+        .status(400)
+        .send('Invalid input. Both userIds and badgeCollection must be non-empty arrays.');
+      return;
+    }
+
+    try {
+      const results = await Promise.all(
+        userIds.map(async (userId) => {
+          const userToBeAssigned = mongoose.Types.ObjectId(userId);
+          const record = await UserProfile.findById(userToBeAssigned);
+
+          if (!record) {
+            return { userId, error: 'User not found' };
+          }
+
+          let totalNewBadges = 0;
+          const existingBadges = {};
+          if (record.badgeCollection && Array.isArray(record.badgeCollection)) {
+            record.badgeCollection.forEach((badgeItem) => {
+              existingBadges[badgeItem.badge.toString()] = badgeItem;
+            });
+          }
+
+          // Merge existing badges with new ones
+          badgeCollection.forEach((badge) => {
+            const existingBadge = existingBadges[badge.badge.toString()];
+            if (existingBadge) {
+              // Update the existing badge
+              existingBadge.count += badge.count;
+              existingBadge.lastModified = Date.now();
+              existingBadge.earnedDate = [
+                ...existingBadge.earnedDate,
+                ...(badge.earnedDate || [new Date().toISOString()]),
+              ];
+            } else {
+              // Add the new badge
+              existingBadges[badge.badge.toString()] = {
+                badge: mongoose.Types.ObjectId(badge.badge),
+                count: badge.count,
+                lastModified: Date.now(),
+                earnedDate: badge.earnedDate || [new Date().toISOString()],
+              };
+              totalNewBadges += badge.count;
+            }
+          });
+
+          // Convert the merged badges back to an array
+          record.badgeCollection = Object.values(existingBadges);
+          record.badgeCount += totalNewBadges;
+
+          if (cache.hasCache(`user-${userToBeAssigned}`)) {
+            cache.removeCache(`user-${userToBeAssigned}`);
+          }
+
+          await record.save();
+          return { userId, success: true };
+        }),
+      );
+
+      const errors = results.filter((result) => result.error);
+      if (errors.length > 0) {
+        res.status(207).send({ message: 'Some users were not assigned badges', errors });
+      } else {
+        res.status(200).send({ message: 'Badges assigned successfully to all users' });
+      }
+    } catch (err) {
+      res.status(500).send(`Internal Error: Badge Collection. ${err.message}`);
+    }
+  };
+
+  const assignBadgesToSingleUser = async function (req, res) {
     if (!(await helper.hasPermission(req.body.requestor, 'assignBadges'))) {
       res.status(403).send('You are not authorized to assign badges.');
       return;
@@ -341,9 +444,10 @@ const badgeController = function (Badge) {
   };
 
   return {
-    //awardBadgesTest,
+    // awardBadgesTest,
     getAllBadges,
     assignBadges,
+    assignBadgesToSingleUser,
     postBadge,
     deleteBadge,
     putBadge,

--- a/src/routes/badgeRouter.js
+++ b/src/routes/badgeRouter.js
@@ -5,15 +5,20 @@ const routes = function (badge) {
 
   const badgeRouter = express.Router();
 
-  //badgeRouter.get('/badge/awardBadgesTest', controller.awardBadgesTest);
+  // badgeRouter.get('/badge/awardBadgesTest', controller.awardBadgesTest);
 
   badgeRouter.route('/badge').get(controller.getAllBadges).post(controller.postBadge);
 
   badgeRouter.route('/badge/:badgeId').delete(controller.deleteBadge).put(controller.putBadge);
 
-  badgeRouter.route('/badge/assign/:userId').put(controller.assignBadges);
+  badgeRouter.route('/badge/assign').post(controller.assignBadges);
 
-  badgeRouter.route('/badge/badgecount/:userId').get(controller.getBadgeCount).put(controller.putBadgecount);
+  badgeRouter.route('/badge/assign/:userId').put(controller.assignBadgesToSingleUser);
+
+  badgeRouter
+    .route('/badge/badgecount/:userId')
+    .get(controller.getBadgeCount)
+    .put(controller.putBadgecount);
 
   badgeRouter.route('/badge/badgecount/reset/:userId').put(controller.resetBadgecount);
 


### PR DESCRIPTION
# Description
This functionality will allow the authorized users to assign one or multiple badges to one or multiple at once.
Or Implements # (WBS) 

## Related PRS (if any):
This PR is a modified version of an existing PR [#1091](https://github.com/OneCommunityGlobal/HGNRest/pull/1091), I just modified it's node version and eslint errors and also merge conflicts.
This frontend PR is related to the #XXX backend PR.
…

## Main changes explained:
Added Controller function and a new route to handle assigning one or multiple badges to one or multiple users.
…

## How to test:
check into current branch
do npm install and ... to run this PR locally
Clear site data/cache
log as admin/owner user
go to dashboard→ Other Links→ Badge Management→ Badge Assignment tab
verify if the user can search and select single or multiple users
verify if the user can select and assign one or multiple badges.
verify if the user gets a success alert message.
To verify if the badge got assigned go to dashboard→ Other Links→ User Management and search for each user(s) who were assigned badges and check the Featured Badges section of their user profile.
Click on the "Select Featured" button and verify if the user can delete one or multiple badges.


