### PR TITLE
Roshini Seelamsetty: Deactivated Volunteers Count Not getting reflected with Time Filter

### DIFF
--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -1615,7 +1615,7 @@ const overviewReportHelper = function () {
               {
                 $match: {
                   isActive: false,
-                  createdDate: { $lte: isoEndDate }, // All inactive volunteers, not just recently deactivated
+                  lastModifiedDate: { $gte: isoStartDate, $lte: isoEndDate },
                 },
               },
               { $count: 'count' },


### PR DESCRIPTION
# Description

<img width="692" height="353" alt="Screenshot 2026-03-17 at 16 57 00" src="https://github.com/user-attachments/assets/e05c0f76-c242-4b2d-9a20-4415aff01683" />


## Related PRs (if any):
Backend-only PR. No frontend changes needed.

## Main changes explained:
- Update `src/helpers/overviewReportHelper.js`: 
  - OLD: `createdDate: { $lte: isoEndDate }` (all historical inactives)
  - NEW: `lastModifiedDate: { $gte: isoStartDate, $lte: isoEndDate }` (only recent deactivations)

## How to test:
1. Checkout this branch
2. `npm install && npm start` (backend restart required)
3. Clear site data/cache
4. Login as Owner → Reports → Total Org Summary
5. Test these ranges:

| Date Range | Deactivated Volunteers |
|------------|------------------------|
| `2026-02-18 → 2026-02-24` | 49 |
| `2026-02-24 → 2026-02-24` | 0 |

## Screenshots or videos of changes:
**Before fix** (same count regardless of dates):  
<img width="1510" height="866" alt="Screenshot 2026-02-24 at 15 18 57" src="https://github.com/user-attachments/assets/a35919b5-8509-4f37-805c-07d39a0693a4" />



**After fix** (changes with date range):  
<img width="1511" height="856" alt="Screenshot 2026-02-24 at 15 41 19" src="https://github.com/user-attachments/assets/a5f30bf8-6c1d-480f-8104-613d6df26b18" />
<img width="1512" height="863" alt="Screenshot 2026-02-24 at 15 41 54" src="https://github.com/user-attachments/assets/5542901f-05b1-4396-8b82-04185804e134" />


https://github.com/user-attachments/assets/ecba6215-3542-4b1f-bbe5-31a5ba8afd49



## Note:
- Single aggregation change, no schema changes
- Frontend unchanged - automatically uses corrected backend data
- Tested locally with Owner login
