### PR TITLE
Xinyi - fix: resolved volunteer trends line chart filter error

### DIFF
--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -267,7 +267,15 @@ const overviewReportHelper = function () {
               $project: { createdDate: 1 },
             },
           ]);
-          startDate = oldestVolunteer.createdDate;
+
+          if (oldestVolunteer) {
+            startDate = oldestVolunteer.createdDate;
+          } else {
+            // fallback: no users found, use earliest reasonable date
+            startDate = new Date(0); // Unix epoch
+          }
+          // fallback: no createdDate found, use earliest reasonable date
+          startDate = oldestVolunteer?.createdDate ?? new Date(0);
           break;
         }
         case '1':


### PR DESCRIPTION
# Description
Problem: The graph updates correctly for all tested ranges, but selecting “All Time” causes an error.
Suggestion: Fix handling for the “All Time” option so the chart loads without errors.

## Related PRS (if any):
This PR is not related to other PRs.
…

## Main changes explained:
- Update file overviewReportHelper.js to resolve data fetch error.
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Reports > Total Org Summary
6. verify Volunteer Trends Line Chart time filter works for all options

## Screenshots or videos of changes:
Before:
<img width="1466" height="713" alt="image" src="https://github.com/user-attachments/assets/8ef5b90a-71e1-4430-aad9-7ee705e73124" />

After:
<img width="1470" height="848" alt="image" src="https://github.com/user-attachments/assets/dadc292b-309b-41c0-9614-53abff4c3596" />

## Note:
None.
