### PR TITLE
Kristin Move Default Password Modification Prevention Block

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -599,22 +599,16 @@ const userProfileController = function (UserProfile, Project) {
       return;
     }
 
-        // Prevent modification of defaultPassword
-    if (req.body.defaultPassword && record.defaultPassword) {
-      res.status(403).send('defaultPassword cannot be modified once it is set.');
-      return;
-    }
-
-    // Prevent modification of defaultPassword
-    if (req.body.defaultPassword && record.defaultPassword) {
-      res.status(403).send('defaultPassword cannot be modified.');
-      return;
-    }
-
     cache.removeCache(`user-${userid}`);
     UserProfile.findById(userid, async (err, record) => {
       if (err || !record) {
         res.status(404).send('No valid records found');
+        return;
+      }
+
+      // Prevent modification of defaultPassword
+      if (req.body.defaultPassword && record.defaultPassword) {
+        res.status(403).send('defaultPassword cannot be modified.');
         return;
       }
 


### PR DESCRIPTION
# Description
Fix for [PR1414](https://github.com/OneCommunityGlobal/HGNRest/pull/1414)

## Related PRS (if any):
This backend PR is related to the previous [PR1414](https://github.com/OneCommunityGlobal/HGNRest/pull/1414) backend PR.

## Main changes explained:
- Move the code block that prevents modification of the default password inside the `findById` fallback after record is defined

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. fill out the form to create an new user
6. verify there is no "Unexpected Error" in the process (and in the console)

## Screenshots or videos of changes:
<img width="1558" height="993" alt="Create New User Test" src="https://github.com/user-attachments/assets/9b821161-7458-41c1-bd01-4885965cc46f" />
