### PR TITLE
Diya fix(projectAssignment): recognizing projectId param

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -756,6 +756,7 @@ const userProfileController = function (UserProfile, Project) {
             if (typeof p === 'string') return p.trim();
             if (typeof p === 'object' && p._id) return String(p._id);
             if (typeof p === 'object' && p.id) return String(p.id);
+            if (typeof p === 'object' && p.projectId) return String(p.projectId);
             return null;
           };
 


### PR DESCRIPTION
# Description
Fixes an issue where adding a project from Quick Setup → Assign and Assign Project on the user profile would cause the latest project to be retained and remove the existing assigned project. 
**Root cause:** the backend putUserProfile handler only normalized projects items that had _id/id (or were plain strings). Items sent with projectId were ignored, resulting in record.projects being overwritten with a reduced array.
**Change:** Update normalization to also accept projectId so mixed payloads (some items with _id, some with projectId) are handled correctly.

## Related PRS (if any):
None

## Main changes explained:
- In putUserProfile, update normalizeToIdString to accept projectId in addition to _id/id/string.

## How to test:
1. DevTools verification
- In the Network tab for the PUT /userProfile/:userId call, confirm the request body includes: projects as an array where items may have _id or projectId.

## Screenshots or videos of changes:
<img width="696" height="71" alt="Screenshot 2025-09-13 at 1 12 33 AM" src="https://github.com/user-attachments/assets/b9031258-da90-4c0e-94f4-3553e792bff6" />

<img width="499" height="223" alt="Screenshot 2025-09-13 at 1 12 05 AM" src="https://github.com/user-attachments/assets/278e6493-9853-419f-9112-4bb933105b0a" />
