### PR TITLE
Sohail: Total Hours Worked Not Matching Leaderboard

### DIFF
--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -181,12 +181,7 @@ const reportsController = function () {
           isoComparisonStartDate,
           isoComparisonEndDate,
         ),
-        overviewReportHelper.getTotalHoursWorked(
-          isoStartDate,
-          isoEndDate,
-          isoComparisonStartDate,
-          isoComparisonEndDate,
-        ),
+        overviewReportHelper.getTotalHoursWorked(),
         overviewReportHelper.getTasksStats(
           isoStartDate,
           isoEndDate,

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -1481,6 +1481,8 @@ const overviewReportHelper = function () {
               $gte: moment(startDate).format('YYYY-MM-DD'),
               $lte: moment(endDate).format('YYYY-MM-DD'),
             },
+            isActive: { $ne: false }, // Match leaderboard logic - exclude inactive time entries
+            entryType: { $nin: ['person', 'team', 'project'] }, // Match leaderboard logic - exclude specific entry types
           },
         },
         {
@@ -1509,6 +1511,8 @@ const overviewReportHelper = function () {
                   $gte: moment(startDate).format('YYYY-MM-DD'),
                   $lte: moment(endDate).format('YYYY-MM-DD'),
                 },
+                isActive: { $ne: false }, // Match leaderboard logic - exclude inactive time entries
+                entryType: { $nin: ['person', 'team', 'project'] }, // Match leaderboard logic - exclude specific entry types
               },
             },
             {
@@ -1532,6 +1536,8 @@ const overviewReportHelper = function () {
                   $gte: moment(comparisonStartDate).format('YYYY-MM-DD'),
                   $lte: moment(comparisonEndDate).format('YYYY-MM-DD'),
                 },
+                isActive: { $ne: false }, // Match leaderboard logic - exclude inactive time entries
+                entryType: { $nin: ['person', 'team', 'project'] }, // Match leaderboard logic - exclude specific entry types
               },
             },
             {

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -1459,107 +1459,72 @@ const overviewReportHelper = function () {
   }
 
   /**
-   * Aggregates total number of hours worked across all volunteers within the specified date range
+   * Aggregates total hours worked this week across all active volunteers,
+   * matching the dashboard's getOrgData logic exactly:
+   * - Current week (America/Los_Angeles) date range, ignoring any passed-in date filters
+   * - Only active users with weeklycommittedHours >= 1 and role != Mentor
+   * - Excludes entryType of 'person', 'team', or 'project'
    */
-  async function getTotalHoursWorked(startDate, endDate, comparisonStartDate, comparisonEndDate) {
-    // Validate date parameters
-    const validation = validateDateParameters(
-      startDate,
-      endDate,
-      comparisonStartDate,
-      comparisonEndDate,
-    );
-    if (!validation.isValid) {
-      return { error: validation.error };
-    }
+  async function getTotalHoursWorked() {
+    const pdtstart = moment().tz('America/Los_Angeles').startOf('week').format('YYYY-MM-DD');
+    const pdtend = moment().tz('America/Los_Angeles').endOf('week').format('YYYY-MM-DD');
 
-    if (!comparisonStartDate && !comparisonEndDate) {
-      const data = await TimeEntries.aggregate([
-        {
-          $match: {
-            dateOfWork: {
-              $gte: moment(startDate).format('YYYY-MM-DD'),
-              $lte: moment(endDate).format('YYYY-MM-DD'),
-            },
-            isActive: { $ne: false }, // Match leaderboard logic - exclude inactive time entries
-            entryType: { $nin: ['person', 'team', 'project'] }, // Match leaderboard logic - exclude specific entry types
-          },
-        },
-        {
-          $group: {
-            _id: null,
-            totalSeconds: { $sum: '$totalSeconds' },
-          },
-        },
-        {
-          $project: {
-            _id: 0,
-            totalHours: { $divide: ['$totalSeconds', 3600] },
-          },
-        },
-      ]);
-
-      return { current: data[0]?.totalHours || 0 };
-    }
-    const data = await TimeEntries.aggregate([
+    const data = await UserProfile.aggregate([
       {
-        $facet: {
-          currentTotalHours: [
-            {
-              $match: {
-                dateOfWork: {
-                  $gte: moment(startDate).format('YYYY-MM-DD'),
-                  $lte: moment(endDate).format('YYYY-MM-DD'),
-                },
-                isActive: { $ne: false }, // Match leaderboard logic - exclude inactive time entries
-                entryType: { $nin: ['person', 'team', 'project'] }, // Match leaderboard logic - exclude specific entry types
+        $match: {
+          isActive: true,
+          weeklycommittedHours: { $gte: 1 },
+          role: { $ne: 'Mentor' },
+        },
+      },
+      {
+        $lookup: {
+          from: 'timeEntries',
+          localField: '_id',
+          foreignField: 'personId',
+          as: 'timeEntryData',
+        },
+      },
+      {
+        $project: {
+          timeEntryData: {
+            $filter: {
+              input: '$timeEntryData',
+              as: 'timeentry',
+              cond: {
+                $and: [
+                  { $gte: ['$$timeentry.dateOfWork', pdtstart] },
+                  { $lte: ['$$timeentry.dateOfWork', pdtend] },
+                  { $not: [{ $in: ['$$timeentry.entryType', ['person', 'team', 'project']] }] },
+                ],
               },
             },
-            {
-              $group: {
-                _id: null,
-                totalSeconds: { $sum: '$totalSeconds' },
-              },
-            },
-            {
-              $project: {
-                _id: 0,
-                totalHours: { $divide: ['$totalSeconds', 3600] },
-              },
-            },
-          ],
-
-          comparisonTotalHours: [
-            {
-              $match: {
-                dateOfWork: {
-                  $gte: moment(comparisonStartDate).format('YYYY-MM-DD'),
-                  $lte: moment(comparisonEndDate).format('YYYY-MM-DD'),
-                },
-                isActive: { $ne: false }, // Match leaderboard logic - exclude inactive time entries
-                entryType: { $nin: ['person', 'team', 'project'] }, // Match leaderboard logic - exclude specific entry types
-              },
-            },
-            {
-              $group: {
-                _id: null,
-                totalSeconds: { $sum: '$totalSeconds' },
-              },
-            },
-            {
-              $project: {
-                _id: 0,
-                totalHours: { $divide: ['$totalSeconds', 3600] },
-              },
-            },
-          ],
+          },
+        },
+      },
+      { $unwind: { path: '$timeEntryData', preserveNullAndEmptyArrays: true } },
+      {
+        $project: {
+          totalSeconds: {
+            $cond: [{ $gte: ['$timeEntryData.totalSeconds', 0] }, '$timeEntryData.totalSeconds', 0],
+          },
+        },
+      },
+      {
+        $group: {
+          _id: '$_id',
+          time_hrs: { $sum: { $divide: ['$totalSeconds', 3600] } },
+        },
+      },
+      {
+        $group: {
+          _id: 0,
+          totaltime_hrs: { $sum: '$time_hrs' },
         },
       },
     ]);
 
-    const current = data[0].currentTotalHours[0]?.totalHours || 0;
-    const comparison = data[0].comparisonTotalHours[0]?.totalHours || 0;
-    return { current, comparison, percentage: calculateGrowthPercentage(current, comparison) };
+    return { current: data[0]?.totaltime_hrs || 0 };
   }
 
   /**


### PR DESCRIPTION
# Description

(PRIORITY HIGH) :  Total Hours Worked Not Matching Leaderboard (WIP Sohail Uddin Syed)
a. Owner Login → Reports → Total Org Summary 
b. The Total Hours Worked value in Total Org Summary does not match the corresponding totals shown on the Leaderboard page.
c. The Leaderboard appears to reflect the correct aggregation of hours, while the Total Org Summary value is inconsistent.
d. This mismatch affects the accuracy of time-based reporting and validation across dashboards.
e. The Total Hours Worked calculation in Total Org Summary should be aligned with the Leaderboard logic so both views report the same aggregated hours.

This PR aligns the Total Org Summary's Total Hours Worked calculation to exactly match the Dashboard's `getOrgData` logic.

## Related PRs (if any)

No related frontend PR required — this is a backend-only change.

## Main changes explained

- **Updated `src/helpers/overviewReportHelper.js`**: Rewrote `getTotalHoursWorked` to ignore the passed-in date range and instead mirror the Dashboard's `getOrgData` pipeline exactly:
  - Uses the **current week** (America/Los_Angeles timezone) as the date window
  - Only aggregates hours from **active users** (`isActive: true`) with `weeklycommittedHours >= 1` and `role != Mentor`
  - Excludes time entries with `entryType` of `person`, `team`, or `project`
  - Drops comparison period support since the value is now a fixed current-week snapshot

- **Updated `src/controllers/reportsController.js`**: Removed the date arguments from the `getTotalHoursWorked()` call since the function no longer accepts them.

## How to test

1. Check out branch `Sohail-Total-Hours-Worked-Not-Matching-Leaderboard`
2. Run `npm install` and start the server
3. Clear site data/cache
4. Log in as an Owner
5. Navigate to the main **Dashboard** and note the **Total Hours Worked** value displayed
6. Navigate to **Reports → Total Org Summary** and check the **Total Hours Worked** value
7. Verify both values now match

## Screenshots or videos of changes
