### PR TITLE
Deep - Fix - Volunteer status pie chart

### DIFF
--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -87,6 +87,7 @@ const reportsController = function () {
     try {
       const [
         volunteerNumberStats,
+        mentorNumberStats,
         volunteerHoursStats,
         totalHoursWorked,
         tasksStats,
@@ -105,6 +106,12 @@ const reportsController = function () {
         totalSummariesSubmitted,
       ] = await Promise.all([
         overviewReportHelper.getVolunteerNumberStats(
+          isoStartDate,
+          isoEndDate,
+          isoComparisonStartDate,
+          isoComparisonEndDate,
+        ),
+        overviewReportHelper.getMentorNumberStats(
           isoStartDate,
           isoEndDate,
           isoComparisonStartDate,
@@ -184,6 +191,7 @@ const reportsController = function () {
       ]);
       res.status(200).send({
         volunteerNumberStats,
+        mentorNumberStats,
         volunteerHoursStats,
         totalHoursWorked,
         tasksStats,

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -1321,6 +1321,129 @@ const overviewReportHelper = function () {
   };
 
   /**
+   * returns mentor counts for the provided date range
+   * mirrors volunteer stats but filters strictly on Mentor role
+   * @param {Date} startDate
+   * @param {Date} endDate
+   * @param {Date} comparisonStartDate
+   * @param {Date} comparisonEndDate
+   */
+  const getMentorNumberStats = async (
+    startDate,
+    endDate,
+    comparisonStartDate,
+    comparisonEndDate,
+  ) => {
+    const getMentorData = async (isoStartDate, isoEndDate) => {
+      const data = await UserProfile.aggregate([
+        {
+          $facet: {
+            activeMentors: [
+              {
+                $match: {
+                  isActive: true,
+                  role: 'Mentor',
+                  createdDate: { $lte: isoEndDate },
+                },
+              },
+              { $count: 'count' },
+            ],
+            newMentors: [
+              {
+                $match: {
+                  role: 'Mentor',
+                  createdDate: {
+                    $gte: isoStartDate,
+                    $lte: isoEndDate,
+                  },
+                },
+              },
+              { $count: 'count' },
+            ],
+            deactivatedMentors: [
+              {
+                $match: {
+                  $and: [
+                    { lastModifiedDate: { $gte: isoStartDate } },
+                    { lastModifiedDate: { $lte: isoEndDate } },
+                    { isActive: false },
+                    { role: 'Mentor' },
+                  ],
+                },
+              },
+              { $count: 'count' },
+            ],
+          },
+        },
+      ]);
+
+      const activeMentors = data[0].activeMentors[0]?.count || 0;
+      const newMentors = data[0].newMentors[0]?.count || 0;
+      const deactivatedMentors = data[0].deactivatedMentors[0]?.count || 0;
+      const totalMentors = activeMentors + newMentors + deactivatedMentors;
+
+      return {
+        activeMentors,
+        newMentors,
+        deactivatedMentors,
+        totalMentors,
+      };
+    };
+
+    const {
+      activeMentors: currentActiveMentors,
+      newMentors: currentNewMentors,
+      deactivatedMentors: currentDeactivatedMentors,
+      totalMentors: currentTotalMentors,
+    } = await getMentorData(startDate, endDate);
+
+    const mentorStats = {
+      activeMentors: {
+        count: currentActiveMentors,
+        percentageOutOfTotal: Math.round((currentActiveMentors / currentTotalMentors) * 100) / 100,
+      },
+      newMentors: {
+        count: currentNewMentors,
+        percentageOutOfTotal: Math.round((currentNewMentors / currentTotalMentors) * 100) / 100,
+      },
+      deactivatedMentors: {
+        count: currentDeactivatedMentors,
+        percentageOutOfTotal:
+          Math.round((currentDeactivatedMentors / currentTotalMentors) * 100) / 100,
+      },
+      totalMentors: { count: currentTotalMentors },
+    };
+
+    if (comparisonStartDate && comparisonEndDate) {
+      const {
+        activeMentors: comparisonActiveMentors,
+        newMentors: comparisonNewMentors,
+        deactivatedMentors: comparisonDeactivatedMentors,
+        totalMentors: comparisonTotalMentors,
+      } = await getMentorData(comparisonStartDate, comparisonEndDate);
+
+      mentorStats.activeMentors.comparisonPercentage = calculateGrowthPercentage(
+        currentActiveMentors,
+        comparisonActiveMentors,
+      );
+      mentorStats.newMentors.comparisonPercentage = calculateGrowthPercentage(
+        currentNewMentors,
+        comparisonNewMentors,
+      );
+      mentorStats.deactivatedMentors.comparisonPercentage = calculateGrowthPercentage(
+        currentDeactivatedMentors,
+        comparisonDeactivatedMentors,
+      );
+      mentorStats.totalMentors.comparisonPercentage = calculateGrowthPercentage(
+        currentTotalMentors,
+        comparisonTotalMentors,
+      );
+    }
+
+    return mentorStats;
+  };
+
+  /**
    *
    * @returns The number of teams with 4 or more members.
    */
@@ -2004,6 +2127,7 @@ const overviewReportHelper = function () {
     getAnniversaries,
     getRoleDistributionStats,
     getVolunteerNumberStats,
+    getMentorNumberStats,
     getTasksStats,
     getWorkDistributionStats,
     getTotalHoursWorked,


### PR DESCRIPTION
# Description
Added a new pie chart to show `Total Mentors` next to `Total Volunteer` pie chart

<img width="689" height="521" alt="Screenshot 2025-09-27 at 23 25 34" src="https://github.com/user-attachments/assets/22592976-ad0b-4790-964d-96ba76fb910d" />


## Related PRS (if any):
To test this backend PR you need to checkout the #XXX frontend PR.
…

## Main changes explained:
- Added mentor statistics to the existing volunteer analytics flow: `getVolunteerStatsData` now calls a new helper for mentor counts and returns a `mentorNumberStats` block alongside the volunteer numbers (reportsController.js).
- Built `getMentorNumberStats` in `overviewReportHelper.js`; it mirrors the volunteer aggregation but filters role: 'Mentor', counting Active/New/Deactivated mentors and computing percentages plus optional comparison deltas.
- Exposed `getMentorNumberStats` in the helper’s export so other code can consume the same mentor breakdown whenever needed.


## How to test:

1. Check into `deep-fix-volunteer-status-pie-chart` branch.
2. Check into `deep-fix-volunteer-status-pie-chart` branch in frontend and run it to test.
3. Run npm install, npm run build, and npm run start to run this PR locally.
4. Clear site data/cache.
5. Log in as Admin user.
6. Go to dashboard→ Reports→ Total Org Summary
7. Verify if the Total Mentors Chart is properly loaded or not. 
8. Verify the count is changing as per date filters.

## Screenshots or videos of changes:

Before:

https://github.com/user-attachments/assets/784a38e6-100a-4187-96e8-4d295e6d16c1

After:

https://github.com/user-attachments/assets/463f25ac-2d71-4b23-821e-706948566802

