### PR TITLE
Diya Blue Square CC Feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "compression": "^1.8.0",
         "cors": "^2.8.4",
         "cron": "^1.8.2",
-        "date-fns": "^4.1.0",
+        "date-fns": "^2.30.0",
         "dotenv": "^5.0.1",
         "dropbox": "^10.34.0",
         "express": "^4.17.1",
@@ -5642,13 +5642,19 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
       "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
       "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "compression": "^1.8.0",
     "cors": "^2.8.4",
     "cron": "^1.8.2",
-    "date-fns": "^4.1.0",
+    "date-fns": "^2.30.0",
     "dotenv": "^5.0.1",
     "dropbox": "^10.34.0",
     "express": "^4.17.1",

--- a/src/controllers/BlueSquareEmailAssignmentController.js
+++ b/src/controllers/BlueSquareEmailAssignmentController.js
@@ -107,12 +107,158 @@ const BlueSquareEmailAssignmentController = function (BlueSquareEmailAssignment,
     }
   };
 
+  const escapeRegExp = (s = '') => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+  const assignCCEmail = async function assignCCEmail(req, res) {
+    try {
+      console.log('assignCCEmail called with', req.params, req.body);
+      // Which user’s profile are we adding the CC list item to?
+      const targetUserId = req.params.userId;
+      console.log('Target userId:', targetUserId);
+      if (!targetUserId) {
+        return res.status(400).json({ error: 'Missing target userId' });
+      }
+
+      // CC person details
+      const { email: ccEmail, firstName, lastName, role } = req.body || {};
+      console.log('email', ccEmail, 'firstName', firstName, 'lastName', lastName, 'role', role);
+      if (!ccEmail || !firstName || !lastName) {
+        return res.status(400).json({ error: 'ccEmail, firstName and lastName are required' });
+      }
+
+      // Find the CC person by email to populate assignedTo
+      const ccUser = await userProfile.findOne(
+        { email: { $regex: `^${escapeRegExp(ccEmail)}$`, $options: 'i' } },
+        { _id: 1, email: 1, firstName: 1, lastName: 1, role: 1 },
+      );
+
+      if (!ccUser) {
+        return res.status(404).json({ error: 'No user found with that CC email' });
+      }
+
+      // Prevent duplicate by email (case-insensitive)
+      const alreadyHas = await userProfile.exists({
+        _id: targetUserId,
+        'infringementCCList.email': { $regex: `^${escapeRegExp(ccEmail)}$`, $options: 'i' },
+      });
+
+      if (alreadyHas) {
+        const existing = await userProfile.findById(targetUserId).select('infringementCCList');
+        return res.status(200).json({
+          message: 'CC already present',
+          infringementCCList: existing?.infringementCCList || [],
+        });
+      }
+
+      // Push the new entry. If infringementCCList doesn't exist, Mongo will create it.
+      const updated = await userProfile
+        .findByIdAndUpdate(
+          targetUserId,
+          {
+            $push: {
+              infringementCCList: {
+                email: ccUser.email, // normalize to the stored email
+                firstName, // take from body as requested
+                lastName, // take from body as requested
+                role, // take from body as requested
+                assignedTo: ccUser._id, // ObjectId reference
+              },
+            },
+          },
+          { new: true, runValidators: true },
+        )
+        .select('infringementCCList');
+
+      console.log('Updated infringementCCList:', updated.infringementCCList);
+
+      if (!updated) {
+        return res.status(404).json({ error: 'Target user not found' });
+      }
+
+      return res.status(200).json({
+        message: 'CC added',
+        infringementCCList: updated.infringementCCList || [],
+      });
+    } catch (error) {
+      console.error('assignCCEmail error:', error);
+      return res.status(500).json({ error: 'Failed to assign CC email', details: error.message });
+    }
+  };
+
+  const removeCCEmail = async function removeCCEmail(req, res) {
+    try {
+      console.log('removeCCEmail called with', req.params);
+      // Which user’s profile are we removing the CC list item from?
+      const targetUserId = req.params.userId;
+      const ccEmail = req.params.email;
+      console.log('Target userId:', targetUserId, 'ccEmail to remove:', ccEmail);
+
+      if (!targetUserId) {
+        return res.status(400).json({ error: 'Missing target userId' });
+      }
+
+      // CC person email to remove
+      if (!ccEmail) {
+        return res.status(400).json({ error: 'ccEmail is required' });
+      }
+
+      // Check if this CC email exists in the list
+      const userProfileDoc = await userProfile
+        .findOne({
+          _id: targetUserId,
+          'infringementCCList.email': {
+            $regex: `^${escapeRegExp(ccEmail)}$`,
+            $options: 'i',
+          },
+        })
+        .select('infringementCCList');
+
+      if (!userProfileDoc) {
+        return res.status(404).json({
+          error: 'No matching CC email found for this user',
+        });
+      }
+
+      // Perform the removal
+      const updated = await userProfile
+        .findByIdAndUpdate(
+          targetUserId,
+          {
+            $pull: {
+              infringementCCList: {
+                email: { $regex: `^${escapeRegExp(ccEmail)}$`, $options: 'i' },
+              },
+            },
+          },
+          { new: true },
+        )
+        .select('infringementCCList');
+
+      if (!updated) {
+        return res.status(404).json({ error: 'Target user not found after update' });
+      }
+
+      return res.status(200).json({
+        message: 'CC email removed successfully',
+        infringementCCList: updated.infringementCCList || [],
+      });
+    } catch (error) {
+      console.error('removeCCEmail error:', error);
+      return res.status(500).json({
+        error: 'Failed to remove CC email',
+        details: error.message,
+      });
+    }
+  };
+
   return {
     getBlueSquareEmailAssignment,
     setBlueSquareEmailAssignment,
     deleteBlueSquareEmailAssignment,
     runManuallyResendWeeklySummaries,
     runManualBlueSquareEmailResend,
+    assignCCEmail,
+    removeCCEmail,
   };
 };
 

--- a/src/controllers/BlueSquareEmailAssignmentController.js
+++ b/src/controllers/BlueSquareEmailAssignmentController.js
@@ -121,7 +121,6 @@ const BlueSquareEmailAssignmentController = function (BlueSquareEmailAssignment,
 
       // CC person details
       const { email: ccEmail, firstName, lastName, role } = req.body || {};
-      console.log('email', ccEmail, 'firstName', firstName, 'lastName', lastName, 'role', role);
       if (!ccEmail || !firstName || !lastName) {
         return res.status(400).json({ error: 'ccEmail, firstName and lastName are required' });
       }
@@ -168,8 +167,6 @@ const BlueSquareEmailAssignmentController = function (BlueSquareEmailAssignment,
           { new: true, runValidators: true },
         )
         .select('infringementCCList');
-
-      console.log('Updated infringementCCList:', updated.infringementCCList);
 
       if (!updated) {
         return res.status(404).json({ error: 'Target user not found' });

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -191,6 +191,7 @@ const userProfileController = function (UserProfile, Project) {
             endDate: 1,
             timeZone: 1,
             infringementCount: { $size: { $ifNull: ['$infringements', []] } },
+            infringementCCList: { $ifNull: ['$infringementCCList', []] },
             jobTitle: {
               $cond: {
                 if: { $isArray: '$jobTitle' },

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -288,6 +288,15 @@ const userProfileSchema = new Schema({
     daterequestedFeedback: { type: Date, default: Date.now },
     foundHelpSomeWhereClosePermanently: { type: Boolean, default: false },
   },
+  infringementCCList: [
+    {
+      email: { type: String, required: true },
+      firstName: { type: String, required: true },
+      lastName: { type: String },
+      role: { type: String },
+      assignedTo: { type: mongoose.SchemaTypes.ObjectId, ref: 'userProfile', required: true },
+    },
+  ],
 });
 
 userProfileSchema.pre('save', function (next) {

--- a/src/routes/BlueSquareEmailAssignmentRouter.js
+++ b/src/routes/BlueSquareEmailAssignmentRouter.js
@@ -25,6 +25,11 @@ const routes = function (BlueSquareEmailAssignment, userProfile) {
     controller.runManualBlueSquareEmailResend,
   );
 
+  BlueSquareEmailAssignmentRouter.route('/assignCCEmail/:userId').post(controller.assignCCEmail);
+  BlueSquareEmailAssignmentRouter.route('/removeCCEmail/:userId/:email').delete(
+    controller.removeCCEmail,
+  );
+
   return BlueSquareEmailAssignmentRouter;
 };
 


### PR DESCRIPTION
# Description
This PR introduces backend support for managing CC email assignments within the Blue Square workflow. It includes creating and removing CC email entries tied to a user’s profile.

## Related PRS (if any):
To test this backend PR you need to checkout the #XXX frontend PR.

## Main changes explained:

- Controller Updates (BlueSquareEmailAssignmentController.js)
-- **New endpoint: assignCCEmail**
-- Accepts userId via URL params and CC details (email, firstName, lastName, role) via request body.
-- Validates input and ensures the target user exists.
-- Finds the CC user in the system and prevents duplicates before inserting.
-- Pushes the new CC entry into the infringementCCList array for the target user.
-- Returns the updated infringementCCList in the response.
-- **New endpoint: removeCCEmail**
-- Accepts userId and email via URL params.
-- Searches for the CC entry in the infringementCCList and removes it if found.
-- Returns the updated infringementCCList after deletion.

- Router Updates (BlueSquareEmailAssignmentRouter.js)
-- Added POST /assignCCEmail/:userId for adding CC entries.
-- Added DELETE /assignCCEmail/:userId/:email for removing CC entries.

- Model Updates (userProfile.js)
-- Added infringementCCList as a nested field inside the user profile schema to store CC email details.

## How to test:
1. Check into the current branch
2. Do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Follow instructions on the frontend PR