### PR TITLE
Rithika taking over for Aditya-feat: Side-by-Side Comparison Mode for Actual vs. Planned Expenditure Charts

### DIFF
--- a/src/controllers/bmdashboard/__tests__/expenditureController.test.js
+++ b/src/controllers/bmdashboard/__tests__/expenditureController.test.js
@@ -1,0 +1,148 @@
+jest.mock('../../../models/bmdashboard/expenditure', () => ({
+  distinct: jest.fn(),
+  aggregate: jest.fn(),
+}));
+
+jest.mock('../../../startup/logger', () => ({
+  logException: jest.fn(),
+  logInfo: jest.fn(),
+}));
+
+const Expenditure = require('../../../models/bmdashboard/expenditure');
+const logger = require('../../../startup/logger');
+const { getProjectExpensesPie, getProjectIdsWithExpenditure } = require('../expenditureController');
+
+const VALID_ID = '507f1f77bcf86cd799439011';
+const INVALID_ID = 'not-a-valid-id';
+
+const makeRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnThis();
+  res.json = jest.fn().mockReturnThis();
+  return res;
+};
+
+describe('expenditureController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('getProjectIdsWithExpenditure', () => {
+    it('returns 200 with the array of project IDs on success', async () => {
+      const ids = [VALID_ID, '507f1f77bcf86cd799439012'];
+      Expenditure.distinct.mockResolvedValue(ids);
+
+      const res = makeRes();
+      await getProjectIdsWithExpenditure({}, res);
+
+      expect(Expenditure.distinct).toHaveBeenCalledWith('projectId');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(ids);
+    });
+
+    it('returns 200 with an empty array when no expenditure records exist', async () => {
+      Expenditure.distinct.mockResolvedValue([]);
+
+      const res = makeRes();
+      await getProjectIdsWithExpenditure({}, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith([]);
+    });
+
+    it('returns 500 and calls logger on DB error', async () => {
+      const error = new Error('DB failure');
+      Expenditure.distinct.mockRejectedValue(error);
+
+      const res = makeRes();
+      await getProjectIdsWithExpenditure({}, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Failed to retrieve project IDs' });
+      expect(logger.logException).toHaveBeenCalledWith(
+        error,
+        'expenditureController.getProjectIdsWithExpenditure',
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  describe('getProjectExpensesPie', () => {
+    it('returns 400 for an invalid projectId without calling aggregate', async () => {
+      const req = { params: { projectId: INVALID_ID } };
+      const res = makeRes();
+
+      await getProjectExpensesPie(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ message: 'Invalid project ID' });
+      expect(Expenditure.aggregate).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 for a short non-hex string without calling aggregate', async () => {
+      const req = { params: { projectId: '12345' } };
+      const res = makeRes();
+
+      await getProjectExpensesPie(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(Expenditure.aggregate).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 with { actual, planned } shape on success', async () => {
+      Expenditure.aggregate.mockResolvedValue([
+        { _id: { type: 'actual', category: 'Labor' }, amount: 1000 },
+        { _id: { type: 'actual', category: 'Materials' }, amount: 500 },
+        { _id: { type: 'planned', category: 'Equipment' }, amount: 2000 },
+      ]);
+
+      const req = { params: { projectId: VALID_ID } };
+      const res = makeRes();
+
+      await getProjectExpensesPie(req, res);
+
+      expect(Expenditure.aggregate).toHaveBeenCalledTimes(1);
+      expect(res.json).toHaveBeenCalledWith({
+        actual: [
+          { category: 'Labor', amount: 1000 },
+          { category: 'Materials', amount: 500 },
+        ],
+        planned: [{ category: 'Equipment', amount: 2000 }],
+      });
+      // status should NOT be explicitly set to 200 (res.json implies 200)
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('returns { actual: [], planned: [] } when no matching records exist', async () => {
+      Expenditure.aggregate.mockResolvedValue([]);
+
+      const req = { params: { projectId: VALID_ID } };
+      const res = makeRes();
+
+      await getProjectExpensesPie(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({ actual: [], planned: [] });
+    });
+
+    it('returns 500 and calls logger with projectId on DB error', async () => {
+      const error = new Error('Aggregate failed');
+      Expenditure.aggregate.mockRejectedValue(error);
+
+      const req = { params: { projectId: VALID_ID } };
+      const res = makeRes();
+
+      await getProjectExpensesPie(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Server error retrieving expenses pie data.',
+      });
+      expect(logger.logException).toHaveBeenCalledWith(
+        error,
+        'expenditureController.getProjectExpensesPie',
+        { projectId: VALID_ID },
+      );
+    });
+  });
+});

--- a/src/controllers/summaryDashboard/__tests__/laborHoursDistributionController.test.js
+++ b/src/controllers/summaryDashboard/__tests__/laborHoursDistributionController.test.js
@@ -58,87 +58,46 @@ describe('laborHoursDistributionController', () => {
       expect(LaborHours.aggregate).not.toHaveBeenCalled();
     });
 
-    it('returns 400 when start_date and end_date are missing', async () => {
+    it.each([
+      [
+        'start_date and end_date are missing',
+        { start_date: undefined, end_date: undefined },
+        'Missing required query parameters: start_date and end_date are required',
+      ],
+      [
+        'start_date format is invalid',
+        { start_date: '01-01-2024', end_date: '2024-01-31' },
+        'Invalid start_date format. Please use YYYY-MM-DD format',
+      ],
+      [
+        'start_date is not a valid calendar date',
+        { start_date: '2024-02-30', end_date: '2024-01-31' },
+        'Invalid start_date: date does not exist (e.g., invalid month or day)',
+      ],
+      [
+        'end_date format is invalid',
+        { start_date: '2024-01-01', end_date: '31/01/2024' },
+        'Invalid end_date format. Please use YYYY-MM-DD format',
+      ],
+      [
+        'end_date is not a valid calendar date',
+        { start_date: '2024-01-01', end_date: '2024-04-31' },
+        'Invalid end_date: date does not exist (e.g., invalid month or day)',
+      ],
+      [
+        'start_date is after end_date',
+        { start_date: '2024-02-01', end_date: '2024-01-15' },
+        'Invalid date range: start_date must be before or equal to end_date',
+      ],
+    ])('returns 400 when %s', async (_, queryOverrides, expectedError) => {
       const controller = getController();
-      const req = makeReq({ start_date: undefined, end_date: undefined });
+      const req = makeReq(queryOverrides);
       const res = makeRes();
 
       await controller.getLaborHoursDistribution(req, res);
 
       expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        error: 'Missing required query parameters: start_date and end_date are required',
-      });
-      expect(LaborHours.aggregate).not.toHaveBeenCalled();
-    });
-
-    it('returns 400 when start_date format is invalid', async () => {
-      const controller = getController();
-      const req = makeReq({ start_date: '01-01-2024', end_date: '2024-01-31' });
-      const res = makeRes();
-
-      await controller.getLaborHoursDistribution(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        error: 'Invalid start_date format. Please use YYYY-MM-DD format',
-      });
-      expect(LaborHours.aggregate).not.toHaveBeenCalled();
-    });
-
-    it('returns 400 when start_date is not a valid calendar date', async () => {
-      const controller = getController();
-      const req = makeReq({ start_date: '2024-02-30', end_date: '2024-01-31' });
-      const res = makeRes();
-
-      await controller.getLaborHoursDistribution(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        error: 'Invalid start_date: date does not exist (e.g., invalid month or day)',
-      });
-      expect(LaborHours.aggregate).not.toHaveBeenCalled();
-    });
-
-    it('returns 400 when end_date format is invalid', async () => {
-      const controller = getController();
-      const req = makeReq({ start_date: '2024-01-01', end_date: '31/01/2024' });
-      const res = makeRes();
-
-      await controller.getLaborHoursDistribution(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        error: 'Invalid end_date format. Please use YYYY-MM-DD format',
-      });
-      expect(LaborHours.aggregate).not.toHaveBeenCalled();
-    });
-
-    it('returns 400 when end_date is not a valid calendar date', async () => {
-      const controller = getController();
-      const req = makeReq({ start_date: '2024-01-01', end_date: '2024-04-31' });
-      const res = makeRes();
-
-      await controller.getLaborHoursDistribution(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        error: 'Invalid end_date: date does not exist (e.g., invalid month or day)',
-      });
-      expect(LaborHours.aggregate).not.toHaveBeenCalled();
-    });
-
-    it('returns 400 when start_date is after end_date', async () => {
-      const controller = getController();
-      const req = makeReq({ start_date: '2024-02-01', end_date: '2024-01-15' });
-      const res = makeRes();
-
-      await controller.getLaborHoursDistribution(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        error: 'Invalid date range: start_date must be before or equal to end_date',
-      });
+      expect(res.json).toHaveBeenCalledWith({ error: expectedError });
       expect(LaborHours.aggregate).not.toHaveBeenCalled();
     });
 

--- a/src/controllers/summaryDashboard/__tests__/laborHoursDistributionController.test.js
+++ b/src/controllers/summaryDashboard/__tests__/laborHoursDistributionController.test.js
@@ -1,0 +1,240 @@
+jest.mock('../../../models/summaryDashboard/laborHours', () => ({
+  aggregate: jest.fn(),
+}));
+jest.mock('../../../startup/logger', () => ({
+  logException: jest.fn(),
+}));
+const mockCacheInstance = {
+  hasCache: jest.fn(),
+  getCache: jest.fn(),
+  setCache: jest.fn(),
+};
+jest.mock('../../../utilities/nodeCache', () => () => mockCacheInstance);
+jest.mock('../../../utilities/permissions', () => ({
+  hasPermission: jest.fn(),
+}));
+
+const LaborHours = require('../../../models/summaryDashboard/laborHours');
+const logger = require('../../../startup/logger');
+const { hasPermission } = require('../../../utilities/permissions');
+const laborHoursDistributionController = require('../laborHoursDistributionController');
+
+const getController = () => laborHoursDistributionController();
+
+const makeReq = (query = {}, body = {}) => ({
+  query: { start_date: '2024-01-01', end_date: '2024-01-31', ...query },
+  body: { requestor: { requestorId: 'user-1' }, ...body },
+});
+
+const makeRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnThis();
+  res.json = jest.fn().mockReturnThis();
+  return res;
+};
+
+describe('laborHoursDistributionController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCacheInstance.hasCache.mockReturnValue(false);
+    mockCacheInstance.getCache.mockReturnValue({});
+    hasPermission.mockResolvedValue(true);
+  });
+
+  describe('getLaborHoursDistribution', () => {
+    it('returns 403 when user lacks getWeeklySummaries permission', async () => {
+      hasPermission.mockResolvedValue(false);
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getLaborHoursDistribution(req, res);
+
+      expect(hasPermission).toHaveBeenCalledWith(req.body.requestor, 'getWeeklySummaries');
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'You are not authorized to access labor hours distribution data',
+      });
+      expect(LaborHours.aggregate).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when start_date and end_date are missing', async () => {
+      const controller = getController();
+      const req = makeReq({ start_date: undefined, end_date: undefined });
+      const res = makeRes();
+
+      await controller.getLaborHoursDistribution(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Missing required query parameters: start_date and end_date are required',
+      });
+      expect(LaborHours.aggregate).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when start_date format is invalid', async () => {
+      const controller = getController();
+      const req = makeReq({ start_date: '01-01-2024', end_date: '2024-01-31' });
+      const res = makeRes();
+
+      await controller.getLaborHoursDistribution(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Invalid start_date format. Please use YYYY-MM-DD format',
+      });
+      expect(LaborHours.aggregate).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when start_date is not a valid calendar date', async () => {
+      const controller = getController();
+      const req = makeReq({ start_date: '2024-02-30', end_date: '2024-01-31' });
+      const res = makeRes();
+
+      await controller.getLaborHoursDistribution(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Invalid start_date: date does not exist (e.g., invalid month or day)',
+      });
+      expect(LaborHours.aggregate).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when end_date format is invalid', async () => {
+      const controller = getController();
+      const req = makeReq({ start_date: '2024-01-01', end_date: '31/01/2024' });
+      const res = makeRes();
+
+      await controller.getLaborHoursDistribution(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Invalid end_date format. Please use YYYY-MM-DD format',
+      });
+      expect(LaborHours.aggregate).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when end_date is not a valid calendar date', async () => {
+      const controller = getController();
+      const req = makeReq({ start_date: '2024-01-01', end_date: '2024-04-31' });
+      const res = makeRes();
+
+      await controller.getLaborHoursDistribution(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Invalid end_date: date does not exist (e.g., invalid month or day)',
+      });
+      expect(LaborHours.aggregate).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when start_date is after end_date', async () => {
+      const controller = getController();
+      const req = makeReq({ start_date: '2024-02-01', end_date: '2024-01-15' });
+      const res = makeRes();
+
+      await controller.getLaborHoursDistribution(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Invalid date range: start_date must be before or equal to end_date',
+      });
+      expect(LaborHours.aggregate).not.toHaveBeenCalled();
+    });
+
+    it('returns 200 with cached response when cache has key', async () => {
+      const cached = {
+        total_hours: 100,
+        distribution: [{ category: 'A', hours: 100, percentage: 100 }],
+      };
+      mockCacheInstance.hasCache.mockReturnValue(true);
+      mockCacheInstance.getCache.mockReturnValue(cached);
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getLaborHoursDistribution(req, res);
+
+      expect(mockCacheInstance.hasCache).toHaveBeenCalled();
+      expect(mockCacheInstance.getCache).toHaveBeenCalled();
+      expect(LaborHours.aggregate).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(cached);
+    });
+
+    it('returns 200 with total_hours and distribution on success', async () => {
+      LaborHours.aggregate.mockResolvedValue([
+        { category: 'Team A', hours: 200 },
+        { category: 'Team B', hours: 300 },
+      ]);
+      const controller = getController();
+      const req = makeReq({ start_date: '2024-01-01', end_date: '2024-01-31' });
+      const res = makeRes();
+
+      await controller.getLaborHoursDistribution(req, res);
+
+      expect(LaborHours.aggregate).toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(200);
+      const payload = res.json.mock.calls[0][0];
+      expect(payload.total_hours).toBe(500);
+      expect(payload.distribution).toHaveLength(2);
+      expect(payload.distribution[0]).toEqual(
+        expect.objectContaining({ category: 'Team A', hours: 200, percentage: 40 }),
+      );
+      expect(payload.distribution[1]).toEqual(
+        expect.objectContaining({ category: 'Team B', hours: 300, percentage: 60 }),
+      );
+      expect(mockCacheInstance.setCache).toHaveBeenCalledWith(
+        'labor_hours_distribution:2024-01-01:2024-01-31:all',
+        payload,
+      );
+    });
+
+    it('returns 200 with total_hours 0 and empty distribution when no data', async () => {
+      LaborHours.aggregate.mockResolvedValue([]);
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getLaborHoursDistribution(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        total_hours: 0,
+        distribution: [],
+      });
+    });
+
+    it('includes optional category in cache key and pipeline when provided', async () => {
+      LaborHours.aggregate.mockResolvedValue([{ category: 'Team A', hours: 100 }]);
+      const controller = getController();
+      const req = makeReq({ category: 'Construction' });
+      const res = makeRes();
+
+      await controller.getLaborHoursDistribution(req, res);
+
+      const pipeline = LaborHours.aggregate.mock.calls[0][0];
+      expect(pipeline[0].$match.category).toBe('Construction');
+      expect(mockCacheInstance.setCache).toHaveBeenCalledWith(
+        'labor_hours_distribution:2024-01-01:2024-01-31:Construction',
+        expect.any(Object),
+      );
+    });
+
+    it('returns 500 and calls logger on aggregate error', async () => {
+      const error = new Error('DB connection failed');
+      LaborHours.aggregate.mockRejectedValue(error);
+      const controller = getController();
+      const req = makeReq();
+      const res = makeRes();
+
+      await controller.getLaborHoursDistribution(req, res);
+
+      expect(logger.logException).toHaveBeenCalledWith(error);
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Error fetching labor hours distribution data. Please try again.',
+      });
+    });
+  });
+});

--- a/src/routes/bmdashboard/bmExpenditureRouter.js
+++ b/src/routes/bmdashboard/bmExpenditureRouter.js
@@ -6,7 +6,7 @@ const {
   getProjectIdsWithExpenditure,
 } = require('../../controllers/bmdashboard/expenditureController');
 
-router.get('/expenditure/:projectId/pie', getProjectExpensesPie);
 router.get('/expenditure/projects', getProjectIdsWithExpenditure);
+router.get('/expenditure/:projectId/pie', getProjectExpensesPie);
 
 module.exports = router;

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -246,6 +246,7 @@ const bmInjuryRouter = require('../routes/bmdashboard/bmInjuryRouter')(injujrySe
 
 const bmExternalTeam = require('../routes/bmdashboard/bmExternalTeamRouter');
 const bmActualVsPlannedCostRouter = require('../routes/bmdashboard/bmActualVsPlannedCostRouter');
+const bmExpenditureRouter = require('../routes/bmdashboard/bmExpenditureRouter');
 const bmRentalChart = require('../routes/bmdashboard/bmRentalChartRouter')();
 const bmToolsReturnedLateRouter = require('../routes/bmdashboard/bmToolsReturnedLateRouter')();
 const toolUtilizationRouter = require('../routes/bmdashboard/toolUtilizationRouter')(buildingTool);
@@ -489,6 +490,7 @@ module.exports = function (app) {
   app.use('/api/bm', bmIssueRouter);
   app.use('/api/bm', bmDashboardRouter);
   app.use('/api/bm', bmActualVsPlannedCostRouter);
+  app.use('/api/bm', bmExpenditureRouter);
   app.use('/api/bm', bmTimeLoggerRouter);
   app.use('/api/bm/injuries', injuryCategoryRoutes);
   app.use('/api', toolAvailabilityRouter);

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -284,6 +284,7 @@ const bmToolStoppageReasonRouter = require('../routes/bmdashboard/bmToolStoppage
   buildingToolStoppageReason,
 );
 const bmActualVsPlannedCostRouter = require('../routes/bmdashboard/bmActualVsPlannedCostRouter');
+const bmExpenditureRouter = require('../routes/bmdashboard/bmExpenditureRouter');
 const bmRentalChart = require('../routes/bmdashboard/bmRentalChartRouter')();
 const bmToolsReturnedLateRouter = require('../routes/bmdashboard/bmToolsReturnedLateRouter')();
 const toolUtilizationRouter = require('../routes/bmdashboard/toolUtilizationRouter')(buildingTool);
@@ -573,6 +574,7 @@ module.exports = function (app) {
   app.use('/api/bm', bmIssueRouter);
   app.use('/api/bm', bmDashboardRouter);
   app.use('/api/bm', bmActualVsPlannedCostRouter);
+  app.use('/api/bm', bmExpenditureRouter);
   app.use('/api/bm', bmTimeLoggerRouter);
   app.use('/api/bm/injuries', injuryCategoryRoutes);
   app.use('/api', projectCostTrackingRouter);

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -284,7 +284,6 @@ const bmToolStoppageReasonRouter = require('../routes/bmdashboard/bmToolStoppage
   buildingToolStoppageReason,
 );
 const bmActualVsPlannedCostRouter = require('../routes/bmdashboard/bmActualVsPlannedCostRouter');
-const bmExpenditureRouter = require('../routes/bmdashboard/bmExpenditureRouter');
 const bmRentalChart = require('../routes/bmdashboard/bmRentalChartRouter')();
 const bmToolsReturnedLateRouter = require('../routes/bmdashboard/bmToolsReturnedLateRouter')();
 const toolUtilizationRouter = require('../routes/bmdashboard/toolUtilizationRouter')(buildingTool);
@@ -574,7 +573,6 @@ module.exports = function (app) {
   app.use('/api/bm', bmIssueRouter);
   app.use('/api/bm', bmDashboardRouter);
   app.use('/api/bm', bmActualVsPlannedCostRouter);
-  app.use('/api/bm', bmExpenditureRouter);
   app.use('/api/bm', bmTimeLoggerRouter);
   app.use('/api/bm/injuries', injuryCategoryRoutes);
   app.use('/api', projectCostTrackingRouter);


### PR DESCRIPTION
# Description

This PR adds **backend support for the Side-by-Side Comparison Mode for Actual vs. Planned Expenditure Charts** on the BM (Building Management) dashboard. It exposes expenditure APIs under `/api/bm`, hardens the expenditure controller with validation and structured logging, fixes route registration so the list-projects endpoint is reachable, and removes the legacy planned-cost flow in favor of the expenditure-based pie data. It also adds unit tests for the expenditure controller, the BM equipment controller (`updateEquipmentById`), and the labor hours distribution controller.
<img width="616" height="532" alt="IssueDescription" src="https://github.com/user-attachments/assets/fdd170a0-f166-4965-b8a0-2eb3b89944f6" />


Location: **Dashboard → Reports → Total Construction Summary → Financials Tracking**. Users can toggle “Comparison View (Side-by-Side)” so Actual and Planned expenditure pie charts appear next to each other (desktop) or as a swipeable/tabbed view (mobile), with consistent colors (Labor = blue, Equipment = green, Materials = yellow). This backend provides the data endpoints the frontend needs for that comparison view.

## Related PRs (if any)

- Previous PR Pair: [PR #3565](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3565) + [PR #1417](https://github.com/OneCommunityGlobal/HGNRest/pull/1417)
- Frontend PR: [PR #4898](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4898)

## Main changes explained

### Created/Updated files

- `**src/controllers/bmdashboard/expenditureController.js`**
  - **getProjectExpensesPie:** Validates `projectId` with `mongoose.Types.ObjectId.isValid(projectId)`; returns **400** and `{ message: 'Invalid project ID' }` when invalid (before any DB call). Uses `new mongoose.Types.ObjectId(projectId)` in the aggregate `$match`. Replaces `console.error` with `logger.logException(..., 'expenditureController.getProjectExpensesPie', { projectId })`. Adds explicit `return` before all `res.json` / `res.status(...).json` to avoid double-send.
  - **getProjectIdsWithExpenditure:** Replaces `console.error` with `logger.logException(..., 'expenditureController.getProjectIdsWithExpenditure')`. Adds explicit `return` for success and error responses.
  - No changes to the Expenditure model or aggregation logic; only validation, logging, and response handling.
- `**src/routes/bmdashboard/bmExpenditureRouter.js`**
  - **Route order fix:** Defines the static route **before** the parameterized one so `GET /expenditure/projects` is not matched by `GET /expenditure/:projectId/pie` (which would treat `"projects"` as `projectId` and return 400).
  - **Order:** `router.get('/expenditure/projects', getProjectIdsWithExpenditure);` then `router.get('/expenditure/:projectId/pie', getProjectExpensesPie);`.
- `**src/startup/routes.js`**
  - **Added:** `const bmExpenditureRouter = require('../routes/bmdashboard/bmExpenditureRouter');` and `app.use('/api/bm', bmExpenditureRouter);`.
  - **Removed:** Require and use of `plannedCost` model and `plannedCostRouter` (including `console.log` debug lines and `app.use('/api', plannedCostRouter(plannedCost, project))`). Removed duplicate/early `app.use` for `toolAvailabilityRouter` and `projectCostTrackingRouter` in the block above BM routes. Removed `app.use('/api', projectMaterialRouter)` and `app.use('/api', plannedCostRouter(...))` from the latter block (routers may still be mounted elsewhere in the file as applicable).
- `**src/controllers/bmdashboard/__tests__/expenditureController.test.js`** (+148, new)
  - **getProjectIdsWithExpenditure:** 200 with array of project IDs; 200 with empty array; 500 and logger call on DB error.
  - **getProjectExpensesPie:** 400 for invalid/short non-hex `projectId` without calling aggregate; 200 with `{ actual, planned }` shape; empty arrays when no data; 500 and logger with `projectId` on aggregate error.
  - Mocks: `Expenditure` (distinct, aggregate), `logger` (logException, logInfo).
- `**src/controllers/bmdashboard/__tests__/bmEquipmentController.test.js`**
  - **fetchSingleEquipment:** success 200 and error 500.
  - **fetchBMEquipments:** success 200 and error 500.
  - **bmPurchaseEquipments:** create when equipment does not exist (201).
  - **updateEquipmentById:** 400 for invalid equipment ID, invalid project ID, invalid enums (`purchaseStatus`, `currentUsage`, `condition`), no valid fields; 200 with updated equipment; 404 when equipment not found after update; 500 on DB error.
- `**src/controllers/summaryDashboard/__tests__/laborHoursDistributionController.test.js`**
  - **getLaborHoursDistribution:** 403 when user lacks `getWeeklySummaries` permission; 400 for missing/invalid `start_date`/`end_date` (format and calendar date); success 200 with cached/uncached aggregation; 500 and logger on aggregate error.
  - Mocks: LaborHours, logger, nodeCache, permissions.

### Deleted files

- `**src/controllers/plannedCostController.js`** (-220)
  - Legacy planned cost controller removed; replaced by expenditure-based APIs.
- `**src/models/plannedCost.js`** (-40)
  - Legacy planned cost model removed.
- `**src/routes/plannedCostRouter.js**` (-25)
  - Legacy planned cost router removed.

### Key implementation details

- **Expenditure API (mounted under `/api/bm`):**
- **GET `/api/bm/expenditure/projects`** — Returns a JSON array of distinct `projectId` values (MongoDB ObjectIds as strings) that have records in the `expenditurePie` collection. Used by the frontend to populate the project selector for the comparison view.
- **GET `/api/bm/expenditure/:projectId/pie`** — Returns `{ actual: [{ category, amount }], planned: [{ category, amount }] }` from the `Expenditure` model (collection `expenditurePie`), aggregated by `type` (`actual`/`planned`) and `category` (Labor, Equipment, Materials). Used to render Actual and Planned pie charts side-by-side with consistent categories and amounts.
- **Expenditure model (unchanged in this PR):** `projectId` (ObjectId), `category` (enum: Labor | Equipment | Materials), `type` (enum: actual | planned), `amount` (Number); collection `expenditurePie`.
- **Controller hardening:** Invalid `projectId` is rejected before any DB call; all errors are logged via `logger.logException` with controller method name and context; every response path uses `return` to avoid double-sending.
- **Route order:** The static path `/expenditure/projects` must be registered before `/expenditure/:projectId/pie` in Express so that a request to list projects is not interpreted as a pie request with `projectId = "projects"`.

## How to test

1. Check out the current branch:

`git checkout Aditya-feat/Add-Side-by-Side-Comparison-Mode-for-Actual-vs-Planned-Expenditure-Charts`
2. Reinstall dependencies and clean cache using `rm -rf node_modules package-lock.json && npm cache clean --force`
3. Run `npm install` to install dependencies, then start the backend locally (`npm run dev`)
4. Use Admin/Owner login.
5. **Test expenditure endpoints** (use an auth token in the `Authorization` header, same as other `/api/bm` routes):
	- **List projects with expenditure data:**
		`GET /api/bm/expenditure/projects`
			Expected: **200**, body is a JSON array of project IDs (or `[]`).
	- **Get pie data for a project:**
		`GET /api/bm/expenditure/:projectId/pie`
			Use a valid 24-character hex ObjectId (e.g., from the list above).
			Expected: **200**, body `{ actual: [...], planned: [...] }` with `category` and `amount` per item.
			Use an invalid ID (e.g. `invalid-id` or `12345`): Expected **400**, `{ message: 'Invalid project ID' }`.
6. **Run unit tests:** `npm test -- --coverage --collectCoverageFrom=src/controllers/bmdashboard/expenditureController.js --collectCoverageFrom=src/controllers/bmdashboard/bmEquipmentController.js --collectCoverageFrom=src/controllers/summaryDashboard/laborHoursDistributionController.js --testPathPattern="(expenditureController|bmEquipmentController|laborHoursDistributionController)"`

```
Verify that `expenditureController.test.js`, `bmEquipmentController.test.js`, and `laborHoursDistributionController.test.js` pass (e.g., 8 + 14 + multiple labor-hours cases).
```

1. **Verify:**
  No remaining references to `plannedCost` or `plannedCostRouter` in `src/startup/routes.js`.
   When the frontend Comparison View is enabled, it can call the above endpoints to load the project list and pie data for side-by-side Actual vs. Planned charts.

## Screenshots or videos of changes

- **Test Coverage:**
  
<img width="728" height="802" alt="TestCoverageReport" src="https://github.com/user-attachments/assets/dadbf726-1349-4614-864b-de168b6e4b86" />

- **Test Video:**
  
https://github.com/user-attachments/assets/82e277c7-51c9-4a29-a67f-602460e8fa89

## Note

- **Breaking changes:** Removal of the `/api` routes previously provided by `plannedCostRouter`. Any client that relied on the old planned cost API must switch to **GET /api/bm/expenditure/projects** and **GET /api/bm/expenditure/:projectId/pie**.
- **Validation:** `projectId` in `getProjectExpensesPie` is validated with `mongoose.Types.ObjectId.isValid`; invalid or short/non-hex values receive 400 without hitting the DB.
- Not backward compatible with callers of the removed planned cost API; they must use the new expenditure endpoints under `/api/bm/expenditure/`.

