### PR TITLE
Diya fix(role): Default Role Assigned to Users when role is deleted

### DIFF
--- a/src/controllers/rolesController.spec.js
+++ b/src/controllers/rolesController.spec.js
@@ -1,40 +1,19 @@
-const Role = require('../models/role');
-const UserProfile = require('../models/userProfile');
-const { mockReq, mockRes, assertResMock } = require('../test');
-
 jest.mock('../models/role');
 jest.mock('../models/userProfile');
 jest.mock('../utilities/permissions');
-jest.mock('../utilities/nodeCache');
 
-const cacheClosure = require('../utilities/nodeCache');
+const Role = require('../models/role');
+const UserProfile = require('../models/userProfile');
 const helper = require('../utilities/permissions');
+const { mockReq, mockRes, assertResMock } = require('../test');
+
 const rolesController = require('./rolesController');
 
 const flushPromises = () => new Promise(setImmediate);
-
 const mockHasPermission = (value) =>
   jest.spyOn(helper, 'hasPermission').mockImplementationOnce(() => Promise.resolve(value));
 
-const makeMockCache = (method, value) => {
-  const cacheObject = {
-    getCache: jest.fn(),
-    removeCache: jest.fn(),
-    hasCache: jest.fn(),
-    setCache: jest.fn(),
-  };
-
-  const mockCache = jest.spyOn(cacheObject, method).mockImplementationOnce(() => value);
-
-  cacheClosure.mockImplementationOnce(() => cacheObject);
-
-  return { mockCache, cacheObject };
-};
-const makeSut = () => {
-  const { getAllRoles, createNewRole, getRoleById, updateRoleById, deleteRoleById } =
-    rolesController(Role);
-  return { getAllRoles, createNewRole, getRoleById, updateRoleById, deleteRoleById };
-};
+const makeSut = () => rolesController(Role);
 
 describe('rolesController module', () => {
   afterEach(() => {
@@ -199,31 +178,86 @@ describe('rolesController module', () => {
 
       const hasPermissionSpy = mockHasPermission(false);
       const response = await deleteRoleById(mockReq, mockRes);
+
       expect(hasPermissionSpy).toHaveBeenCalledWith(mockReq.body.requestor, 'deleteRole');
       assertResMock(403, 'You are not authorized to delete roles.', response, mockRes);
     });
 
-    test('Should return 200 and the deleted role on success', async () => {
+    test('Should return 404 if role does not exist', async () => {
       mockHasPermission(true);
 
-      const mockRole = { remove: jest.fn().mockResolvedValue(), roleName: 'role' };
-      const { mockCache: hasCacheMock, cacheObject } = makeMockCache('hasCache', true);
-      const { deleteRoleById } = makeSut();
-      jest
-        .spyOn(cacheObject, 'getCache')
-        .mockImplementationOnce(() => JSON.stringify([{ role: 'role', _id: '1' }]));
-      jest.spyOn(Role, 'findById').mockResolvedValue(mockRole);
-      jest.spyOn(cacheObject, 'setCache').mockImplementationOnce(() => {});
-      jest.spyOn(cacheObject, 'removeCache').mockImplementationOnce(() => {});
-      jest.spyOn(UserProfile, 'updateMany').mockResolvedValue();
+      jest.spyOn(Role, 'findById').mockResolvedValue(null); // No role found
 
+      const { deleteRoleById } = makeSut();
       const response = await deleteRoleById(mockReq, mockRes);
-      expect(mockRole.remove).toHaveBeenCalled();
-      expect(hasCacheMock).toHaveBeenCalledWith('allusers');
-      expect(cacheObject.getCache).toHaveBeenCalledWith('allusers');
-      expect(cacheObject.setCache).toHaveBeenCalled();
-      expect(cacheObject.removeCache).toHaveBeenCalled();
-      assertResMock(200, { message: 'Deleted role' }, response, mockRes);
+
+      assertResMock(404, { error: 'Role not found' }, response, mockRes);
+    });
+
+    describe('deleteRoleById function', () => {
+      test('Should return 403 if user lacks permission', async () => {
+        const { deleteRoleById } = makeSut();
+
+        const hasPermissionSpy = mockHasPermission(false);
+        const response = await deleteRoleById(mockReq, mockRes);
+
+        expect(hasPermissionSpy).toHaveBeenCalledWith(mockReq.body.requestor, 'deleteRole');
+        assertResMock(403, 'You are not authorized to delete roles.', response, mockRes);
+      });
+
+      test('Should return 404 if role does not exist', async () => {
+        mockHasPermission(true);
+
+        jest.spyOn(Role, 'findById').mockResolvedValue(null); // No role found
+
+        const { deleteRoleById } = makeSut();
+        const response = await deleteRoleById(mockReq, mockRes);
+
+        assertResMock(404, { error: 'Role not found' }, response, mockRes);
+      });
+
+      test('Should return 200 and update users after deleting role', async () => {
+        mockHasPermission(true);
+
+        // --- Setup mock request ---
+        mockReq.params = { roleId: '12345' };
+
+        // --- Mock role returned by Role.findById ---
+        const mockRole = { _id: '12345', roleName: 'role' };
+
+        // Spy on Role methods
+        jest.spyOn(Role, 'findById').mockResolvedValue(mockRole);
+        jest.spyOn(Role, 'deleteOne').mockResolvedValue({ deletedCount: 1 });
+
+        // Spy on UserProfile.updateMany
+        const updateManySpy = jest
+          .spyOn(UserProfile, 'updateMany')
+          .mockResolvedValue({ modifiedCount: 2 });
+
+        const { deleteRoleById } = makeSut();
+        const response = await deleteRoleById(mockReq, mockRes);
+
+        // --- Debugging log ---
+        console.log('UpdateMany mock calls:', updateManySpy.mock.calls);
+
+        // Verify updateMany was called exactly once with correct args
+        expect(updateManySpy).toHaveBeenCalledTimes(1);
+        expect(updateManySpy).toHaveBeenCalledWith(
+          { role: 'role' },
+          { $set: { role: 'Volunteer' } },
+        );
+
+        // Verify role deletion
+        expect(Role.deleteOne).toHaveBeenCalledWith({ _id: '12345' });
+
+        // Verify response
+        assertResMock(
+          200,
+          { message: 'Deleted role "role" and reassigned affected users to Volunteer' },
+          response,
+          mockRes,
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
# Description
This PR adds functionality to ensure that when a role is deleted, all users who have that role are automatically reassigned to the default "Volunteer" role.

## Related PRS (if any):
None

## Main changes explained:
- `rolesController.js`
-- Added logic to validate role existence before deleting.
-- Bulk update all users currently assigned to the deleted role, setting their role to "Volunteer".
-- Update in-memory cache (allusers and individual user caches) to reflect the change.
-- Improved error handling and added meaningful logging for visibility.

## How to test:
1. Check into current branch
2. Do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. Login as a user with access to create a new role.
5. Other Links > Permissions Management > Add New Role
6. Change the role of any user to this or create any users and assign them the newly created role.
7. Other Links > Permissions Management > Click on the newly created role > Delete Role
8. Verify that the users assigned the new role have been updated and assigned the 'Volunteer' role.