### PR TITLE
Abhishek - Fix - Role Distribution Pie Chart - Date Filters 

### DIFF
--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -134,7 +134,12 @@ const reportsController = function () {
           isoComparisonStartDate,
           isoComparisonEndDate,
         ),
-        overviewReportHelper.getRoleDistributionStats(),
+        overviewReportHelper.getRoleDistributionStats(
+          isoStartDate,
+          isoEndDate,
+          isoComparisonStartDate,
+          isoComparisonEndDate,
+        ),
         overviewReportHelper.getTeamMembersCount(isoEndDate, isoComparisonEndDate),
         overviewReportHelper.getBlueSquareStats(
           isoStartDate,


### PR DESCRIPTION
# Description
Added changes to handle date filter changes to `Total Org Summary` Role Distribution Pie Chart

<img width="643" height="175" alt="image" src="https://github.com/user-attachments/assets/8e02b517-5798-471d-91c8-8b58261898ad" />

## Related PRS (if any):
To test this backend PR you need to checkout the [#4125](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4125) frontend PR.
…

## Main changes explained:

- Signature updated to (startDate, endDate, comparisonStartDate, comparisonEndDate).
- Returns { current, comparison } when the comparison range is given, otherwise preserves array shape [{ _id: role, count }].
- `getVolunteerStatsData` now calls `overviewReportHelper.getRoleDistributionStats(isoStartDate, isoEndDate, isoComparisonStartDate, isoComparisonEndDate)`.
- No other call sites modified.

## How to test:
1. Check into `abhishek-fix-role-dist-pie-chart` branch.
2. Check into `abhishek-fix-role-dist-pie-chart` branch in frontend and run it to test.
3. Run `npm install`, `npm run build`, and `npm run start` to run this PR locally.
4. Clear site data/cache.
5. Log in as Admin user.
6. Go to dashboard→ Reports→ Total Org Summary
7. Verify if the loader gets displayed when the date range is changed.
8. Verify if the date filter works for the Role Distribution Pie Chart.

## Screenshots or videos of changes:

### Before

https://github.com/user-attachments/assets/43add8cd-d9e1-4ffb-bfc5-65208b2bc4bd

### After

https://github.com/user-attachments/assets/35c238e0-215d-4ac2-b2e2-f964693ab618
