### PR TITLE
Xinyi - fix: return volunteer anniversaries data with createdDate field

### DIFF
--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -504,6 +504,7 @@ const overviewReportHelper = function () {
             firstName: 1,
             lastName: 1,
             email: 1,
+            createdDate: 1,
             profilePic: { $ifNull: ['$profilePic', null] },
           },
         },


### PR DESCRIPTION
# Description
<img width="548" height="443" alt="image" src="https://github.com/user-attachments/assets/0322ea89-639c-491b-b987-eff5b8b65a2a" />


## Related PRS (if any):
To test this backend PR you need to checkout the [#4153](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4153) frontend PR.

## Main changes explained:
- Update file src/helpers/overviewReportHelper.js for including createdDate in the return value.

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ reports→ Total Org Symmary → Anniversary Celebrated
6. verify that the search function filters users correctly and the export button generates the expected data file
7. verify that each user’s start date aligns correctly with the displayed anniversary award (e.g., 6-month or 1-year)

## Screenshots or videos of changes:
before: 
<img width="564" height="555" alt="image" src="https://github.com/user-attachments/assets/c1f90487-06c6-42d8-97c5-1ec5af7243aa" />
after:
<img width="588" height="628" alt="image" src="https://github.com/user-attachments/assets/1d2801fb-b0cf-4737-afcb-3f217968eb7d" />
