### PR TITLE
Humemah(userProfile): add final day API route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3658,6 +3658,7 @@
       "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.2.4.tgz",
       "integrity": "sha512-SG23E3JDH6y8qF20a4G9txLuUl+TCV16gxsKyntmGiJez2V9VBJr1Y8WxTBBD6OgBVcvspQ7sxgdNMkXFVcaEA==",
       "deprecated": "This is a stub types definition. bson provides its own type definitions, so you do not need this installed.",
+      "license": "MIT",
       "dependencies": {
         "bson": "*"
       }

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -2309,6 +2309,51 @@ const userProfileController = function (UserProfile, Project) {
     }
   };
 
+  const setFinalDay = async (req, res) => {
+    try {
+      const { userId } = req.params;
+      const { date } = req.body;
+
+      const user = await UserProfile.findById(userId);
+      if (!user) {
+        return res.status(404).json({
+          success: false,
+          message: 'User not found',
+        });
+      }
+
+      const finalDate = new Date(date);
+
+      if (finalDate < user.startDate) {
+        return res.status(400).json({
+          success: false,
+          message: 'Final day cannot be before start date',
+          startDate: user.startDate,
+        });
+      }
+
+      user.endDate = finalDate;
+      const updatedUser = await user.save();
+
+      res.status(200).json({
+        success: true,
+        message: 'Final day set successfully',
+        user: {
+          id: updatedUser._id,
+          firstName: updatedUser.firstName,
+          lastName: updatedUser.lastName,
+          endDate: updatedUser.endDate,
+          isActive: updatedUser.isActive,
+        },
+      });
+    } catch (error) {
+      console.error('Error setting final day:', error);
+      res.status(500).json({
+        success: false,
+        message: 'Server error',
+      });
+    }
+  };
   return {
     searchUsersByName,
     postUserProfile,
@@ -2347,6 +2392,7 @@ const userProfileController = function (UserProfile, Project) {
     updateUserInformation,
     getAllMembersSkillsAndContact,
     replaceTeamCodeForUsers,
+    setFinalDay,
   };
 };
 

--- a/src/routes/userProfileRouter.js
+++ b/src/routes/userProfileRouter.js
@@ -141,6 +141,8 @@ const routes = function (userProfile, project) {
     .route('/userProfile/skills/:skill')
     .get(controller.getAllMembersSkillsAndContact);
 
+  userProfileRouter.route('/userProfile/:userId/finalDay').patch(controller.setFinalDay);
+
   return userProfileRouter;
 };
 


### PR DESCRIPTION
# Description
This PR introduces functionality to set the final day (endDate) for a user.

## Related PRS (if any):
This backend PR is related to the  frontend  [PR.](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3991)

…

## Main changes explained:
Created controller function setEndDate in controllers/userController.js to handle the PATCH request.
Added route PATCH /users/:id/end-date in routes/userRoutes.js.

## How to test:
Checkout this branch.
Run npm install and start the backend with npm run dev.
Send a PATCH request via Postman or frontend to:
PATCH /users/:id/end-date
{
  "endDate": "2025-09-30"
}
user.endDate is updated.

## Screenshots or videos of changes:

## Note:
Include the information the reviewers need to know.
