### PR TITLE
Sohail: Phase 1 - Fix Personal Max Record badge

### DIFF
--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -3,7 +3,7 @@ const UserProfile = require('../models/userProfile');
 const helper = require('../utilities/permissions');
 const escapeRegex = require('../utilities/escapeRegex');
 const cacheClosure = require('../utilities/nodeCache');
-// const userHelper = require('../helpers/userHelper')();
+const userHelper = require('../helpers/userHelper')();
 
 const badgeController = function (Badge) {
   /**
@@ -13,10 +13,10 @@ const badgeController = function (Badge) {
    */
   const cache = cacheClosure();
 
-  // const awardBadgesTest = async function (req, res) {
-  //   await userHelper.awardNewBadges();
-  //   res.status(200).send('Badges awarded');
-  // };
+  const awardNewBadges = async function (req, res) {
+    await userHelper.awardNewBadges();
+    res.status(200).send('Badges awarded');
+  };
 
   const getAllBadges = async function (req, res) {
     // console.log(req.body.requestor);  // Retain logging from development branch for debugging
@@ -341,7 +341,7 @@ const badgeController = function (Badge) {
   };
 
   return {
-    // awardBadgesTest,
+    awardNewBadges,
     getAllBadges,
     assignBadges,
     postBadge,

--- a/src/helpers/__tests__/checkPersonalMax.spec.js
+++ b/src/helpers/__tests__/checkPersonalMax.spec.js
@@ -1,0 +1,247 @@
+const mongoose = require('mongoose');
+
+/* =======================
+   MOCKS (MUST COME FIRST)
+   ======================= */
+
+jest.mock('../../models/userProfile', () => ({
+  updateOne: jest.fn(),
+  findByIdAndUpdate: jest.fn(),
+}));
+
+jest.mock('../../models/badge', () => ({
+  find: jest.fn(),
+}));
+
+// Mock all heavy dependencies userHelper pulls in
+jest.mock('../../models/team', () => ({}));
+jest.mock('../../models/timeentry', () => ({}));
+jest.mock('../../models/timeOffRequest', () => ({}));
+jest.mock('../../models/profileInitialSetupToken', () => ({}));
+jest.mock('../../models/BlueSquareEmailAssignment', () => ({}));
+jest.mock('../../helpers/dashboardhelper', () => () => ({}));
+jest.mock('../../helpers/helperModels/myTeam', () => ({}));
+jest.mock('../../utilities/emailSender', () => ({}));
+jest.mock('../../utilities/timeUtils', () => ({}));
+jest.mock('../../services/notificationService', () => ({}));
+jest.mock('../../constants/message', () => ({ NEW_USER_BLUE_SQUARE_NOTIFICATION_MESSAGE: '' }));
+jest.mock('../../utilities/nodeCache', () => () => ({
+  hasCache: jest.fn(() => false),
+  removeCache: jest.fn(),
+  getCache: jest.fn(),
+  setCache: jest.fn(),
+}));
+jest.mock('../../startup/logger', () => ({
+  logException: jest.fn(),
+}));
+jest.mock('puppeteer', () => ({}));
+jest.mock('sharp', () => ({}));
+
+/* =======================
+   IMPORTS AFTER MOCKS
+   ======================= */
+
+const userProfile = require('../../models/userProfile');
+const badge = require('../../models/badge');
+const userHelperFactory = require('../userHelper');
+
+const { checkPersonalMax } = userHelperFactory();
+
+/* =======================
+   HELPERS
+   ======================= */
+
+const masterBadgeId = new mongoose.Types.ObjectId();
+const personId = new mongoose.Types.ObjectId();
+
+const makeBadge = (overrides = {}) => ({
+  _id: new mongoose.Types.ObjectId(),
+  badge: { _id: masterBadgeId, type: 'Personal Max' },
+  count: 1,
+  earnedDate: ['Jan-01-25'],
+  ...overrides,
+});
+
+const makeUser = (overrides = {}) => ({
+  lastWeekTangibleHrs: 10,
+  savedTangibleHrs: [10],
+  personalBestMaxHrs: 0,
+  ...overrides,
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  badge.find.mockResolvedValue([{ _id: masterBadgeId, type: 'Personal Max' }]);
+  userProfile.updateOne.mockResolvedValue({});
+  userProfile.findByIdAndUpdate.mockImplementation((id, update, cb) => {
+    if (typeof cb === 'function') cb(null);
+    return Promise.resolve({});
+  });
+});
+
+/* =======================
+   TESTS
+   ======================= */
+
+describe('checkPersonalMax', () => {
+  // 1. No master badge in DB — should bail out early
+  test('does nothing if no master Personal Max badge exists', async () => {
+    badge.find.mockResolvedValue([]);
+    const user = makeUser();
+    await checkPersonalMax(personId, user, []);
+    expect(userProfile.updateOne).not.toHaveBeenCalled();
+    expect(userProfile.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  // 2. New user — no badge yet, first week logging hours
+  test('adds badge for new user and sets initial personal max', async () => {
+    const user = makeUser({
+      lastWeekTangibleHrs: 10,
+      savedTangibleHrs: [10],
+      personalBestMaxHrs: 0,
+    });
+    await checkPersonalMax(personId, user, []);
+    // badge should be added
+    expect(userProfile.findByIdAndUpdate).toHaveBeenCalled();
+    // record should be set since previousMax = 0 and lastWeek = 10
+    expect(userProfile.updateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: personId }),
+      expect.objectContaining({ $set: expect.objectContaining({ personalBestMaxHrs: 10 }) }),
+    );
+  });
+
+  // 3. New user logs 0 hours — badge added but no record set
+  test('adds badge for new user but does not set record if 0 hours logged', async () => {
+    const user = makeUser({ lastWeekTangibleHrs: 0, savedTangibleHrs: [0], personalBestMaxHrs: 0 });
+    await checkPersonalMax(personId, user, []);
+    expect(userProfile.findByIdAndUpdate).toHaveBeenCalled();
+    expect(userProfile.updateOne).not.toHaveBeenCalled();
+  });
+
+  // 4. Existing user breaks the record
+  test('updates earnedDate and personalBestMaxHrs when record is broken', async () => {
+    const user = makeUser({
+      lastWeekTangibleHrs: 20,
+      savedTangibleHrs: [10, 8, 15, 12, 20],
+      personalBestMaxHrs: 15,
+    });
+    await checkPersonalMax(personId, user, [makeBadge()]);
+    expect(userProfile.updateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: personId }),
+      expect.objectContaining({ $set: expect.objectContaining({ personalBestMaxHrs: 20 }) }),
+    );
+  });
+
+  // 5. Existing user does not break the record
+  test('does not update badge when record is not broken', async () => {
+    const user = makeUser({
+      lastWeekTangibleHrs: 10,
+      savedTangibleHrs: [10, 8, 15, 12, 10],
+      personalBestMaxHrs: 15,
+    });
+    await checkPersonalMax(personId, user, [makeBadge()]);
+    expect(userProfile.updateOne).not.toHaveBeenCalled();
+  });
+
+  // 6. Existing user ties the record — should NOT update
+  test('does not update badge when hours tie the previous record', async () => {
+    const user = makeUser({
+      lastWeekTangibleHrs: 15,
+      savedTangibleHrs: [10, 8, 15, 12, 15],
+      personalBestMaxHrs: 15,
+    });
+    await checkPersonalMax(personId, user, [makeBadge()]);
+    expect(userProfile.updateOne).not.toHaveBeenCalled();
+  });
+
+  // 7. Existing user logs 0 hours
+  test('does not update badge when user logs 0 hours', async () => {
+    const user = makeUser({
+      lastWeekTangibleHrs: 0,
+      savedTangibleHrs: [10, 8, 0],
+      personalBestMaxHrs: 10,
+    });
+    await checkPersonalMax(personId, user, [makeBadge()]);
+    expect(userProfile.updateOne).not.toHaveBeenCalled();
+  });
+
+  // 8. User has duplicate Personal Max badges — duplicates removed, record not broken
+  test('removes duplicate badges when record is not broken', async () => {
+    const badge1 = makeBadge();
+    const badge2 = makeBadge();
+    const user = makeUser({
+      lastWeekTangibleHrs: 5,
+      savedTangibleHrs: [10, 5],
+      personalBestMaxHrs: 10,
+    });
+    await checkPersonalMax(personId, user, [badge1, badge2]);
+    // removeDupBadge calls findByIdAndUpdate with $pull
+    expect(userProfile.findByIdAndUpdate).toHaveBeenCalledWith(
+      personId,
+      expect.objectContaining({ $pull: expect.anything() }),
+      expect.anything(),
+      expect.anything(),
+    );
+    expect(userProfile.updateOne).not.toHaveBeenCalled();
+  });
+
+  // 9. User has duplicate badges AND breaks record
+  test('removes duplicates and updates badge when record is broken', async () => {
+    const badge1 = makeBadge();
+    const badge2 = makeBadge();
+    const user = makeUser({
+      lastWeekTangibleHrs: 25,
+      savedTangibleHrs: [10, 8, 20, 25],
+      personalBestMaxHrs: 20,
+    });
+    await checkPersonalMax(personId, user, [badge1, badge2]);
+    expect(userProfile.findByIdAndUpdate).toHaveBeenCalled();
+    expect(userProfile.updateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: personId }),
+      expect.objectContaining({ $set: expect.objectContaining({ personalBestMaxHrs: 25 }) }),
+    );
+  });
+
+  // 10. Full savedTangibleHrs array (200 entries), last entry is current week
+  test('correctly identifies record break with full 200-entry history', async () => {
+    const history = Array(199).fill(20); // previous 199 weeks all at 20hrs
+    const savedTangibleHrs = [...history, 25]; // current week = 25
+    const user = makeUser({
+      lastWeekTangibleHrs: 25,
+      savedTangibleHrs,
+      personalBestMaxHrs: 20,
+    });
+    await checkPersonalMax(personId, user, [makeBadge()]);
+    expect(userProfile.updateOne).toHaveBeenCalledWith(
+      expect.objectContaining({ _id: personId }),
+      expect.objectContaining({ $set: expect.objectContaining({ personalBestMaxHrs: 25 }) }),
+    );
+  });
+
+  // 11. Full 200-entry history, current week does NOT break record
+  test('does not update when current week does not beat full 200-entry history', async () => {
+    const history = Array(199).fill(20);
+    history[100] = 30; // a previous week had 30hrs
+    const savedTangibleHrs = [...history, 25]; // current week = 25, previous max = 30
+    const user = makeUser({
+      lastWeekTangibleHrs: 25,
+      savedTangibleHrs,
+      personalBestMaxHrs: 30,
+    });
+    await checkPersonalMax(personId, user, [makeBadge()]);
+    expect(userProfile.updateOne).not.toHaveBeenCalled();
+  });
+
+  // 12. earnedDate is replaced (not appended) when record is broken
+  test('replaces earnedDate array rather than appending', async () => {
+    const user = makeUser({
+      lastWeekTangibleHrs: 30,
+      savedTangibleHrs: [10, 20, 30],
+      personalBestMaxHrs: 20,
+    });
+    await checkPersonalMax(personId, user, [makeBadge({ earnedDate: ['Jan-01-25', 'Feb-01-25'] })]);
+    const setArg = userProfile.updateOne.mock.calls[0][1].$set;
+    expect(Array.isArray(setArg['badgeCollection.$.earnedDate'])).toBe(true);
+    expect(setArg['badgeCollection.$.earnedDate']).toHaveLength(1);
+  });
+});

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -2329,61 +2329,46 @@ const userHelper = function () {
 
   // 'Personal Max',
   const checkPersonalMax = async function (personId, user, badgeCollection) {
-    let badgeOfType;
-    const duplicateBadges = [];
     const currentDate = moment().tz('America/Los_Angeles').format('MMM-DD-YY');
+    const lastWeek = user.lastWeekTangibleHrs;
 
     const masterBadges = await badge.find({ type: 'Personal Max' });
-    console.log(`[DEBUG] Found master badges: `);
+    if (!masterBadges.length) return;
 
-    // Check for existing badge in badgeCollection
-    for (let i = 0; i < badgeCollection.length; i += 1) {
-      const b = badgeCollection[i];
-      if (b.badge?.type === 'Personal Max') {
-        console.log(`[DEBUG] Found Personal Max badge at index $`);
-        if (!badgeOfType) {
-          badgeOfType = b;
-        } else {
-          duplicateBadges.push(b);
-          console.log(`[DEBUG] Found duplicate Personal Max badge:)}`);
-        }
-        break;
-      }
+    const masterBadgeId = masterBadges[0]._id;
+
+    // Collect all Personal Max badges from the user's collection
+    const personalMaxBadges = badgeCollection.filter((b) => b.badge?.type === 'Personal Max');
+
+    // Remove all duplicates beyond the first
+    for (let i = 1; i < personalMaxBadges.length; i += 1) {
+      await removeDupBadge(personId, personalMaxBadges[i]._id);
     }
 
-    // Remove duplicate badges
-    for (const b of duplicateBadges) {
-      // console.log(`[DEBUG] Removing duplicate badge with ID: ${b._id}`);
-      await removeDupBadge(personId, b._id);
+    const badgeOfType = personalMaxBadges[0] || null;
+
+    // Add badge if user doesn't have one yet
+    if (!badgeOfType) {
+      await addBadge(personId, masterBadgeId);
     }
 
-    // Add new badge if missing
-    if (!badgeOfType && masterBadges.length > 0) {
-      const newBadgeId = masterBadges[0]._id;
-      console.log(`[DEBUG] No existing badge found. Adding new badge ID: ${newBadgeId}`);
-      await addBadge(personId, newBadgeId);
-    }
-
-    const lastWeek = user.lastWeekTangibleHrs;
+    // Compare against all previous weeks (exclude last entry which is the current week)
     const savedHrs = user.savedTangibleHrs || [];
-    const lastSaved = savedHrs[savedHrs.length - 1];
-    const personalBest = user.personalBestMaxHrs;
+    const previousMax = savedHrs.length > 1 ? Math.max(...savedHrs.slice(0, -1)) : 0;
 
-    if (
-      lastWeek &&
-      lastSaved > lastWeek &&
-      lastWeek >= personalBest &&
-      !badgeOfType?.earnedDate?.includes(currentDate)
-    ) {
-      console.log(`[DEBUG] Conditions met to increase badge count`);
-      if (badgeOfType) {
-        await increaseBadgeCount(personId, mongoose.Types.ObjectId(badgeOfType.badge._id));
-      }
+    // If last week's hours broke the personal record, update the badge's earnedDate and personalBestMaxHrs
+    if (lastWeek && lastWeek > previousMax) {
+      await userProfile.updateOne(
+        { _id: personId, 'badgeCollection.badge': masterBadgeId },
+        {
+          $set: {
+            'badgeCollection.$.earnedDate': [currentDate],
+            'badgeCollection.$.lastModified': Date.now().toString(),
+            personalBestMaxHrs: lastWeek,
+          },
+        },
+      );
     }
-
-    console.log(`[DEBUG] Updating personal max...`);
-    await updatePersonalMax(personId, user);
-    console.log(`[DEBUG] checkPersonalMax complete for personId: ${personId}`);
   };
 
   // 'Most Hrs in Week'
@@ -3480,6 +3465,7 @@ const userHelper = function () {
     sendUserSeparatedEmail,
     sendUserReactivatedAfterSeparation,
     weeklyCompanySummaryEmail,
+    checkPersonalMax,
   };
 };
 

--- a/src/routes/badgeRouter.js
+++ b/src/routes/badgeRouter.js
@@ -5,7 +5,7 @@ const routes = function (badge) {
 
   const badgeRouter = express.Router();
 
-  // badgeRouter.get('/badge/awardBadgesTest', controller.awardBadgesTest);
+  badgeRouter.post('/badge/awardNewBadges', controller.awardNewBadges);
 
   badgeRouter.route('/badge').get(controller.getAllBadges).post(controller.postBadge);
 


### PR DESCRIPTION
# Description

This PR fixes critical issues with the Personal Max badge assignment and update logic that were causing the badge to never/incorrectly update when a user broke their personal weekly hours record.

**Fixes:** Personal Max badge assignment and update logic (Priority: High)

Original PR: #1193 

## Issues Fixed:

1. The badge count was being incremented each time a record was broken, when only one Personal Max badge should ever exist per user.
2. A race condition caused `personalBestMaxHrs` to be updated by `$max` earlier in the weekly flow before `checkPersonalMax` ran, meaning the comparison `lastWeek > personalBest` always evaluated to false and the badge never updated.
3. The `earnedDate` was being appended to rather than replaced when a new record was set.
4. The broken condition `lastSaved > lastWeek` was always false since both values are set to the same `timeSpent` in the same atomic DB operation.

## Main changes explained:

- **Updated `src/helpers/userHelper.js`**: Rewrote `checkPersonalMax` function with correct badge assignment logic
  - User now has exactly ONE Personal Max badge at all times
  - When a new weekly record is broken, `earnedDate` is replaced with the current date and `personalBestMaxHrs` is updated in the same atomic DB operation
  - Record comparison now uses `Math.max(...savedTangibleHrs.slice(0, -1))` to derive the previous best from history, bypassing the race condition with `personalBestMaxHrs`
  - A tie does not count as a new record (strictly greater than)
  - Duplicate badge cleanup retained
  - Badge is automatically added for users who do not yet have one
- **Added `src/helpers/__tests__/checkPersonalMax.spec.js`**: Unit test file covering 12 edge cases, all passing

## How to test:

1. Check out current branch
2. Run `npm install` to ensure dependencies are up to date
3. Run `npm run dev` to start the server locally
4. Send POST request to `/api/login`, save the response auth token as a header in Postman
5. Log in as an owner user
6. Connect with our MongoDB server -> UserProfiles Collection -> Your user profile -> Test with different hours in `savedTangibleHrs` (For assuming hours for the most recent week, assign `lastWeekTangibleHours`)
8. Test badge assignment via POST request to `/api/badge/awardNewBadges`

> [!IMPORTANT]
> Replace `awardNewBadges` in `src/helpers/userHelper.js` with this before sending an API call to ensure you only test for your dev account:

```js
const awardNewBadges = async () => {
  try {
    const users = await userProfile
      .find({ isActive: true, firstName: 'Sohail', lastName: 'Admin' })
      .populate('badgeCollection.badge');
    const user = users[0];
    const { _id, badgeCollection } = user;
    const personId = mongoose.Types.ObjectId(_id);
    await checkPersonalMax(personId, user, badgeCollection);
    if (cache.hasCache(`user-${_id}`)) {
      cache.removeCache(`user-${_id}`);
    }
  } catch (err) {
    console.log(err);
    logger.logException(err);
  }
};
```

9. To run the unit tests:

```bash
npx jest src/helpers/__tests__/checkPersonalMax.spec.js --no-coverage --forceExit
```

10. Verify the following scenarios:

### Test Scenario 1: New User — First Week Logging Hours
- Set `savedTangibleHrs` = [10], `lastWeekTangibleHrs` = 10, `personalBestMaxHrs` = 0
- Badge should be added, `earnedDate` = today, `personalBestMaxHrs` = 10

### Test Scenario 2: Record Broken
- Set `savedTangibleHrs` = [10, 8, 15, 12, 20], `lastWeekTangibleHrs` = 20
- Badge `earnedDate` should update to today, `personalBestMaxHrs` = 20

### Test Scenario 3: Record Not Broken / Tied
- Set `lastWeekTangibleHrs` to a value equal to or less than the max of prior weeks
- Badge should remain unchanged

### Test Scenario 4: Zero Hours Logged
- Set `lastWeekTangibleHrs` = 0
- Badge should not update

### Test Scenario 5: Duplicate Badge Cleanup
- If user has multiple Personal Max badges, all but one should be removed automatically

## Expected Results:

- ✅ Each user has exactly ONE Personal Max badge
- ✅ Badge `earnedDate` is replaced (not appended) when a new record is set
- ✅ `personalBestMaxHrs` is updated atomically alongside the badge
- ✅ A tie does not trigger a badge update
- ✅ Zero hours logged does not trigger a badge update
- ✅ New users get the badge assigned on their first week with hours
- ✅ Duplicate badges are cleaned up automatically

## Note:

- The Personal Max badge tracks the highest tangible hours a user has logged in a single week
- The weekly cron job (`awardNewBadges`) runs every Sunday at 12 AM and calls `checkPersonalMax` for each active user
- The record comparison uses `savedTangibleHrs` history (last 200 weeks) excluding the current week, not the stored `personalBestMaxHrs` field, to avoid the race condition with the `$max` update earlier in the weekly flow
