### PR TITLE
Sohail: HGN Questionnaire Dashboard: Community Members (Filtered Members View)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1392,7 +1392,6 @@
     "node_modules/@babel/core": {
       "version": "7.28.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -4155,7 +4154,6 @@
     "node_modules/@redis/client": {
       "version": "1.6.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -5231,7 +5229,6 @@
     "node_modules/@types/node-fetch": {
       "version": "2.6.13",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/node": "*",
         "form-data": "^4.0.4"
@@ -5376,7 +5373,6 @@
       "version": "8.15.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6506,7 +6502,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -8197,7 +8192,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -8361,7 +8355,6 @@
       "version": "2.32.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8413,7 +8406,6 @@
       "version": "6.10.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "aria-query": "^5.3.2",
         "array-includes": "^3.1.8",
@@ -8442,7 +8434,6 @@
       "version": "7.37.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -8474,7 +8465,6 @@
       "version": "4.6.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },

--- a/src/controllers/communityController.js
+++ b/src/controllers/communityController.js
@@ -9,22 +9,31 @@ const communityMemberController = function () {
       if (search) {
         query['userInfo.name'] = { $regex: search, $options: 'i' };
       }
-      const formResponses = await FormResponse.find(query).sort({
-        'userInfo.name': sortOrder === 'asc' ? 1 : -1,
-      });
+
+      // Use .lean() to get plain JS objects so Object.entries() works correctly on subdocuments
+      const formResponses = await FormResponse.find(query)
+        .lean()
+        .sort({ 'userInfo.name': sortOrder === 'asc' ? 1 : -1 });
 
       const skillFilters = skills ? skills.split(',').map((s) => s.trim().toLowerCase()) : [];
+
+      // Extract skill keys that have a numeric rating value, excluding 'overall' and internal fields
+      const extractSkills = (section) => {
+        if (!section || typeof section !== 'object') return {};
+        return Object.entries(section).reduce((acc, [key, val]) => {
+          if (key.toLowerCase() === 'overall' || key.startsWith('$') || key.startsWith('_')) {
+            return acc;
+          }
+          const num = parseFloat(val);
+          if (!Number.isNaN(num)) {
+            acc[key] = num;
+          }
+          return acc;
+        }, {});
+      };
+
       const structuredMembers = formResponses.map((member) => {
         const { userInfo, frontend, backend, general } = member;
-
-        const extractSkills = (section) =>
-          Object.entries(section || {}).reduce((acc, [key, val]) => {
-            const num = parseFloat(val);
-            if (key.toLowerCase() !== 'overall' && !Number.isNaN(num)) {
-              acc[key] = num;
-            }
-            return acc;
-          }, {});
 
         return {
           _id: member._id,
@@ -42,12 +51,11 @@ const communityMemberController = function () {
       const filteredMembers =
         skillFilters.length > 0
           ? structuredMembers.filter((member) => {
-              const allSkills = {
-                ...member.skills.frontend,
-                ...member.skills.backend,
-              };
-              const lowercased = Object.keys(allSkills).map((s) => s.toLowerCase());
-              return skillFilters.every((filterSkill) => lowercased.includes(filterSkill));
+              const allSkillKeys = [
+                ...Object.keys(member.skills.frontend),
+                ...Object.keys(member.skills.backend),
+              ].map((s) => s.toLowerCase());
+              return skillFilters.every((filterSkill) => allSkillKeys.includes(filterSkill));
             })
           : structuredMembers;
 

--- a/src/controllers/communityController.js
+++ b/src/controllers/communityController.js
@@ -3,11 +3,16 @@ const FormResponse = require('../models/hgnFormResponse');
 const communityMemberController = function () {
   const getCommunityMembers = async function (req, res) {
     try {
-      const query = {};
-      const { search, skills, sortOrder = 'asc' } = req.query;
+      const { search, skills } = req.query;
 
+      // Validate sortOrder against an allowlist to prevent injection
+      const sortOrder = req.query.sortOrder === 'desc' ? 'desc' : 'asc';
+
+      const query = {};
       if (search) {
-        query['userInfo.name'] = { $regex: search, $options: 'i' };
+        // Escape regex special characters to prevent ReDoS
+        const escapedSearch = search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+        query['userInfo.name'] = { $regex: escapedSearch, $options: 'i' };
       }
 
       // Use .lean() to get plain JS objects so Object.entries() works correctly on subdocuments
@@ -34,7 +39,6 @@ const communityMemberController = function () {
 
       const structuredMembers = formResponses.map((member) => {
         const { userInfo, frontend, backend, general } = member;
-
         return {
           _id: member._id,
           name: userInfo?.name || 'N/A',


### PR DESCRIPTION

# Description
Task: HGN Questionnaire Dashboard: Community Members (Filtered Members View)

**Route**: /hgnhelp/community
**Related PR:**  [PR 4214](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4214) -> [4503](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4503)
**Purpose**: Displays community members with skill-based filtering.
**Issue**:
- Team members are not displayed after clicking fliters. Shows failed to load members
- Investigate and fix the backend API/endpoint used to retrieve team members (assign new developer if required).

The `GET /api/hgnHelp/community` endpoint was returning an empty result set whenever skill-based filters were used. Two bugs in `communityController.js` were identified as the cause:

1. `FormResponse.find()` was called without `.lean()`, returning Mongoose documents instead of plain JS objects. `Object.entries()` on Mongoose subdocuments does not enumerate actual data fields, so `extractSkills` always produced empty objects, meaning no member ever matched a skill filter.
2. Without proper key guards in `extractSkills`, internal Mongoose/MongoDB fields (prefixed with `$` or `_`) could surface during enumeration and pollute the skill key list.

## Related PRs (if any):

This backend PR is related to the development frontend branch.

## Main changes explained:

- Update `src/controllers/communityController.js` to add `.lean()` to the `FormResponse.find()` query so plain JS objects are returned, allowing `Object.entries()` to correctly enumerate skill fields.
- Update `src/controllers/communityController.js` to add key guards in `extractSkills` that skip keys starting with `$` or `_`, preventing internal fields from appearing in skill results.
- Move `extractSkills` outside the `.map()` callback to avoid redefining the function on every iteration.

## How to test:

1. Check out branch `fix/community-members-skill-filter`
2. Run `npm install` then start the server
3. Clear site data/cache
4. Log in as an admin user
5. Navigate to `/hgnhelp/community`
6. Apply one or more skill filters (e.g. `React`, `MongoDB`)
7. Verify that matching community members are displayed in the list
8. Verify that with no filters applied, all members are still shown
9. Verify that the `search` and `sortOrder` query params still work as expected

## Screenshots or videos of changes:

Before:
<img width="1777" height="604" alt="image" src="https://github.com/user-attachments/assets/d4eae63c-c005-4576-924c-817c1e4f8635" />

After:
<img width="1874" height="821" alt="Screenshot 2026-03-29 025723" src="https://github.com/user-attachments/assets/3a8beeee-5b36-43dc-82f6-fbb188555c32" />