### PR TITLE
feat: add backend timelog usage tracking with event capture and times…

### DIFF
--- a/src/controllers/timelogTrackingController.js
+++ b/src/controllers/timelogTrackingController.js
@@ -1,0 +1,32 @@
+const TimelogTracking = require('../models/timelogTracking');
+const logger = require('../startup/logger');
+
+/**
+ * Get timelog tracking events for a specific user
+ * @param {Object} req - Express request object
+ * @param {Object} res - Express response object
+ */
+const getTimelogTracking = async (req, res) => {
+  try {
+    const { userId } = req.params;
+
+    if (!userId) {
+      return res.status(400).json({ error: 'User ID is required' });
+    }
+
+    // Get the last 100 events for the user, sorted by timestamp descending (most recent first)
+    const trackingEvents = await TimelogTracking.find({ userId })
+      .sort({ timestamp: -1 })
+      .limit(100)
+      .populate('userId', 'firstName lastName email timeZone');
+
+    res.status(200).json(trackingEvents);
+  } catch (error) {
+    logger.logException(error);
+    res.status(500).json({ error: 'Failed to fetch timelog tracking events' });
+  }
+};
+
+module.exports = {
+  getTimelogTracking,
+};

--- a/src/models/timelogTracking.js
+++ b/src/models/timelogTracking.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const timelogTrackingSchema = new Schema({
+  userId: { type: Schema.Types.ObjectId, required: true, ref: 'userProfile' },
+  eventType: {
+    type: String,
+    required: true,
+    enum: ['Timelog Resumed', 'Timelog Paused', 'Time Logged', 'Automatic Pause'],
+  },
+  timestamp: { type: Date, required: true, default: Date.now }, // Stored in UTC
+  createdAt: { type: Date, default: Date.now },
+});
+
+timelogTrackingSchema.index({ userId: 1, timestamp: -1 });
+
+module.exports = mongoose.model('timelogTracking', timelogTrackingSchema, 'timelogTrackings');

--- a/src/routes/timelogTrackingRouter.js
+++ b/src/routes/timelogTrackingRouter.js
@@ -1,0 +1,14 @@
+const express = require('express');
+
+const routes = function () {
+  const timelogTrackingRouter = express.Router();
+
+  const controller = require('../controllers/timelogTrackingController');
+
+  // Get timelog tracking events for a user
+  timelogTrackingRouter.route('/timelogTracking/:userId').get(controller.getTimelogTracking);
+
+  return timelogTrackingRouter;
+};
+
+module.exports = routes;

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -91,6 +91,7 @@ const currentWarningsRouter = require('../routes/curentWarningsRouter')(currentW
 const badgeRouter = require('../routes/badgeRouter')(badge);
 const dashboardRouter = require('../routes/dashboardRouter')(weeklySummaryAIPrompt);
 const timeEntryRouter = require('../routes/timeentryRouter')(timeEntry);
+const timelogTrackingRouter = require('../routes/timelogTrackingRouter')();
 const projectRouter = require('../routes/projectRouter')(project);
 const informationRouter = require('../routes/informationRouter')(information);
 const teamRouter = require('../routes/teamRouter')(team);
@@ -287,6 +288,7 @@ module.exports = function (app) {
   app.use('/api', userProfileRouter);
   app.use('/api', dashboardRouter);
   app.use('/api', timeEntryRouter);
+  app.use('/api', timelogTrackingRouter);
   app.use('/api', teamRouter);
   app.use('/api', wastedMaterialRouter);
 

--- a/src/websockets/TimerService/clientsHandler.js
+++ b/src/websockets/TimerService/clientsHandler.js
@@ -2,6 +2,7 @@
 /* eslint-disable radix */
 const moment = require('moment');
 const Timer = require('../../models/timer');
+const TimelogTracking = require('../../models/timelogTracking');
 const logger = require('../../startup/logger');
 
 const getClient = async (clients, userId) => {
@@ -56,7 +57,21 @@ const updatedTimeSinceStart = (client) => {
   return updatedTime > 0 ? updatedTime : 0;
 };
 
-const startTimer = (client) => {
+const logTimelogEvent = async (userId, eventType) => {
+  try {
+    // Store timestamp in UTC only - timezone conversion happens on frontend
+    await TimelogTracking.create({
+      userId,
+      eventType,
+      timestamp: new Date(), // UTC timestamp
+    });
+  } catch (error) {
+    logger.logException(error);
+    // Don't throw error to avoid breaking timer functionality
+  }
+};
+
+const startTimer = async (client) => {
   client.startAt = moment.utc();
   client.paused = false;
   if (!client.started) {
@@ -64,9 +79,12 @@ const startTimer = (client) => {
     client.time = client.goal;
   }
   if (client.forcedPause) client.forcedPause = false;
+
+  // Log the timelog resumed event
+  await logTimelogEvent(client.userId, 'Timelog Resumed');
 };
 
-const pauseTimer = (client, forced = false) => {
+const pauseTimer = async (client, forced = false) => {
   if (client.paused) return;
 
   client.time = updatedTimeSinceStart(client);
@@ -74,6 +92,10 @@ const pauseTimer = (client, forced = false) => {
   client.startAt = moment.invalid(); // invalid can not be saved in database
   client.paused = true;
   if (forced) client.forcedPause = true;
+
+  // Log the appropriate pause event
+  const eventType = forced ? 'Automatic Pause' : 'Timelog Paused';
+  await logTimelogEvent(client.userId, eventType);
 };
 
 const startChime = (client, msg) => {
@@ -87,8 +109,8 @@ const ackForcedPause = (client) => {
   client.startAt = moment.invalid();
 };
 
-const stopTimer = (client) => {
-  if (client.started) pauseTimer(client);
+const stopTimer = async (client) => {
+  if (client.started) await pauseTimer(client);
   client.startAt = moment.invalid();
   client.started = false;
   client.pause = false;
@@ -100,6 +122,9 @@ const stopTimer = (client) => {
   } else {
     client.goal = client.time;
   }
+
+  // Log the time logged event
+  await logTimelogEvent(client.userId, 'Time Logged');
 };
 
 const clearTimer = (client) => {
@@ -176,10 +201,12 @@ const handleMessage = async (msg, clients, userId) => {
 
   const client = await getClient(clients, userId);
   let resp = null;
+  let timelogEvent = null; // Track if a timelog event was created
 
   switch (msg.action) {
     case action.START_TIMER:
-      startTimer(client);
+      await startTimer(client);
+      timelogEvent = { eventType: 'Timelog Resumed', timestamp: new Date() };
       break;
     case action.GET_TIMER:
       resp = client;
@@ -197,19 +224,22 @@ const handleMessage = async (msg, clients, userId) => {
       startChime(client, msg);
       break;
     case action.PAUSE_TIMER:
-      pauseTimer(client);
+      await pauseTimer(client);
+      timelogEvent = { eventType: 'Timelog Paused', timestamp: new Date() };
       break;
     case action.FORCED_PAUSE:
-      pauseTimer(client, true);
+      await pauseTimer(client, true);
+      timelogEvent = { eventType: 'Automatic Pause', timestamp: new Date() };
       break;
     case action.ACK_FORCED:
       ackForcedPause(client);
       break;
     case action.CLEAR_TIMER:
-      clearTimer(client);
+      await clearTimer(client);
       break;
     case action.STOP_TIMER:
-      stopTimer(client);
+      await stopTimer(client);
+      timelogEvent = { eventType: 'Time Logged', timestamp: new Date() };
       break;
     default:
       resp = {
@@ -222,7 +252,12 @@ const handleMessage = async (msg, clients, userId) => {
   saveClient(client);
   clients.set(userId, client);
   if (resp === null) resp = client;
-  return JSON.stringify(resp);
+
+  // Return both the timer response and any timelog event
+  return {
+    timerResponse: JSON.stringify(resp),
+    timelogEvent: timelogEvent ? { ...timelogEvent, userId } : null,
+  };
 };
 
 module.exports = {

--- a/src/websockets/index.js
+++ b/src/websockets/index.js
@@ -95,8 +95,15 @@ export default () => {
         ws.send(JSON.stringify({ heartbeat: 'pong' }));
         return;
       }
-      const resp = await handleMessage(msg, clients, msg.userId ?? userId);
-      broadcastToSameUser(connections, userId, resp);
+      const result = await handleMessage(msg, clients, msg.userId ?? userId);
+      broadcastToSameUser(connections, userId, result.timerResponse);
+      if (result.timelogEvent) {
+        const timelogEventMessage = JSON.stringify({
+          type: 'TIMELOG_EVENT',
+          data: result.timelogEvent,
+        });
+        broadcastToSameUser(connections, userId, timelogEventMessage);
+      }
     });
 
     /**


### PR DESCRIPTION
# Description
<img alt="Screenshot 2025-10-05 035324" src="https://github.com/user-attachments/assets/8f8e4a03-5475-4b65-9071-cdb2c3ba1822" />

## Related PRS (if any):
This backend PR is related to the [Frontend PR #XXXX] frontend PR.
To test this backend PR you need to checkout the [Frontend PR #XXXX] frontend PR.

## Main changes explained:
- Created new `timelogTracking` MongoDB model to store user timelog events with UTC timestamps
- Modified timer WebSocket service to capture and broadcast real-time timelog events
- Added `getTimelogTracking` API endpoint to retrieve user's timelog event history
- Implemented event tracking for: Timelog Resumed, Timelog Paused, Time Logged, and Automatic Pause
- Updated WebSocket message handling to support both timer responses and timelog event broadcasts
- Ensured UTC timestamp storage with timezone-aware display conversion on frontend

## How to test:
1. Checkout current branch
2. Run `npm install`, `npm run build` and `npm start` to run this PR locally
3. Clear site data/cache
4. Log in as any user
5. Navigate to user's Dashboard page
6. Click the "Timestamps" tab (between "Weekly Summaries" and "Badges")
7. Start/stop/pause the timer to see events appear in real-time
8. Verify timestamps show in user's local timezone
9. Test with multiple browser tabs to ensure real-time sync

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/86951184-fea8-4991-b426-5681617c3526


## API Changes:
- GET `/api/timelogTracking/:userId` - Retrieves user's timelog events
- WebSocket broadcasts `TIMELOG_EVENT` messages for real-time updates
