### PR TITLE
Ramsundar -  Prevent duplicate PR entries in PR Grading Dashboard (backend)

### DIFF
--- a/src/controllers/prAnalytics/weeklyGradingController.js
+++ b/src/controllers/prAnalytics/weeklyGradingController.js
@@ -1,5 +1,5 @@
-// Helper function to normalize prNumbers for comparison
-const normalizePrNumbers = (prNumbers) => prNumbers.replace(/\s+/g, ' ').trim();
+// Helper function to normalize prNumbers for comparison (removes all whitespace)
+const normalizePrNumbers = (prNumbers) => prNumbers.replace(/\s+/g, '');
 
 // Helper function to validate prNumbers regex
 const validatePrNumbers = (prNumbers) => {
@@ -27,6 +27,19 @@ const validateGradedPr = (gradedPr) => {
   }
 };
 
+const checkForDuplicatePRsInSubmission = (gradedPrs, reviewer) => {
+  const seenPRs = new Set();
+  for (const pr of gradedPrs) {
+    const normalized = normalizePrNumbers(pr.prNumbers);
+    if (seenPRs.has(normalized)) {
+      throw new Error(
+        `Duplicate PR number "${pr.prNumbers}" found in submission for reviewer: ${reviewer}`,
+      );
+    }
+    seenPRs.add(normalized);
+  }
+};
+
 // Validate a single grading entry
 const validateGradingEntry = (grading) => {
   const { reviewer, prsReviewed, prsNeeded, gradedPrs } = grading;
@@ -41,6 +54,8 @@ const validateGradingEntry = (grading) => {
   }
 
   gradedPrs.forEach(validateGradedPr);
+
+  checkForDuplicatePRsInSubmission(gradedPrs, reviewer);
 };
 
 // Merge gradedPrs from request with existing gradedPrs


### PR DESCRIPTION
# Description
<img width="705" height="400" alt="Screenshot 2026-02-28 at 7 23 37 PM" src="https://github.com/user-attachments/assets/683dc70a-39eb-442f-b36b-379344e1c992" />


## Related PRS (if any):
This backend PR is related to the #[4921](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4921) frontend PR.

## Main changes explained:
- Updated normalizePrNumbers to strip all whitespace for consistent key comparison
- Integrated this check into validateGradingEntry as a defensive layer before the data reaches mergeGradedPrs

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Go to /pr-grading-dashboard
6. Click "Add new" button and check with existing Pr's for the particular user 

## Screenshots or videos of changes:
https://www.loom.com/share/cb7835414e18423f80d845daf0fcb0ba
## Note:
Include the information the reviewers need to know.
