### PR TITLE
Mani shashank fix: add tools stoppage reason API endpoints

### DIFF
--- a/src/routes/bmdashboard/bmToolStoppageReasonRouter.js
+++ b/src/routes/bmdashboard/bmToolStoppageReasonRouter.js
@@ -6,12 +6,12 @@ const routes = function (ToolStoppageReason) {
     ToolStoppageReason,
   );
 
-  // GET /api/bm/projects/:id/tools-availability
+  // GET /api/bm/projects/:id/tools-stoppage-reason
   bmToolStoppageReasonRouter
     .route('/bm/projects/:id/tools-stoppage-reason')
     .get(controller.getToolsStoppageReason);
 
-  // GET /api/bm/tools-availability/projects
+  // GET /api/bm/tools-stoppage-reason/projects
   bmToolStoppageReasonRouter
     .route('/bm/tools-stoppage-reason/projects')
     .get(controller.getUniqueProjectIds);


### PR DESCRIPTION
# Description
(PRIORITY HIGH) JAE/JAIWANTH/VARSHA: Phase 2 Summary Dashboard: Create a stacked horizontal bar graph titled reason of stoppage of tools

- X-axis should be the percentage of tools. Y-axis is the tool name.
- Turn on stacking so that all data for a tool is in one row.
- Have different colours for each of 3 categories: Used for its lifetime, Damaged and Lost
- Include two filters: A Project filter to view data for a specific project. A Date filter to select a custom date range.
- Turn data labels on so that values for all 3 categories are visible for all tools.

## Related PRS (if any):
To test this backend PR you need to checkout the [#4376](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4376) frontend PR.

## Main changes explained:
- Add bmToolStoppageReasonController with aggregation pipeline
- Create MongoDB aggregation to calculate tool stoppage percentages
- Add routes for project-based tools stoppage data
- Include date range filtering functionality
- Add buildingToolsStoppage model for data structure
- Support for 'Used for lifetime', 'Damaged', and 'Lost' categories

## How to test:
1. check into current branch
2. do npm install and npm run start:local to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to dashboard→ Reports→ Total Construction Summary→ Tools and Equipment Tracking Card
6. verify the Reason of Stoppage of Tools graph is visible and the values are in %
 
## Screenshots or videos of changes:

https://github.com/user-attachments/assets/c1ad3ffe-e905-475a-8560-2fbca48cdb83
