### PR TITLE
Ramsundar - Fix Weekly Summaries report hours are inaccurate

### DIFF
--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -172,13 +172,8 @@ const reporthelper = function () {
           result.totalSeconds[index] = 0;
         }
 
-        if (entry.isTangible === true) {
+        if (entry.isTangible === true && index >= 0 && index < 4) {
           result.totalSeconds[index] += entry.totalSeconds;
-          if (index >= 0 && index < 4) {
-            if (entry.isTangible === true) {
-              result.totalSeconds[index] += entry.totalSeconds;
-            }
-          }
         }
       });
 


### PR DESCRIPTION
# Description
Bug Explanation Video: https://www.loom.com/share/a9a5bf54d09d4ab7a2bc015b6fdccf12?sid=2ec6c42f-cef3-4778-aecd-3bd05eb02f43

Go to Dashboard → Reports → Weekly Summaries Report, then view “This week / Last week / Week before last / Three weeks ago.” You’ll notice some users show incorrect hours in the “This week” column—for example, someone who logged 5 tangible hours appears with 10, suggesting the value is being double-counted. It occurs in all the columns because everything is getting one value as an input from the backend. 


## Related PRS (if any):

To test this backend PR you need to checkout the Latest Development branch of Highest Good network  Frontend repo. 
…

## Main changes explained:
- The mismatch came from the weekly summaries report double-counting tangible time for each entry.
- Removed the duplicate addition and kept a single, guarded increment that only runs when the entry is tangible and the computed week index is within the 0–3 range.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as Volunteer user
5. Add some tangible time for Ex: 2 hours.
6. Log as Admin Account, Go to dashboard -> Reports -> Weekly Summaries report -> This week -> Check Hours logged of the volunteer user -> It should be 2 hours not doubled.

## Screenshots or videos of changes:

https://www.loom.com/share/5a398e0b370e4496be732cb692c980a6?sid=ec9de782-4f33-45ae-b2d3-06fb58a24cb5

## Note:
Include the information the reviewers need to know.
