### PR TITLE
Deep Fix(totalOrgSummary): update In Team/Not In team queries

### DIFF
--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -708,14 +708,34 @@ const overviewReportHelper = function () {
   async function getTeamMembersCount(isoEndDate, isoComparisonEndDate) {
     // Gets counts for total members and members in team within a given time range
     const getData = async (endDate) => {
-      const [data] = await UserProfile.aggregate([
-        {
-          $match: {
-            isActive: true,
+      const baseFilters = {
+        isActive: true,
+        weeklycommittedHours: {
+          $gte: 1,
+        },
+        role: {
+          $ne: 'Mentor',
+        },
+      };
+
+      if (endDate) {
+        baseFilters.$or = [
+          {
+            createdDate: {
+              $exists: false,
+            },
+          },
+          {
             createdDate: {
               $lte: endDate,
             },
           },
+        ];
+      }
+
+      const [data] = await UserProfile.aggregate([
+        {
+          $match: baseFilters,
         },
         {
           $facet: {
@@ -729,7 +749,16 @@ const overviewReportHelper = function () {
                 $match: {
                   teams: {
                     $exists: true,
-                    $ne: [],
+                  },
+                  $expr: {
+                    $gt: [
+                      {
+                        $size: {
+                          $ifNull: ['$teams', []],
+                        },
+                      },
+                      0,
+                    ],
                   },
                 },
               },


### PR DESCRIPTION
# Description

Updated the queries to calculate total number of volunteers in team and not in team on TotalOrgSummary page.

<img width="689" height="480" alt="Screenshot 2025-10-04 at 14 38 47" src="https://github.com/user-attachments/assets/74121074-f67b-4435-a6b0-f5f9be766959" />

<img width="689" height="427" alt="Screenshot 2025-10-04 at 14 39 20" src="https://github.com/user-attachments/assets/09ff6df5-84d0-4d13-82cb-5c31c3251945" />

## Related PRS (if any):
To test this backend PR you need to checkout the `development` branch in the frontend.

## Main changes explained:
- Aligned `getTeamMembersCount’s` base filters with the leaderboard totals by requiring `isActive`, `weeklycommittedHours ≥ 1`, and `non-Mentor` roles before counting team membership.
- Added logic so profiles missing `createdDate` are still included when an `endDate` filter is applied, keeping totals consistent with leaderboard data.
…

## How to test:
1. check into current branch in the backend and `development` branch in the frontend
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. On the frontend, log as owner user and go to `http://localhost:5173/totalorgsummary`
5. Go to `Team Stats` under `Volunteer Roles and Team Dynamics`
6. verify the count of volunteers `In Team` vs `Not In Team`. The total of both should be equal to `HGN Totals` shown in the Leaderboard on the `/dashboard` page

<img width="689" height="427" alt="Screenshot 2025-10-04 at 14 53 31" src="https://github.com/user-attachments/assets/90d4e61f-b9d2-4da3-a670-74ba5fcf9f7e" />


## Screenshots or videos of changes:

After:

1471 + 903 = 2374 (HGN Total)
<img width="716" height="500" alt="Screenshot 2025-10-04 at 14 54 46" src="https://github.com/user-attachments/assets/fbc53188-a479-47aa-bd44-14f9bda8f839" />

