### PR TITLE
Sayali: add server-side caching for volunteer stats data endpoint to optimize date range queries

### DIFF
--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -145,6 +145,11 @@ const reportsController = function () {
         });
       }
     }
+    const cacheKey = `volunteerStatsData_${startDate}_${endDate}_${comparisonStartDate || ''}_${comparisonEndDate || ''}`;
+
+    if (cacheUtil.hasCache(cacheKey)) {
+      return res.status(200).send(cacheUtil.getCache(cacheKey));
+    }
 
     try {
       const [
@@ -281,8 +286,7 @@ const reportsController = function () {
           error: 'Invalid date parameters',
         });
       }
-
-      res.status(200).send({
+      const responseData = {
         volunteerNumberStats,
         mentorNumberStats,
         volunteerHoursStats,
@@ -301,7 +305,12 @@ const reportsController = function () {
         volunteersOverAssignedTime,
         completedAssignedHours,
         totalSummariesSubmitted,
-      });
+      };
+
+      cacheUtil.setCache(cacheKey, responseData);
+      cacheUtil.setKeyTimeToLive(cacheKey, 300);
+
+      res.status(200).send(responseData);
     } catch (err) {
       console.error('Backend Error in getVolunteerStatsData:', err);
       res.status(500).send({ msg: 'Error occured while fetching data. Please try again!' });


### PR DESCRIPTION

<img width="722" height="404" alt="image" src="https://github.com/user-attachments/assets/998b3c77-94c2-48be-b67b-e6d8df3ce677" />

# Description
Implements #(TaskNumber) (Priority Medium)

## Related PRS (if any):
Frontend PR related to backend https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5019

## Main changes explained:
- Updated reportsController.js to add server-side caching for getVolunteerStatsData endpoint
- Cache key is based on startDate, endDate, comparisonStartDate, comparisonEndDate
- Cached response is served instantly for repeated requests with same date range (5 minute TTL)
- Uses existing cacheUtil (nodeCache) already present in the codebase

## How to test:
1. Check out branch Sayali_Optimize_TotalOrgSummary_DateRange
2. npm run build && npm run start
3. Log in as admin
4. Navigate to Dashboard → Total Org Summary
5. Select a date range - verify data loads correctly
6. Switch to different date range, then switch back to first one
7. Verify second load of same date range is significantly faster (served from cache)
8. Verify all dashboard metrics display correctly

## Screenshots or videos of changes:
Refer to frontend https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5019 screenshots 

## Note:
Frontend https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5019 must be merged alongside this for full optimization benefit (frontend caching + debounce).