### PR TITLE
Rithika taking over for Kanishk: Add Event Popularity Analytics API Endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ skip-db.js
 stub-db.js
 stub-db-strong.js
 # scripts/
+.claude/

--- a/src/controllers/__tests__/eventPopularityController.test.js
+++ b/src/controllers/__tests__/eventPopularityController.test.js
@@ -1,0 +1,375 @@
+jest.mock('../../models/event', () => ({
+  find: jest.fn(),
+}));
+
+const Event = require('../../models/event');
+const eventPopularityController = require('../eventPopularityController');
+
+const getController = () => eventPopularityController();
+
+const makeReq = (query = {}) => ({ query });
+
+const makeRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnThis();
+  res.json = jest.fn().mockReturnThis();
+  return res;
+};
+
+const mockEventFind = (events) => {
+  Event.find.mockReturnValue({ lean: jest.fn().mockResolvedValue(events) });
+};
+
+describe('eventPopularityController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('getPopularityMetrics', () => {
+    it('returns empty metrics when there are no events', async () => {
+      mockEventFind([]);
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getPopularityMetrics(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({ metrics: [] });
+    });
+
+    it('groups events by type and calculates averages', async () => {
+      mockEventFind([
+        {
+          _id: '1',
+          type: 'Workshop',
+          title: 'A',
+          currentAttendees: 10,
+          maxAttendees: 20,
+          location: 'Virtual',
+        },
+        {
+          _id: '2',
+          type: 'Workshop',
+          title: 'B',
+          currentAttendees: 20,
+          maxAttendees: 20,
+          location: 'Virtual',
+        },
+        {
+          _id: '3',
+          type: 'Meeting',
+          title: 'C',
+          currentAttendees: 5,
+          maxAttendees: 10,
+          location: 'In person',
+        },
+      ]);
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getPopularityMetrics(req, res);
+
+      const { metrics } = res.json.mock.calls[0][0];
+      const workshop = metrics.find((m) => m.eventType === 'Workshop');
+      const meeting = metrics.find((m) => m.eventType === 'Meeting');
+
+      expect(workshop.totalEvents).toBe(2);
+      expect(workshop.totalAttendees).toBe(30);
+      expect(workshop.averageAttendeesPerEvent).toBe(15);
+      expect(meeting.totalEvents).toBe(1);
+      expect(meeting.averageAttendeesPerEvent).toBe(5);
+    });
+
+    it('defaults missing type to Unknown', async () => {
+      mockEventFind([{ _id: '1', title: 'A', currentAttendees: 1, maxAttendees: 5 }]);
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getPopularityMetrics(req, res);
+
+      const { metrics } = res.json.mock.calls[0][0];
+      expect(metrics[0].eventType).toBe('Unknown');
+    });
+
+    it('applies startDate and endDate filters to the query', async () => {
+      mockEventFind([]);
+      const controller = getController();
+      const req = makeReq({ startDate: '2024-01-01', endDate: '2024-01-31' });
+      const res = makeRes();
+
+      await controller.getPopularityMetrics(req, res);
+
+      const calledQuery = Event.find.mock.calls[0][0];
+      expect(calledQuery.date.$gte).toEqual(new Date('2024-01-01'));
+      expect(calledQuery.date.$lte).toEqual(new Date('2024-01-31'));
+    });
+
+    it('returns 500 on database error', async () => {
+      Event.find.mockImplementation(() => {
+        throw new Error('DB failure');
+      });
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getPopularityMetrics(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: 'Failed to fetch popularity metrics' }),
+      );
+    });
+  });
+
+  describe('getEngagementMetrics', () => {
+    it('returns zeroed engagement when there are no events', async () => {
+      mockEventFind([]);
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getEngagementMetrics(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        engagement: {
+          totalEvents: 0,
+          totalAttendees: 0,
+          averageSessionDuration: 0,
+          averageInteractionRate: 0,
+          events: [],
+        },
+      });
+    });
+
+    it('calculates session duration from startTime and endTime', async () => {
+      mockEventFind([
+        {
+          _id: '1',
+          title: 'A',
+          type: 'Workshop',
+          currentAttendees: 5,
+          maxAttendees: 10,
+          startTime: '2024-01-01T10:00:00Z',
+          endTime: '2024-01-01T11:30:00Z',
+        },
+      ]);
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getEngagementMetrics(req, res);
+
+      const { engagement } = res.json.mock.calls[0][0];
+      expect(engagement.events[0].averageSessionDuration).toBe(90);
+      expect(engagement.events[0].interactionRate).toBe(50);
+    });
+
+    it('falls back to default duration by event type when times are missing', async () => {
+      mockEventFind([
+        { _id: '1', title: 'A', type: 'Webinar', currentAttendees: 0, maxAttendees: 0 },
+      ]);
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getEngagementMetrics(req, res);
+
+      const { engagement } = res.json.mock.calls[0][0];
+      expect(engagement.events[0].averageSessionDuration).toBe(90);
+      expect(engagement.events[0].interactionRate).toBe(0);
+    });
+
+    it('falls back to 60 minute default for an unrecognized type', async () => {
+      mockEventFind([
+        { _id: '1', title: 'A', type: 'Mystery', currentAttendees: 0, maxAttendees: 0 },
+      ]);
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getEngagementMetrics(req, res);
+
+      const { engagement } = res.json.mock.calls[0][0];
+      expect(engagement.events[0].averageSessionDuration).toBe(60);
+    });
+
+    it('applies location filter only for allowed format values (security fix)', async () => {
+      mockEventFind([]);
+      const controller = getController();
+      const req = makeReq({ format: 'Virtual' });
+      const res = makeRes();
+
+      await controller.getEngagementMetrics(req, res);
+
+      const calledQuery = Event.find.mock.calls[0][0];
+      expect(calledQuery.location).toBe('Virtual');
+    });
+
+    it('ignores a disallowed or malicious format value instead of injecting it', async () => {
+      mockEventFind([]);
+      const controller = getController();
+      const req = makeReq({ format: { $ne: null } });
+      const res = makeRes();
+
+      await controller.getEngagementMetrics(req, res);
+
+      const calledQuery = Event.find.mock.calls[0][0];
+      expect(calledQuery.location).toBeUndefined();
+    });
+
+    it('ignores a format value that is not in the allowed list', async () => {
+      mockEventFind([]);
+      const controller = getController();
+      const req = makeReq({ format: 'NotAFormat' });
+      const res = makeRes();
+
+      await controller.getEngagementMetrics(req, res);
+
+      const calledQuery = Event.find.mock.calls[0][0];
+      expect(calledQuery.location).toBeUndefined();
+    });
+
+    it('returns 500 on database error', async () => {
+      Event.find.mockImplementation(() => {
+        throw new Error('DB failure');
+      });
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getEngagementMetrics(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: 'Failed to fetch engagement metrics' }),
+      );
+    });
+  });
+
+  describe('getEventValue', () => {
+    it('returns zeroed values when there are no events', async () => {
+      mockEventFind([]);
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getEventValue(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        eventValues: {
+          totalValue: 0,
+          averageValuePerEvent: 0,
+          events: [],
+        },
+      });
+    });
+
+    it('calculates estimated value using type-specific base values', async () => {
+      mockEventFind([
+        { _id: '1', title: 'A', type: 'Workshop', currentAttendees: 10 },
+        { _id: '2', title: 'B', type: 'Meeting', currentAttendees: 5 },
+      ]);
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getEventValue(req, res);
+
+      const { eventValues } = res.json.mock.calls[0][0];
+      expect(eventValues.events[0].estimatedValue).toBe(500); // 10 * 50
+      expect(eventValues.events[1].estimatedValue).toBe(150); // 5 * 30
+      expect(eventValues.totalValue).toBe(650);
+    });
+
+    it('falls back to a base value of 30 for an unrecognized type', async () => {
+      mockEventFind([{ _id: '1', title: 'A', type: 'Mystery', currentAttendees: 4 }]);
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getEventValue(req, res);
+
+      const { eventValues } = res.json.mock.calls[0][0];
+      expect(eventValues.events[0].baseValuePerAttendee).toBe(30);
+      expect(eventValues.events[0].estimatedValue).toBe(120);
+    });
+
+    it('returns 500 on database error', async () => {
+      Event.find.mockImplementation(() => {
+        throw new Error('DB failure');
+      });
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getEventValue(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: 'Failed to fetch event values' }),
+      );
+    });
+  });
+
+  describe('getFormatComparison', () => {
+    it('returns metrics for both virtual and in-person events', async () => {
+      Event.find.mockImplementation((query) => {
+        if (query.location === 'Virtual') {
+          return {
+            lean: jest.fn().mockResolvedValue([{ currentAttendees: 10 }, { currentAttendees: 20 }]),
+          };
+        }
+        return { lean: jest.fn().mockResolvedValue([{ currentAttendees: 5 }]) };
+      });
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getFormatComparison(req, res);
+
+      const { comparison } = res.json.mock.calls[0][0];
+      expect(comparison.virtual).toEqual({
+        totalEvents: 2,
+        totalAttendees: 30,
+        averageAttendeesPerEvent: 15,
+      });
+      expect(comparison.inPerson).toEqual({
+        totalEvents: 1,
+        totalAttendees: 5,
+        averageAttendeesPerEvent: 5,
+      });
+    });
+
+    it('applies date filters to both virtual and in-person queries', async () => {
+      mockEventFind([]);
+      const controller = getController();
+      const req = makeReq({ startDate: '2024-01-01', endDate: '2024-01-31' });
+      const res = makeRes();
+
+      await controller.getFormatComparison(req, res);
+
+      const virtualQuery = Event.find.mock.calls[0][0];
+      const inPersonQuery = Event.find.mock.calls[1][0];
+      expect(virtualQuery.date.$gte).toEqual(new Date('2024-01-01'));
+      expect(inPersonQuery.date.$lte).toEqual(new Date('2024-01-31'));
+    });
+
+    it('returns 500 on database error', async () => {
+      Event.find.mockImplementation(() => {
+        throw new Error('DB failure');
+      });
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getFormatComparison(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ error: 'Failed to fetch format comparison' }),
+      );
+    });
+  });
+});

--- a/src/controllers/__tests__/eventPopularityController.test.js
+++ b/src/controllers/__tests__/eventPopularityController.test.js
@@ -102,8 +102,8 @@ describe('eventPopularityController', () => {
       await controller.getPopularityMetrics(req, res);
 
       const calledQuery = Event.find.mock.calls[0][0];
-      expect(calledQuery.date.$gte).toEqual(new Date('2024-01-01'));
-      expect(calledQuery.date.$lte).toEqual(new Date('2024-01-31'));
+      expect(calledQuery.date.$gte).toEqual(new Date(Date.UTC(2024, 0, 1)));
+      expect(calledQuery.date.$lt).toEqual(new Date(Date.UTC(2024, 0, 32)));
     });
 
     it('returns 500 on database error', async () => {
@@ -352,8 +352,8 @@ describe('eventPopularityController', () => {
 
       const virtualQuery = Event.find.mock.calls[0][0];
       const inPersonQuery = Event.find.mock.calls[1][0];
-      expect(virtualQuery.date.$gte).toEqual(new Date('2024-01-01'));
-      expect(inPersonQuery.date.$lte).toEqual(new Date('2024-01-31'));
+      expect(virtualQuery.date.$gte).toEqual(new Date(Date.UTC(2024, 0, 1)));
+      expect(inPersonQuery.date.$lt).toEqual(new Date(Date.UTC(2024, 0, 32)));
     });
 
     it('returns 500 on database error', async () => {

--- a/src/controllers/eventPopularityController.js
+++ b/src/controllers/eventPopularityController.js
@@ -1,0 +1,304 @@
+const Event = require('../models/event');
+
+const eventPopularityController = () => {
+  // Calculate popularity metrics by event type
+  const getPopularityMetrics = async (req, res) => {
+    try {
+      const { startDate, endDate } = req.query;
+
+      // Build date filter if provided
+      const query = { isActive: true };
+      if (startDate || endDate) {
+        query.date = {};
+        if (startDate) query.date.$gte = new Date(startDate);
+        if (endDate) query.date.$lte = new Date(endDate);
+      }
+
+      // Get all events with attendance data
+      const events = await Event.find(query).lean();
+
+      // Handle empty events
+      if (!events || events.length === 0) {
+        return res.json({ metrics: [] });
+      }
+
+      // Group by event type
+      const typeMetrics = {};
+
+      events.forEach((event) => {
+        const type = event.type || 'Unknown';
+        if (!typeMetrics[type]) {
+          typeMetrics[type] = {
+            eventType: type,
+            totalEvents: 0,
+            totalAttendees: 0,
+            totalRegistrations: 0,
+            averageAttendeesPerEvent: 0,
+            events: [],
+          };
+        }
+
+        const attendees = event.currentAttendees || 0;
+        const registrations = event.currentAttendees || 0; // Using currentAttendees as proxy for registrations
+
+        typeMetrics[type].totalEvents += 1;
+        typeMetrics[type].totalAttendees += attendees;
+        typeMetrics[type].totalRegistrations += registrations;
+        typeMetrics[type].events.push({
+          eventId: event._id,
+          title: event.title,
+          attendees,
+          registrations,
+          maxAttendees: event.maxAttendees,
+          location: event.location,
+        });
+      });
+
+      // Calculate averages
+      const result = Object.values(typeMetrics).map((metrics) => ({
+        ...metrics,
+        averageAttendeesPerEvent:
+          metrics.totalEvents > 0 ? metrics.totalAttendees / metrics.totalEvents : 0,
+        averageRegistrationsPerEvent:
+          metrics.totalEvents > 0 ? metrics.totalRegistrations / metrics.totalEvents : 0,
+      }));
+
+      res.json({ metrics: result });
+    } catch (error) {
+      console.error('Error in getPopularityMetrics:', error);
+      res.status(500).json({
+        error: 'Failed to fetch popularity metrics',
+        details: error.message,
+        stack: process.env.NODE_ENV === 'development' ? error.stack : undefined,
+      });
+    }
+  };
+
+  // Calculate engagement metrics (session duration, interactions)
+  const getEngagementMetrics = async (req, res) => {
+    try {
+      const { startDate, endDate, format } = req.query; // format: 'Virtual' or 'In person'
+
+      const query = { isActive: true };
+      if (startDate || endDate) {
+        query.date = {};
+        if (startDate) query.date.$gte = new Date(startDate);
+        if (endDate) query.date.$lte = new Date(endDate);
+      }
+
+      if (format) {
+        query.location = format;
+      }
+
+      const events = await Event.find(query).lean();
+
+      // Handle empty events
+      if (!events || events.length === 0) {
+        return res.json({
+          engagement: {
+            totalEvents: 0,
+            totalAttendees: 0,
+            averageSessionDuration: 0,
+            averageInteractionRate: 0,
+            events: [],
+          },
+        });
+      }
+
+      // Calculate session duration based on event start/end times
+      const engagementData = events.map((event) => {
+        const attendees = event.currentAttendees || 0;
+
+        // Calculate session duration from startTime and endTime
+        let averageSessionDuration = 0;
+        if (event.startTime && event.endTime) {
+          const start = new Date(event.startTime);
+          const end = new Date(event.endTime);
+          averageSessionDuration = Math.round((end - start) / (1000 * 60)); // Duration in minutes
+        } else {
+          // Default duration based on event type
+          const defaultDurations = {
+            Workshop: 120,
+            Meeting: 60,
+            Webinar: 90,
+            'Social Gathering': 90,
+          };
+          averageSessionDuration = defaultDurations[event.type] || 60;
+        }
+
+        const interactionRate = event.maxAttendees > 0 ? (attendees / event.maxAttendees) * 100 : 0;
+
+        return {
+          eventId: event._id,
+          title: event.title,
+          type: event.type,
+          location: event.location,
+          attendees,
+          averageSessionDuration,
+          interactionRate: Math.round(interactionRate * 100) / 100,
+        };
+      });
+
+      const totalAttendees = engagementData.reduce((sum, e) => sum + e.attendees, 0);
+      const averageSessionDuration =
+        engagementData.length > 0
+          ? engagementData.reduce((sum, e) => sum + e.averageSessionDuration, 0) /
+            engagementData.length
+          : 0;
+      const averageInteractionRate =
+        engagementData.length > 0
+          ? engagementData.reduce((sum, e) => sum + e.interactionRate, 0) / engagementData.length
+          : 0;
+
+      res.json({
+        engagement: {
+          totalEvents: events.length,
+          totalAttendees,
+          averageSessionDuration: Math.round(averageSessionDuration),
+          averageInteractionRate: Math.round(averageInteractionRate * 100) / 100,
+          events: engagementData,
+        },
+      });
+    } catch (error) {
+      console.error('Error in getEngagementMetrics:', error);
+      res.status(500).json({
+        error: 'Failed to fetch engagement metrics',
+        details: error.message,
+        stack: process.env.NODE_ENV === 'development' ? error.stack : undefined,
+      });
+    }
+  };
+
+  // Calculate event value (estimated value per event)
+  const getEventValue = async (req, res) => {
+    try {
+      const { startDate, endDate } = req.query;
+
+      const query = { isActive: true };
+      if (startDate || endDate) {
+        query.date = {};
+        if (startDate) query.date.$gte = new Date(startDate);
+        if (endDate) query.date.$lte = new Date(endDate);
+      }
+
+      const events = await Event.find(query).lean();
+
+      // Handle empty events
+      if (!events || events.length === 0) {
+        return res.json({
+          eventValues: {
+            totalValue: 0,
+            averageValuePerEvent: 0,
+            events: [],
+          },
+        });
+      }
+
+      // Calculate estimated value per event
+      // Value calculation: base value per attendee * attendee count
+      // Different event types have different base values
+      const baseValues = {
+        Workshop: 50,
+        Meeting: 30,
+        Webinar: 25,
+        'Social Gathering': 20,
+      };
+
+      const eventValues = events.map((event) => {
+        const attendees = event.currentAttendees || 0;
+        const baseValue = baseValues[event.type] || 30;
+        const estimatedValue = attendees * baseValue;
+
+        return {
+          eventId: event._id,
+          title: event.title,
+          type: event.type,
+          location: event.location,
+          attendees,
+          estimatedValue,
+          baseValuePerAttendee: baseValue,
+        };
+      });
+
+      const totalValue = eventValues.reduce((sum, e) => sum + e.estimatedValue, 0);
+      const averageValuePerEvent = eventValues.length > 0 ? totalValue / eventValues.length : 0;
+
+      res.json({
+        eventValues: {
+          totalValue,
+          averageValuePerEvent: Math.round(averageValuePerEvent * 100) / 100,
+          events: eventValues,
+        },
+      });
+    } catch (error) {
+      console.error('Error in getEventValue:', error);
+      res.status(500).json({
+        error: 'Failed to fetch event values',
+        details: error.message,
+        stack: process.env.NODE_ENV === 'development' ? error.stack : undefined,
+      });
+    }
+  };
+
+  // Get comparison metrics for virtual vs in-person
+  const getFormatComparison = async (req, res) => {
+    try {
+      const { startDate, endDate } = req.query;
+
+      const virtualQuery = { isActive: true, location: 'Virtual' };
+      const inPersonQuery = { isActive: true, location: 'In person' };
+
+      if (startDate || endDate) {
+        const dateFilter = {};
+        if (startDate) dateFilter.$gte = new Date(startDate);
+        if (endDate) dateFilter.$lte = new Date(endDate);
+        virtualQuery.date = dateFilter;
+        inPersonQuery.date = dateFilter;
+      }
+
+      const virtualEvents = await Event.find(virtualQuery).lean();
+      const inPersonEvents = await Event.find(inPersonQuery).lean();
+
+      const calculateMetrics = (events) => {
+        const totalAttendees = events.reduce(
+          (sum, event) => sum + (event.currentAttendees || 0),
+          0,
+        );
+        const totalEvents = events.length;
+        const averageAttendees = totalEvents > 0 ? totalAttendees / totalEvents : 0;
+
+        return {
+          totalEvents,
+          totalAttendees,
+          averageAttendeesPerEvent: Math.round(averageAttendees * 100) / 100,
+        };
+      };
+
+      const virtualMetrics = calculateMetrics(virtualEvents);
+      const inPersonMetrics = calculateMetrics(inPersonEvents);
+
+      res.json({
+        comparison: {
+          virtual: virtualMetrics,
+          inPerson: inPersonMetrics,
+        },
+      });
+    } catch (error) {
+      console.error('Error in getFormatComparison:', error);
+      res.status(500).json({
+        error: 'Failed to fetch format comparison',
+        details: error.message,
+        stack: process.env.NODE_ENV === 'development' ? error.stack : undefined,
+      });
+    }
+  };
+
+  return {
+    getPopularityMetrics,
+    getEngagementMetrics,
+    getEventValue,
+    getFormatComparison,
+  };
+};
+
+module.exports = eventPopularityController;

--- a/src/controllers/eventPopularityController.js
+++ b/src/controllers/eventPopularityController.js
@@ -86,7 +86,8 @@ const eventPopularityController = () => {
         if (endDate) query.date.$lte = new Date(endDate);
       }
 
-      if (format) {
+      const ALLOWED_FORMATS = ['Virtual', 'In person'];
+      if (typeof format === 'string' && ALLOWED_FORMATS.includes(format)) {
         query.location = format;
       }
 

--- a/src/controllers/eventPopularityController.js
+++ b/src/controllers/eventPopularityController.js
@@ -86,9 +86,14 @@ const eventPopularityController = () => {
         if (endDate) query.date.$lte = new Date(endDate);
       }
 
-      const ALLOWED_FORMATS = ['Virtual', 'In person'];
-      if (typeof format === 'string' && ALLOWED_FORMATS.includes(format)) {
-        query.location = format;
+      let safeFormat;
+      if (format === 'Virtual') {
+        safeFormat = 'Virtual';
+      } else if (format === 'In person') {
+        safeFormat = 'In person';
+      }
+      if (safeFormat) {
+        query.location = safeFormat;
       }
 
       const events = await Event.find(query).lean();

--- a/src/controllers/eventPopularityController.js
+++ b/src/controllers/eventPopularityController.js
@@ -1,4 +1,33 @@
 const Event = require('../models/event');
+const { parseDateFlexibleUTC, parseYmdUtc } = require('../utilities/bmDateUtils');
+
+/**
+ * Builds a Mongo date range filter from startDate/endDate query params.
+ * Date-only strings (YYYY-MM-DD) are treated as an inclusive day: the end date
+ * is advanced to the next day and compared with $lt so events on that day aren't excluded.
+ * Returns { dateFilter, invalidDate }.
+ */
+const buildDateFilter = (startDate, endDate) => {
+  const s = parseDateFlexibleUTC(startDate);
+  const e0 = parseDateFlexibleUTC(endDate);
+
+  const invalidDate =
+    (startDate && !s && !parseYmdUtc(startDate)) || (endDate && !e0 && !parseYmdUtc(endDate));
+
+  const dateFilter = {};
+  if (s) dateFilter.$gte = s;
+  if (e0) {
+    if (parseYmdUtc(endDate)) {
+      const endExclusive = new Date(e0);
+      endExclusive.setUTCDate(endExclusive.getUTCDate() + 1);
+      dateFilter.$lt = endExclusive;
+    } else {
+      dateFilter.$lte = e0;
+    }
+  }
+
+  return { dateFilter, invalidDate };
+};
 
 const eventPopularityController = () => {
   // Calculate popularity metrics by event type
@@ -7,11 +36,15 @@ const eventPopularityController = () => {
       const { startDate, endDate } = req.query;
 
       // Build date filter if provided
+      const { dateFilter, invalidDate } = buildDateFilter(startDate, endDate);
+      if (invalidDate) {
+        return res
+          .status(400)
+          .json({ error: 'Invalid startDate or endDate (use YYYY-MM-DD or ISO)' });
+      }
       const query = { isActive: true };
-      if (startDate || endDate) {
-        query.date = {};
-        if (startDate) query.date.$gte = new Date(startDate);
-        if (endDate) query.date.$lte = new Date(endDate);
+      if (Object.keys(dateFilter).length > 0) {
+        query.date = dateFilter;
       }
 
       // Get all events with attendance data
@@ -79,11 +112,15 @@ const eventPopularityController = () => {
     try {
       const { startDate, endDate, format } = req.query; // format: 'Virtual' or 'In person'
 
+      const { dateFilter, invalidDate } = buildDateFilter(startDate, endDate);
+      if (invalidDate) {
+        return res
+          .status(400)
+          .json({ error: 'Invalid startDate or endDate (use YYYY-MM-DD or ISO)' });
+      }
       const query = { isActive: true };
-      if (startDate || endDate) {
-        query.date = {};
-        if (startDate) query.date.$gte = new Date(startDate);
-        if (endDate) query.date.$lte = new Date(endDate);
+      if (Object.keys(dateFilter).length > 0) {
+        query.date = dateFilter;
       }
 
       let safeFormat;
@@ -180,11 +217,15 @@ const eventPopularityController = () => {
     try {
       const { startDate, endDate } = req.query;
 
+      const { dateFilter, invalidDate } = buildDateFilter(startDate, endDate);
+      if (invalidDate) {
+        return res
+          .status(400)
+          .json({ error: 'Invalid startDate or endDate (use YYYY-MM-DD or ISO)' });
+      }
       const query = { isActive: true };
-      if (startDate || endDate) {
-        query.date = {};
-        if (startDate) query.date.$gte = new Date(startDate);
-        if (endDate) query.date.$lte = new Date(endDate);
+      if (Object.keys(dateFilter).length > 0) {
+        query.date = dateFilter;
       }
 
       const events = await Event.find(query).lean();
@@ -254,10 +295,13 @@ const eventPopularityController = () => {
       const virtualQuery = { isActive: true, location: 'Virtual' };
       const inPersonQuery = { isActive: true, location: 'In person' };
 
-      if (startDate || endDate) {
-        const dateFilter = {};
-        if (startDate) dateFilter.$gte = new Date(startDate);
-        if (endDate) dateFilter.$lte = new Date(endDate);
+      const { dateFilter, invalidDate } = buildDateFilter(startDate, endDate);
+      if (invalidDate) {
+        return res
+          .status(400)
+          .json({ error: 'Invalid startDate or endDate (use YYYY-MM-DD or ISO)' });
+      }
+      if (Object.keys(dateFilter).length > 0) {
         virtualQuery.date = dateFilter;
         inPersonQuery.date = dateFilter;
       }

--- a/src/routes/eventPopularityRouter.js
+++ b/src/routes/eventPopularityRouter.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const eventPopularityController = require('../controllers/eventPopularityController');
+
+const eventPopularityRouter = express.Router();
+const controller = eventPopularityController();
+
+eventPopularityRouter.get('/events/popularity', controller.getPopularityMetrics);
+eventPopularityRouter.get('/events/engagement', controller.getEngagementMetrics);
+eventPopularityRouter.get('/events/value', controller.getEventValue);
+eventPopularityRouter.get('/events/format-comparison', controller.getFormatComparison);
+
+module.exports = eventPopularityRouter;

--- a/src/routes/eventRouter.js
+++ b/src/routes/eventRouter.js
@@ -3,11 +3,11 @@ const eventsController = require('../controllers/eventController');
 
 const eventRouter = express.Router();
 
-eventRouter.get('/events', eventsController.getEvents);
-eventRouter.get('/events/:id', eventsController.getEventById);
 eventRouter.get('/events/types', eventsController.getEventTypes);
 eventRouter.get('/events/locations', eventsController.getEventLocations);
+eventRouter.get('/events', eventsController.getEvents);
 eventRouter.post('/events', eventsController.createEvent);
+eventRouter.get('/events/:id', eventsController.getEventById);
 eventRouter.post('/events/:id/register', eventsController.registerForEvent);
 eventRouter.delete('/events/:id/register/:userId', eventsController.unregisterFromEvent);
 

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -613,6 +613,10 @@ module.exports = function (app) {
   // lb dashboard
   app.use('/api/lbdashboard', lbRegisterRouter);
   app.use('/api/lb', lbListingsRouter);
+  const eventRouter = require('../routes/eventRouter');
+  app.use('/api', eventRouter);
+  const eventPopularityRouter = require('../routes/eventPopularityRouter');
+  app.use('/api', eventPopularityRouter);
   app.use('/api/villages', require('../routes/lbdashboard/villages'));
   app.use('/api/lb', lbMessageRouter);
   app.use('/api/lb', lbUserPrefRouter);

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -647,6 +647,10 @@ module.exports = function (app) {
   // lb dashboard
   app.use('/api/lbdashboard', lbRegisterRouter);
   app.use('/api/lb', lbListingsRouter);
+  const eventRouter = require('../routes/eventRouter');
+  app.use('/api', eventRouter);
+  const eventPopularityRouter = require('../routes/eventPopularityRouter');
+  app.use('/api', eventPopularityRouter);
   app.use('/api/villages', require('../routes/lbdashboard/villages'));
   app.use('/api/lb', lbMessageRouter);
   app.use('/api/lb', lbUserPrefRouter);

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -647,10 +647,10 @@ module.exports = function (app) {
   // lb dashboard
   app.use('/api/lbdashboard', lbRegisterRouter);
   app.use('/api/lb', lbListingsRouter);
-  const eventRouter = require('../routes/eventRouter');
-  app.use('/api', eventRouter);
   const eventPopularityRouter = require('../routes/eventPopularityRouter');
   app.use('/api', eventPopularityRouter);
+  const eventRouter = require('../routes/eventRouter');
+  app.use('/api', eventRouter);
   app.use('/api/villages', require('../routes/lbdashboard/villages'));
   app.use('/api/lb', lbMessageRouter);
   app.use('/api/lb', lbUserPrefRouter);


### PR DESCRIPTION
## Description
This PR adds backend API endpoints for Event Popularity Analytics. Please verify everything shows properly in the frontend PR.

## Related PRs
- Frontend PR: [PR 4514](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4514)

## Main Changes

### New Controller
- **eventPopularityController.js** - Implements four main endpoints:
  - `getPopularityMetrics()` - Calculates popularity metrics by event type
  - `getEngagementMetrics()` - Calculates engagement metrics (session duration, interaction rate)
  - `getEventValue()` - Calculates estimated value per event
  - `getFormatComparison()` - Compares Virtual vs In-Person event metrics

### New Router
- **eventPopularityRouter.js** - Defines API routes:
  - `GET /api/events/popularity` - Get popularity metrics
  - `GET /api/events/engagement` - Get engagement metrics
  - `GET /api/events/value` - Get event value calculations
  - `GET /api/events/format-comparison` - Get format comparison data

### Route Registration
- Updated `src/startup/routes.js` to register the new eventPopularityRouter

## Reviewer Notes
- Please verify everything shows properly in the frontend PR
- All endpoints require JWT authentication