### PR TITLE
Roshini Seelamsetty: Total Active Teams Metric Includes Teams Without Logged Volunteer Hours

### DIFF
--- a/server.log
+++ b/server.log
@@ -1,0 +1,36 @@
+
+> hgnrest@1.0.0 start
+> node dist/server.js
+
+making router
+{
+  getNoShowsData: [Function: getNoShowsData],
+  getNoShowsByLocation: [Function: getNoShowsByLocation],
+  getNoShowsByAgeGroup: [Function: getNoShowsByAgeGroup],
+  getAttendanceByDay: [Function: getAttendanceByDay],
+  getUniqueEventTypes: [Function: getUniqueEventTypes],
+  getNoShowProportions: [Function: getNoShowProportions]
+}
+Loading plannedCost model...
+PlannedCost model loaded: success
+Loading plannedCostRouter...
+PlannedCostRouter loaded: success
+Started server on port 4500
+Error: listen EADDRINUSE: address already in use :::4500
+    at Server.setupListenHandle [as _listen2] (node:net:1908:16)
+    at listenInCluster (node:net:1965:12)
+    at Server.listen (node:net:2067:7)
+    at Object.<anonymous> (/Users/roshini/Desktop/Backend/HGNRest/dist/server.js:49:8)
+    at Module._compile (node:internal/modules/cjs/loader:1521:14)
+    at Module._extensions..js (node:internal/modules/cjs/loader:1623:10)
+    at Module.load (node:internal/modules/cjs/loader:1266:32)
+    at Module._load (node:internal/modules/cjs/loader:1091:12)
+    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:164:12)
+    at node:internal/main/run_main_module:28:49 {
+  code: 'EADDRINUSE',
+  errno: -48,
+  syscall: 'listen',
+  address: '::',
+  port: 4500
+}
+Error event:  Request - undefined 

--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -224,7 +224,12 @@ const reportsController = function () {
           isoComparisonStartDate,
           isoComparisonEndDate,
         ),
-        overviewReportHelper.getTotalActiveTeamCount(isoEndDate, isoComparisonEndDate),
+        overviewReportHelper.getTotalActiveTeamCount(
+          isoStartDate,
+          isoEndDate,
+          isoComparisonStartDate,
+          isoComparisonEndDate,
+        ),
         overviewReportHelper.getMapLocations(),
         overviewReportHelper.getVolunteersCompletedHours(
           isoStartDate,

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -488,56 +488,101 @@ const overviewReportHelper = function () {
 
   /**
    * Get the total number of active teams
+   * A team is considered active only if:
+   * 1. The team is marked as isActive: true
+   * 2. At least one team member has logged actual hours within the selected date range
    */
-  async function getTotalActiveTeamCount(endDate, comparisonEndDate) {
-    if (comparisonEndDate) {
-      const res = await Team.aggregate([
+  async function getTotalActiveTeamCount(
+    startDate,
+    endDate,
+    comparisonStartDate,
+    comparisonEndDate,
+  ) {
+    const getActiveTeamCount = async (start, end) => {
+      // Convert dates to YYYY-MM-DD string format for comparison with dateOfWork
+      const startStr = moment(start).format('YYYY-MM-DD');
+      const endStr = moment(end).format('YYYY-MM-DD');
+
+      console.log(`\n[getTotalActiveTeamCount] ========== START ==========`);
+      console.log(`[getTotalActiveTeamCount] Processing date range: ${startStr} to ${endStr}`);
+      console.log(`[getTotalActiveTeamCount] Input dates - start: ${start}, end: ${end}`);
+
+      // Step 1: Get all active teams
+      const activeTeamsCount = await Team.countDocuments({ isActive: true });
+      console.log(`[getTotalActiveTeamCount] Total active teams (no filter): ${activeTeamsCount}`);
+
+      const result = await Team.aggregate([
+        // Step 1: Match active teams created before/on the end date
         {
-          $facet: {
-            current: [
-              {
-                $match: {
-                  isActive: true,
-                  createdDatetime: { $lte: endDate },
-                },
-              },
-              {
-                $count: 'activeTeams',
-              },
-            ],
-            comparison: [
-              {
-                $match: {
-                  isActive: true,
-                  createdDatetime: { $lte: comparisonEndDate },
-                },
-              },
-              {
-                $count: 'activeTeams',
-              },
-            ],
+          $match: {
+            isActive: true,
+            $or: [{ createdDatetime: { $exists: false } }, { createdDatetime: { $lte: end } }],
           },
         },
-      ]);
-      const data = {};
-      data.current = res[0]?.current[0]?.activeTeams || 0;
-      data.comparison = res[0]?.comparison[0]?.activeTeams || 0;
-      data.percentage = calculateGrowthPercentage(data.current, data.comparison);
-      return data;
-    }
-    const res = await Team.aggregate([
-      {
-        $match: {
-          isActive: true,
-          createdDatetime: { $lte: endDate },
+        // Step 2: Lookup time entries for all team members
+        {
+          $lookup: {
+            from: 'timeEntries',
+            localField: 'members.userId',
+            foreignField: 'personId',
+            as: 'allTeamTimeEntries',
+          },
         },
-      },
-      {
-        $count: 'activeTeams',
-      },
-    ]);
+        // Step 3: Filter the time entries to only those in the date range
+        {
+          $project: {
+            _id: 1,
+            teamName: 1,
+            isActive: 1,
+            memberCount: { $size: '$members' },
+            totalTimeEntriesCount: { $size: '$allTeamTimeEntries' },
+            // Filter time entries to only those within the date range
+            timeEntriesInRange: {
+              $filter: {
+                input: '$allTeamTimeEntries',
+                as: 'entry',
+                cond: {
+                  $and: [
+                    { $gte: ['$$entry.dateOfWork', startStr] },
+                    { $lte: ['$$entry.dateOfWork', endStr] },
+                  ],
+                },
+              },
+            },
+          },
+        },
+        // Step 4: Keep only teams that have at least one time entry in the date range
+        {
+          $match: {
+            'timeEntriesInRange.0': { $exists: true },
+          },
+        },
+        // Step 5: Count the matching teams
+        {
+          $count: 'activeTeams',
+        },
+      ]);
 
-    return { current: res[0]?.activeTeams || 0 };
+      const activeTeamsWithHours = result[0]?.activeTeams || 0;
+      console.log(
+        `[getTotalActiveTeamCount] Teams with logged hours in range ${startStr} to ${endStr}: ${activeTeamsWithHours}`,
+      );
+      console.log(`[getTotalActiveTeamCount] ========== END ==========\n`);
+      return activeTeamsWithHours;
+    };
+
+    const current = await getActiveTeamCount(startDate, endDate);
+
+    if (comparisonStartDate && comparisonEndDate) {
+      const comparison = await getActiveTeamCount(comparisonStartDate, comparisonEndDate);
+      return {
+        current,
+        comparison,
+        percentage: calculateGrowthPercentage(current, comparison),
+      };
+    }
+
+    return { current };
   }
 
   /**


### PR DESCRIPTION
# Description

<img width="748" height="642" alt="Screenshot 2026-03-17 at 17 02 08" src="https://github.com/user-attachments/assets/c0a35382-b3aa-45a9-8a34-44ccf82f9c7d" />


## Related PRS (if any):
None — backend only fix, no frontend PR required.

## Main changes explained:
- Update src/helpers/overviewReportHelper.js to rewrite getTotalActiveTeamCount to accept startDate and endDate, join with timeEntries, and filter teams by actual logged hours in the reporting period. Also made createdDatetime filter optional to avoid excluding teams without that field.
- Update src/controllers/reportsController.js to pass isoStartDate, isoEndDate, isoComparisonStartDate, and isoComparisonEndDate into getTotalActiveTeamCount instead of only isoEndDate and isoComparisonEndDate.

## How to test:

1. Check out roshini_fix_active_teams_metric branch
2. Run npm install then npm start to run the backend locally
3. Clear site data/cache
4. Log in as Owner
5. Go to Dashboard → Volunteer Activities → observe Total Active Teams
6. Set date range to a future period (e.g. Apr 8 – Jun 18, 2026) → verify Total Active Teams shows 0
7. Set date range to current week → verify count reflects only teams with actual logged hours
8. Set a broad historical range (e.g. Nov 2024 – Apr 2026) → verify a realistic count

## Screenshots or videos of changes:
Before:
<img width="1512" height="864" alt="Screenshot 2026-03-08 at 22 37 05" src="https://github.com/user-attachments/assets/bf974860-a322-46f1-810e-6892ec0f4f26" />

<img width="1511" height="850" alt="Screenshot 2026-03-09 at 13 25 19" src="https://github.com/user-attachments/assets/455f35ab-94c5-45e3-8363-1ac0b00c486d" />

After:
<img width="1506" height="854" alt="Screenshot 2026-03-09 at 11 56 04" src="https://github.com/user-attachments/assets/e3545d79-abcd-4a4a-84c3-fee7eeb675fc" />

<img width="1507" height="858" alt="Screenshot 2026-03-09 at 12 37 58" src="https://github.com/user-attachments/assets/9813575c-7acc-433e-8cd6-3d1d346895d8" />

<img width="1509" height="860" alt="Screenshot 2026-03-09 at 12 38 27" src="https://github.com/user-attachments/assets/df5b2c3e-4658-42ff-9391-6034d148c928" />



## Note:
Include the information the reviewers need to know.
