### PR TITLE
Diya - fix(auth): allow password-reset emails in dev

### DIFF
--- a/src/controllers/dashBoardController.spec.js
+++ b/src/controllers/dashBoardController.spec.js
@@ -120,6 +120,9 @@ describe('Unit Tests for forgotPwdcontroller.js', () => {
         expectedEmailMessage,
         null,
         null,
+        null,
+        null,
+        { type: 'password_reset' },
       );
       assertResMock(200, { message: 'generated new password' }, response, mockRes);
       expect(findOneSpy).toHaveBeenCalledWith({

--- a/src/controllers/forgotPwdcontroller.js
+++ b/src/controllers/forgotPwdcontroller.js
@@ -43,6 +43,9 @@ const forgotPwdController = function (userProfile) {
           getEmailMessageForForgotPassword(user, ranPwd),
           null,
           null,
+          null,
+          null,
+          { type: 'password_reset' },
         );
 
         logger.logInfo(`New password ${ranPwd} was generated for ${user._id}`);

--- a/src/utilities/emailSender.js
+++ b/src/utilities/emailSender.js
@@ -103,6 +103,7 @@ const processQueue = async () => {
  * @param {string[]|null} [cc=null] - Optional array of CC (carbon copy) email addresses.
  * @param {string|null} [replyTo=null] - Optional reply-to email address.
  * @param {string[]|null} [emailBccs=null] - Optional array of BCC (blind carbon copy) email addresses.
+ * @param {Object} [opts={}] - Optional settings object.
  *
  * @returns {Promise<string>} A promise that resolves when the email queue has been processed successfully or rejects on error.
  *
@@ -130,8 +131,15 @@ const emailSender = (
   cc = null,
   replyTo = null,
   emailBccs = null,
+  opts = {},
 ) => {
-  if (!process.env.sendEmail || String(process.env.sendEmail).toLowerCase() === 'false') {
+  const type = opts.type || 'general';
+  const isReset = type === 'password_reset';
+
+  if (
+    !process.env.sendEmail ||
+    (String(process.env.sendEmail).toLowerCase() === 'false' && !isReset)
+  ) {
     return Promise.resolve('EMAIL_SENDING_DISABLED');
   }
 


### PR DESCRIPTION
# Description
Reset password on test accounts not sending email for new password.
- Login to Dev Admin → Other Links → User Management → Create a test account (with an actual working email - that can recieve emails)
- Login using test account → Logout → Forgot Password.

Fixes # 
36. (PRIORITY HIGH) - HGN Phase 1 Bugs 
- Last action item above 'Badges Component'

## Related PRS (if any):
None

## Main changes explained:
- Added an optional object for the 'email sender' constant. It can now accept an email options object
- Passing option type as reset password from the forgot password controller.

## How to test:
1. Create a GCP project and generate client values for next step(mentioned below)
2. Add the following environment variables into your .env file with values generated from Step 1.
sendEmail=false
REACT_APP_EMAIL=**testuser**@gmail.com
REACT_APP_EMAIL_CLIENT_ID=100____com
REACT_APP_EMAIL_CLIENT_SECRET=GO_____h
REACT_APP_EMAIL_CLIENT_REDIRECT_URI=https://developers.google.com/oauthplayground
REACT_APP_EMAIL_REFRESH_TOKEN=1//_______
3. Create a test account in dev or use an existing account.
4. Check into current branch, npm install, npm run build, npm run dev
5. Enter the following curl into Postman and test (POST request)
curl --location 'http://localhost:4500/api/forgotpassword' \
--header 'Content-Type: application/json' \
--data-raw '{
    "email": "<testaccount@gmail.com>",
    "firstName": "<firstName>",
    "lastName": "<lastName>"
}'
Replace the data with test account details you created

### Steps to create a GCP project -

<img width="1871" height="52" alt="Screenshot 2025-09-10 at 9 12 28 PM" src="https://github.com/user-attachments/assets/926148d6-b07e-400b-9d31-0a59eeca88cb" />

1. Head to Google Cloud Console: https://console.cloud.google.com
2. Next to the 'Google Cloud' title, you should see your project picker. Create a new project, name it anything like 'EmailSenderSample'. Should take a few minutes
3. Use either notifications or your project picker to select your newly created project.
4. Head over to 'APIs and Services' > '+ Enable APIs and services' > Enter Gmail API in the search bar and Enable it.
5. Select OAuth consent screen from the left-side menu > Get Started and create this.
- Set App Name as something like 'EmailSender'
- Select your email as User Support Email (We will add this email as a test user later)
- Select audience as 'External'
6. Select Audience from the left-side menu and add your email as the test user.
7. Select Clients from the left-side menu > '+ Create Client'
- Application Type: Web application
- Authorized redirect URIs: https://developers.google.com/oauthplayground
8. Copy and save your Client ID and Secret values somewhere safe.(these values will be used later)
9. Head over to OAuth2.0 Playground: https://developers.google.com/oauthplayground/
10. Gear icon > Use your own OAuth credentials > Paste client ID and secret here
11. Authorize API: https://mail.google.com/
12. Click on 'Exchange authorization code for tokens'. Copy and save the Refresh Token recieved.



## Screenshots or videos of changes:
Logs should say something like

'New password d678a701-6207-4794-91aa-4336c269753eTEMP was generated for 66725af292f78117649bdc5b'
and you should receive an email with above password.


## Note:
Please create the GCP project to get the OAuth credentials.
