### PR TITLE
Aditya - fix: Volunteer Hours Distribution Pie Chart Data Categorization Bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,14 +92,14 @@
       }
     },
     "node_modules/@apimatic/authentication-adapters": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/@apimatic/authentication-adapters/-/authentication-adapters-0.5.12.tgz",
-      "integrity": "sha512-H0dVMsuiPRRS6qPSz42T8ktaOUBlvJgKSj5L+DKr4DwBEZaE6rZx4i5kuEdAUZ5oIuteupbGEx5hMJlPi6Y0XA==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/@apimatic/authentication-adapters/-/authentication-adapters-0.5.13.tgz",
+      "integrity": "sha512-lZ7q5ctiIBm/A6W6vvdfFbttJwcHDLOBmJhGm9BJ8TEg4Rfz92QJ0X4NuUF7x79dsmCHnl5vECox7t6S71xPpA==",
       "license": "MIT",
       "dependencies": {
-        "@apimatic/core-interfaces": "^0.2.12",
-        "@apimatic/http-headers": "^0.3.7",
-        "@apimatic/http-query": "^0.3.7",
+        "@apimatic/core-interfaces": "^0.2.13",
+        "@apimatic/http-headers": "^0.3.8",
+        "@apimatic/http-query": "^0.3.8",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -107,18 +107,18 @@
       }
     },
     "node_modules/@apimatic/axios-client-adapter": {
-      "version": "0.3.18",
-      "resolved": "https://registry.npmjs.org/@apimatic/axios-client-adapter/-/axios-client-adapter-0.3.18.tgz",
-      "integrity": "sha512-4DX6PgMT3VyACsf+EA3IxPrJzE1Schnwm+EGoCDZ8oAt7WYf3nByH1nKbmRVLEw7TGp4ZNU9slUHmdiJZ7FM6A==",
+      "version": "0.3.19",
+      "resolved": "https://registry.npmjs.org/@apimatic/axios-client-adapter/-/axios-client-adapter-0.3.19.tgz",
+      "integrity": "sha512-PRFDQZQAkPqe5yz6ppzdx7LARoxq3ae1bb1RrC7E9cVKh0hMZ1vk1s+gAtLphxp6dU6hFN2UTkrJoAh56zvxtQ==",
       "license": "MIT",
       "dependencies": {
-        "@apimatic/convert-to-stream": "^0.1.7",
-        "@apimatic/core-interfaces": "^0.2.12",
-        "@apimatic/file-wrapper": "^0.3.7",
-        "@apimatic/http-headers": "^0.3.7",
-        "@apimatic/http-query": "^0.3.7",
+        "@apimatic/convert-to-stream": "^0.1.8",
+        "@apimatic/core-interfaces": "^0.2.13",
+        "@apimatic/file-wrapper": "^0.3.8",
+        "@apimatic/http-headers": "^0.3.8",
+        "@apimatic/http-query": "^0.3.8",
         "@apimatic/json-bigint": "^1.2.0",
-        "@apimatic/proxy": "^0.1.2",
+        "@apimatic/proxy": "^0.1.3",
         "axios": "^1.8.4",
         "detect-browser": "^5.3.0",
         "detect-node": "^2.1.0",
@@ -132,9 +132,9 @@
       }
     },
     "node_modules/@apimatic/convert-to-stream": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@apimatic/convert-to-stream/-/convert-to-stream-0.1.7.tgz",
-      "integrity": "sha512-uOCSy8YV0umHI4422l6wXcY/CN/oplLgoitpOY+P52I8dSrkQK+P+8HCITLDW4ND1I5OvRfvb1OwvN4+1JdgvA==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@apimatic/convert-to-stream/-/convert-to-stream-0.1.8.tgz",
+      "integrity": "sha512-A4VO/wyGFksKtizp4aUOGGtSlejoVI1uAXLGPVymhfpion3wUwrlST/yif9SOj3faVAGeCTNx0w5A+BpVdzSEA==",
       "license": "ISC",
       "dependencies": {
         "tslib": "2.8.1"
@@ -144,18 +144,18 @@
       }
     },
     "node_modules/@apimatic/core": {
-      "version": "0.10.26",
-      "resolved": "https://registry.npmjs.org/@apimatic/core/-/core-0.10.26.tgz",
-      "integrity": "sha512-wml7KNNP3P8BXXI2bOXyuMugQpLZ1MpOl6EM40nSOCXmR4lTr1ssfoUi+LrK1n7o6JxLoYp9mGkMNHoR7n35Tw==",
+      "version": "0.10.27",
+      "resolved": "https://registry.npmjs.org/@apimatic/core/-/core-0.10.27.tgz",
+      "integrity": "sha512-LnoAT3I51uUCvcCt9IiCxDjoGzt/qnGnLEHafvOIuLdrNquLj3A+TNmodiRlSqD8cz1PcMFPkUctzwDmNybPpg==",
       "license": "MIT",
       "dependencies": {
-        "@apimatic/convert-to-stream": "^0.1.7",
-        "@apimatic/core-interfaces": "^0.2.12",
-        "@apimatic/file-wrapper": "^0.3.7",
-        "@apimatic/http-headers": "^0.3.7",
-        "@apimatic/http-query": "^0.3.7",
+        "@apimatic/convert-to-stream": "^0.1.8",
+        "@apimatic/core-interfaces": "^0.2.13",
+        "@apimatic/file-wrapper": "^0.3.8",
+        "@apimatic/http-headers": "^0.3.8",
+        "@apimatic/http-query": "^0.3.8",
         "@apimatic/json-bigint": "^1.2.0",
-        "@apimatic/schema": "^0.7.20",
+        "@apimatic/schema": "^0.7.21",
         "detect-browser": "^5.3.0",
         "detect-node": "^2.1.0",
         "form-data": "^4.0.1",
@@ -169,12 +169,12 @@
       }
     },
     "node_modules/@apimatic/core-interfaces": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/@apimatic/core-interfaces/-/core-interfaces-0.2.12.tgz",
-      "integrity": "sha512-XdEbSEfLEUY6KvKWQVXGMMGQmt589Zj0MnssPZ7FdgWFCrqe4aNgYt2Fl/fOC9r64GZvd7o1T9m4HKFilXi4nw==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@apimatic/core-interfaces/-/core-interfaces-0.2.13.tgz",
+      "integrity": "sha512-qta5qpu0c3ef+W3bPbXmrxFXG+zCIiEB1LuICZuUgXRvmomd/e7wTrEbromE7ow/wmqRfVvaOpYZ1alLtnyG+g==",
       "license": "MIT",
       "dependencies": {
-        "@apimatic/file-wrapper": "^0.3.7",
+        "@apimatic/file-wrapper": "^0.3.8",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -182,9 +182,9 @@
       }
     },
     "node_modules/@apimatic/file-wrapper": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@apimatic/file-wrapper/-/file-wrapper-0.3.7.tgz",
-      "integrity": "sha512-uJh2immpzZiZYOiG+Q9qtArg3bUk7lmx7eYFRI38wIOS2zlxQh90WkuJzaL2nvSmNsJ3p+yg5ePAyRpqoJmw7Q==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@apimatic/file-wrapper/-/file-wrapper-0.3.8.tgz",
+      "integrity": "sha512-3l/xLLEeVW8POr0f7fHXI2s7aSPBNCQROGmdOmMYhq1e4Va3PSFWx7lhaEEk9goTYGYf9nTQgr2euJ5Vl7VJ4g==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -194,9 +194,9 @@
       }
     },
     "node_modules/@apimatic/http-headers": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@apimatic/http-headers/-/http-headers-0.3.7.tgz",
-      "integrity": "sha512-DxLmwDMnAT5sOiuYI7EIuQq2PAVhbV9ICDLSdICRFflklgfKQ9agVEyNRgYVhuXz1m7IDoqqjGb1hs6iMJJpEg==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@apimatic/http-headers/-/http-headers-0.3.8.tgz",
+      "integrity": "sha512-ShvCuT39hYfBTI+H1I16m5i6XZCyUy2kQJ6Jhfj78TwsW5r6AyCbzW7DEro8GN2nNYRU1+E/hrgH6J85YmriOA==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -206,12 +206,12 @@
       }
     },
     "node_modules/@apimatic/http-query": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@apimatic/http-query/-/http-query-0.3.7.tgz",
-      "integrity": "sha512-HauS4Jsuve1tGy1pnAidjHNL/TFVLesOxL7QtOdZyb+s0EHiHF6Vhx/kNroJ4mH/yCN3OHcHcqMJlfg0V5ET9g==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@apimatic/http-query/-/http-query-0.3.8.tgz",
+      "integrity": "sha512-5dM3zVPfMYp7Q4LHIQXpyicxPeCGk46tDfathetx547VuPCHz0M7mhp/M7zFAcTEiCQl+pPktiGBSO/vLSgWzQ==",
       "license": "MIT",
       "dependencies": {
-        "@apimatic/file-wrapper": "^0.3.7",
+        "@apimatic/file-wrapper": "^0.3.8",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -225,14 +225,14 @@
       "license": "MIT"
     },
     "node_modules/@apimatic/oauth-adapters": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/@apimatic/oauth-adapters/-/oauth-adapters-0.4.16.tgz",
-      "integrity": "sha512-rmFj32QRbRhCkhBf50Wz0VdVghw58FiJPIl9ICWhpbgP9MuBg7xnSpbdHBflqjGRFyS9rtOTJOzCQnUl76F3oQ==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/@apimatic/oauth-adapters/-/oauth-adapters-0.4.17.tgz",
+      "integrity": "sha512-cIe1dZwcNizydZUX9Q4qBVCgTCKPSTTTz6UJKTd3xyOSsAleLyPBK+AZ/D0M7ZcU60QCc+QTYMEztZnK9KksKQ==",
       "license": "MIT",
       "dependencies": {
-        "@apimatic/core-interfaces": "^0.2.12",
-        "@apimatic/file-wrapper": "^0.3.7",
-        "@apimatic/http-headers": "^0.3.7",
+        "@apimatic/core-interfaces": "^0.2.13",
+        "@apimatic/file-wrapper": "^0.3.8",
+        "@apimatic/http-headers": "^0.3.8",
         "tslib": "^2.8.1"
       },
       "engines": {
@@ -240,9 +240,9 @@
       }
     },
     "node_modules/@apimatic/proxy": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/@apimatic/proxy/-/proxy-0.1.2.tgz",
-      "integrity": "sha512-Xo3PO69tos+ssAfjcBGxSxXu1jpdEwse+yYnWC8D8bCsuWKUVJh8TwWl01Zyw3s60FdikyGCGtiQ3LB2cBrbeg==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@apimatic/proxy/-/proxy-0.1.3.tgz",
+      "integrity": "sha512-2UQmmbhOxAXHgbkl6WzGiVLG96ubw7udUsm0cv3jqiCLUyC+c15NgC64pJ+jeYHpZm3BtsLG01rMA+dBdHsxYQ==",
       "license": "ISC",
       "dependencies": {
         "http-proxy-agent": "^7.0.2",
@@ -253,9 +253,9 @@
       }
     },
     "node_modules/@apimatic/schema": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/@apimatic/schema/-/schema-0.7.20.tgz",
-      "integrity": "sha512-kMU1LqCypb0AwY8nXLV0aBoyubHHAxD8htyeAMFLYqWmmt+1pUBe33hHIDMdkREkNm+AYpl2n6vHBC1kqgju1w==",
+      "version": "0.7.21",
+      "resolved": "https://registry.npmjs.org/@apimatic/schema/-/schema-0.7.21.tgz",
+      "integrity": "sha512-RCke4toXjA7fBRxQVa1GR+Lj9utVOEJ3voDI26dhk+bZuAac4UXPzkTEaIO3AIe/o8pcKCOkpNIzhzm57Cv2Qg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"
@@ -4640,9 +4640,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.7",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.7.tgz",
-      "integrity": "sha512-bxxN2M3a4d1CRoQC//IqsR5XrLh0IJ8TCv2x6Y9N0nckNz/rTjZB3//GGscZziZOxmjP55rzxg/ze7usFI9FqQ==",
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.10.tgz",
+      "integrity": "sha512-uLfgBi+7IBNay8ECBO2mVMGZAc1VgZWEChxm4lv+TobGdG82LnXMjuNGo/BSSZZL4UmkWhxEHP2f5ziLNwGWMA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -4797,9 +4797,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.26.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
-      "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
+      "version": "4.26.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
+      "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
       "funding": [
         {
           "type": "opencollective",
@@ -4816,9 +4816,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.8.3",
-        "caniuse-lite": "^1.0.30001741",
-        "electron-to-chromium": "^1.5.218",
+        "baseline-browser-mapping": "^2.8.9",
+        "caniuse-lite": "^1.0.30001746",
+        "electron-to-chromium": "^1.5.227",
         "node-releases": "^2.0.21",
         "update-browserslist-db": "^1.1.3"
       },
@@ -4983,9 +4983,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001745",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001745.tgz",
-      "integrity": "sha512-ywt6i8FzvdgrrrGbr1jZVObnVv6adj+0if2/omv9cmR2oiZs30zL4DIyaptKcbOrBdOIc74QTMoJvSE2QHh5UQ==",
+      "version": "1.0.30001746",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001746.tgz",
+      "integrity": "sha512-eA7Ys/DGw+pnkWWSE/id29f2IcPHVoE8wxtvE5JdvD2V28VTDPy1yEeo11Guz0sJ4ZeGRcm3uaTcAqK1LXaphA==",
       "funding": [
         {
           "type": "opencollective",
@@ -5947,9 +5947,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.224",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.224.tgz",
-      "integrity": "sha512-kWAoUu/bwzvnhpdZSIc6KUyvkI1rbRXMT0Eq8pKReyOyaPZcctMli+EgvcN1PAvwVc7Tdo4Fxi2PsLNDU05mdg==",
+      "version": "1.5.229",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.229.tgz",
+      "integrity": "sha512-cwhDcZKGcT/rEthLRJ9eBlMDkh1sorgsuk+6dpsehV0g9CABsIqBxU4rLRjG+d/U6pYU1s37A4lSKrVc5lSQYg==",
       "license": "ISC"
     },
     "node_modules/emittery": {
@@ -6021,12 +6021,12 @@
       }
     },
     "node_modules/engine.io/node_modules/@types/node": {
-      "version": "24.5.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
-      "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
+      "version": "24.6.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.2.tgz",
+      "integrity": "sha512-d2L25Y4j+W3ZlNAeMKcy7yDsK425ibcAOO2t7aPTz6gNMH0z2GThtwENCDc0d/Pw9wgyRqE5Px1wkV7naz8ang==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.12.0"
+        "undici-types": "~7.13.0"
       }
     },
     "node_modules/engine.io/node_modules/cookie": {
@@ -7462,6 +7462,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/generic-pool": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
@@ -8349,13 +8358,14 @@
       }
     },
     "node_modules/is-generator-function": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-      "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
       "license": "MIT",
       "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.0",
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
         "has-tostringtag": "^1.0.2",
         "safe-regex-test": "^1.1.0"
       },
@@ -13826,9 +13836,9 @@
       "license": "0BSD"
     },
     "node_modules/twilio": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/twilio/-/twilio-5.10.1.tgz",
-      "integrity": "sha512-J7+gPQggonXqc1GrkctxlHI8F6LYBAvVy6d8t2SOZ6HI3FpR9EHOcKBj7E+JYjigPKxYZeiiTDAyLpJsipbx2A==",
+      "version": "5.10.2",
+      "resolved": "https://registry.npmjs.org/twilio/-/twilio-5.10.2.tgz",
+      "integrity": "sha512-pkMdXK0PJHR0elu3GmaDlYt4DDWPkkmuJLVUQjnctehu01IgbAp+VZ2ctbUSh1anDuqKqimAIuMnW9xmKith6w==",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.12.0",
@@ -14023,9 +14033,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.12.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
-      "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
+      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -183,7 +183,7 @@ const reportsController = function () {
         ),
       ]);
 
-      // Check for validation errors in pie chart functions
+      // Check for validation errors in functions that use date parameters
       if (volunteerHoursStats && volunteerHoursStats.error) {
         console.log('Date validation error in volunteerHoursStats:', volunteerHoursStats.error);
         return res.status(400).json({
@@ -196,6 +196,14 @@ const reportsController = function () {
         console.log('Date validation error in workDistributionStats:', workDistributionStats.error);
         return res.status(400).json({
           msg: workDistributionStats.error,
+          error: 'Invalid date parameters',
+        });
+      }
+
+      if (totalHoursWorked && totalHoursWorked.error) {
+        console.log('Date validation error in totalHoursWorked:', totalHoursWorked.error);
+        return res.status(400).json({
+          msg: totalHoursWorked.error,
           error: 'Invalid date parameters',
         });
       }

--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -73,16 +73,65 @@ const reportsController = function () {
       return res.status(400).send({ msg: 'Please provide a start and end date' });
     }
 
-    let isoComparisonStartDate;
-    let isoComparisonEndDate;
+    // Validate date format and validity
+    const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
 
-    if (comparisonStartDate && comparisonEndDate) {
-      isoComparisonStartDate = new Date(comparisonStartDate);
-      isoComparisonEndDate = new Date(comparisonEndDate);
+    if (!dateRegex.test(startDate)) {
+      return res.status(400).send({
+        msg: 'Invalid startDate format. Please use YYYY-MM-DD format',
+        error: 'Invalid date parameters',
+      });
+    }
+
+    if (!dateRegex.test(endDate)) {
+      return res.status(400).send({
+        msg: 'Invalid endDate format. Please use YYYY-MM-DD format',
+        error: 'Invalid date parameters',
+      });
     }
 
     const isoStartDate = new Date(`${startDate}T00:00:00-07:00`);
     const isoEndDate = new Date(`${endDate}T23:59:00-07:00`);
+
+    // Check if dates are valid
+    if (Number.isNaN(isoStartDate.getTime())) {
+      return res.status(400).send({
+        msg: 'Invalid startDate. Please provide a valid date',
+        error: 'Invalid date parameters',
+      });
+    }
+
+    if (Number.isNaN(isoEndDate.getTime())) {
+      return res.status(400).send({
+        msg: 'Invalid endDate. Please provide a valid date',
+        error: 'Invalid date parameters',
+      });
+    }
+
+    let isoComparisonStartDate;
+    let isoComparisonEndDate;
+
+    if (comparisonStartDate && comparisonEndDate) {
+      if (!dateRegex.test(comparisonStartDate) || !dateRegex.test(comparisonEndDate)) {
+        return res.status(400).send({
+          msg: 'Invalid comparison date format. Please use YYYY-MM-DD format',
+          error: 'Invalid date parameters',
+        });
+      }
+
+      isoComparisonStartDate = new Date(comparisonStartDate);
+      isoComparisonEndDate = new Date(comparisonEndDate);
+
+      if (
+        Number.isNaN(isoComparisonStartDate.getTime()) ||
+        Number.isNaN(isoComparisonEndDate.getTime())
+      ) {
+        return res.status(400).send({
+          msg: 'Invalid comparison dates. Please provide valid dates',
+          error: 'Invalid date parameters',
+        });
+      }
+    }
 
     try {
       const [

--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -182,6 +182,24 @@ const reportsController = function () {
           isoComparisonEndDate,
         ),
       ]);
+
+      // Check for validation errors in pie chart functions
+      if (volunteerHoursStats && volunteerHoursStats.error) {
+        console.log('Date validation error in volunteerHoursStats:', volunteerHoursStats.error);
+        return res.status(400).json({
+          msg: volunteerHoursStats.error,
+          error: 'Invalid date parameters',
+        });
+      }
+
+      if (workDistributionStats && workDistributionStats.error) {
+        console.log('Date validation error in workDistributionStats:', workDistributionStats.error);
+        return res.status(400).json({
+          msg: workDistributionStats.error,
+          error: 'Invalid date parameters',
+        });
+      }
+
       res.status(200).send({
         volunteerNumberStats,
         volunteerHoursStats,
@@ -356,10 +374,20 @@ const reportsController = function () {
         lastWeekStartDate,
         lastWeekEndDate,
       );
+
+      // Check if the helper function returned an error
+      if (volunteerHoursStats && volunteerHoursStats.error) {
+        console.log('Date validation error:', volunteerHoursStats.error);
+        return res.status(400).json({
+          msg: volunteerHoursStats.error,
+          error: 'Invalid date parameters',
+        });
+      }
+
       res.status(200).json(volunteerHoursStats);
     } catch (error) {
       console.log(error);
-      res.status(404).send(error);
+      res.status(500).json({ msg: 'Error occurred while fetching data. Please try again!' });
     }
   };
 

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -1328,6 +1328,17 @@ const overviewReportHelper = function () {
    * Aggregates total number of hours worked across all volunteers within the specified date range
    */
   async function getTotalHoursWorked(startDate, endDate, comparisonStartDate, comparisonEndDate) {
+    // Validate date parameters
+    const validation = validateDateParameters(
+      startDate,
+      endDate,
+      comparisonStartDate,
+      comparisonEndDate,
+    );
+    if (!validation.isValid) {
+      return { error: validation.error };
+    }
+
     if (!comparisonStartDate && !comparisonEndDate) {
       const data = await TimeEntries.aggregate([
         {
@@ -1352,7 +1363,7 @@ const overviewReportHelper = function () {
         },
       ]);
 
-      return { current: data[0].totalHours };
+      return { current: data[0]?.totalHours || 0 };
     }
     const data = await TimeEntries.aggregate([
       {


### PR DESCRIPTION
# Description

**Bug Description:** Critical bug in Volunteer Hours Distribution Pie Chart Data Categorization in Total Org Summary reports. The MongoDB $bucket aggregation with `default: 40` setting incorrectly categorized volunteers with 0-9 hours into the "40+" bucket due to boundaries starting at [10, 20, 30, 35, 40]. For short time periods, most volunteers work 0-9 hours, so they all appeared as "40+ Hours" users.

**Root Cause:** The original implementation used MongoDB's $bucket aggregation with boundaries [10, 20, 30, 35, 40] and `default: 40`, which meant any value below 10 (including 0-9.99 hours) was placed in the default bucket labeled as "40+". This created misleading data where low-hour volunteers appeared as high-hour contributors.

![[HGN/Features-Bugs/Bugs/Backend/New PR/Images/IssueDescription.png]]

## Related PRS (if any):
No related frontend PRs are required as this is a data calculation fix.

## Main changes explained:

**Update file `src/helpers/overviewReportHelper.js` for complete volunteer hours distribution logic overhaul:**
- **Add `validateDateParameters()` function** - Comprehensive date validation with proper error messages for all date inputs
- **Replace `getHoursStats()` function** - Complete rewrite to calculate weekly averages instead of total accumulated hours
- **Add `getUserHoursData()` helper function** - Extracts user-level hours data for internal calculations
- **Add `shouldCountWeek()` helper function** - Implements 4+ days rule for week counting (Sunday to Saturday)
- **Add `assignToBucket()` helper function** - Proper bucket assignment logic for weekly averages
- **Update bucket structure** - Changed from ranges (10-19.99, 20-29.99, etc.) to single values (10, 20, 30, 40, 40+)
- **Implement weekly average calculation** - Only counts weeks where users actually logged time
- **Add current week exception** - Current week always counts regardless of days in range
- **Filter users properly** - Only include users with time entries in the specified date range

**Update file `src/controllers/reportsController.js` for enhanced error handling:**
- **Add comprehensive date validation** - Regex validation for YYYY-MM-DD format and proper date object validation
- **Add error handling for helper functions** - Check for validation errors from `overviewReportHelper` functions
- **Improve error responses** - Better error messages and proper HTTP status codes
- **Add null safety checks** - Handle cases where aggregation results might be null/undefined

## How to test:
1. Check into current branch: `git checkout Aditya-fix/Volunteer-Hours-Distribution-Pie-Chart-Data-Categorization`
2. Clean node_modules and package-lock.json: `rm -rf node_modules package-lock.json`
3. Test the endpoint for happy paths and edge cases: `http://localhost:4500/api/reports/volunteerstats`
4. Go to frontend development branch, ensure `REACT_APP_APIENDPOINT="http://localhost:4500/api"`.
5. Run `npm install` to install dependencies, then run the app locally (`npm start`)
6. Clear site data/cache in browser
7. Log in as owner user
8. Navigate to **Reports>Total Org Summary>Volunteer Hours Distribution**.
9. Select a **short time period** (e.g., last 2 weeks)
10. **Verify the Volunteer Hours Distribution Pie Chart:**
    - Users with 0-9 hours should now appear in the "10" bucket (not "40+")
    - Users with 10-19 hours should appear in the "20" bucket
    - Users with 20-29 hours should appear in the "30" bucket
    - Users with 30-39 hours should appear in the "40" bucket
    - Users with 40+ hours should appear in the "40+" bucket
8. **Test with different date ranges:**
    - Test with very short periods (1-2 weeks) - should show proper distribution
    - Test with longer periods (1-3 months) - should show meaningful weekly averages
    - Test with invalid dates - should show proper error messages
9. **Verify error handling:**
    - Try invalid date formats (e.g., "2024-13-01") - should return 400 error
    - Try start date after end date - should return 400 error
    - Try missing dates - should return 400 error

## Screenshots or videos of changes:
**Before Fix:** All volunteers with 0-9 hours appeared in "40+ Hours" bucket, making the chart misleading and useless for short time periods.
![[BeforeImage.png]]
**After Fix:** Proper distribution showing volunteers correctly categorized based on their weekly average hours worked, with meaningful data for both short and long time periods.
![[AfterImage.png]]
**Test Video:**
![[HGN/Features-Bugs/Bugs/Backend/New PR/Images/TestVideo.mov|TestVideo]]
## Note:
- The new implementation is more computationally intensive as it calculates weekly averages, but provides accurate and meaningful data
- The API response format remains the same, only the calculation logic has changed
- Implements the 4+ days rule where a week is only counted if 4 or more days fall within the report period (exception: current week always counts)