### PR TITLE
Yu Yan - Take over PR #1748 - fix: Removed userId of deleted users from task->resources and teams->members

### DIFF
--- a/src/controllers/userProfileController.deleteUserProfile.spec.js
+++ b/src/controllers/userProfileController.deleteUserProfile.spec.js
@@ -1,7 +1,12 @@
 jest.mock('../helpers/userHelper', () => () => ({}));
+jest.mock('jsonwebtoken', () => ({
+  sign: jest.fn(),
+}));
 jest.mock('../models/timeentry', () => ({}));
 jest.mock('../models/team', () => ({
-  updateMany: jest.fn(),
+  collection: {
+    updateMany: jest.fn(),
+  },
 }));
 jest.mock('../models/badge', () => ({}));
 jest.mock('../utilities/nodeCache', () =>
@@ -15,7 +20,9 @@ jest.mock('../models/followUp', () => ({
   findOneAndDelete: jest.fn(),
 }));
 jest.mock('../models/task', () => ({
-  updateMany: jest.fn(),
+  collection: {
+    updateMany: jest.fn(),
+  },
 }));
 jest.mock('../models/hgnFormResponse', () => ({}));
 jest.mock('../services/userService', () => ({}));
@@ -38,7 +45,6 @@ const Team = require('../models/team');
 const Task = require('../models/task');
 const followUp = require('../models/followUp');
 const { hasPermission, canRequestorUpdateUser } = require('../utilities/permissions');
-const { mockReq, mockRes } = require('../test');
 const userProfileController = require('./userProfileController');
 
 describe('userProfileController deleteUserProfile', () => {
@@ -47,6 +53,8 @@ describe('userProfileController deleteUserProfile', () => {
     findById: jest.fn(),
     deleteOne: jest.fn(),
   };
+  let mockReq;
+  let mockRes;
 
   const makeSut = () => userProfileController(mockUserProfileModel, {});
 
@@ -60,19 +68,21 @@ describe('userProfileController deleteUserProfile', () => {
     });
     mockUserProfileModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
     followUp.findOneAndDelete.mockResolvedValue({});
-    Task.updateMany.mockResolvedValue({ modifiedCount: 1 });
-    Team.updateMany.mockResolvedValue({ modifiedCount: 1 });
-    mockRes.status.mockReturnThis();
-
-    mockReq.body = {
-      ...mockReq.body,
-      userId,
-      option: 'delete',
-      role: 'Volunteer',
-      requestor: {
-        ...mockReq.body.requestor,
-        requestorId: '507f1f77bcf86cd799439011',
+    Task.collection.updateMany.mockResolvedValue({ modifiedCount: 1 });
+    Team.collection.updateMany.mockResolvedValue({ modifiedCount: 1 });
+    mockReq = {
+      body: {
+        userId,
+        option: 'delete',
+        role: 'Volunteer',
+        requestor: {
+          requestorId: '507f1f77bcf86cd799439011',
+        },
       },
+    };
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
     };
   });
 
@@ -86,11 +96,11 @@ describe('userProfileController deleteUserProfile', () => {
 
     expect(mockUserProfileModel.deleteOne).toHaveBeenCalledWith({ _id: userId });
     expect(followUp.findOneAndDelete).toHaveBeenCalledWith({ userId });
-    expect(Task.updateMany).toHaveBeenCalledWith(
+    expect(Task.collection.updateMany).toHaveBeenCalledWith(
       { 'resources.userID': { $in: expectedMatchedUserIds } },
       { $pull: { resources: { userID: { $in: expectedMatchedUserIds } } } },
     );
-    expect(Team.updateMany).toHaveBeenCalledWith(
+    expect(Team.collection.updateMany).toHaveBeenCalledWith(
       { 'members.userId': { $in: expectedMatchedUserIds } },
       { $pull: { members: { userId: { $in: expectedMatchedUserIds } } } },
     );

--- a/src/controllers/userProfileController.deleteUserProfile.spec.js
+++ b/src/controllers/userProfileController.deleteUserProfile.spec.js
@@ -1,0 +1,100 @@
+jest.mock('../helpers/userHelper', () => () => ({}));
+jest.mock('../models/timeentry', () => ({}));
+jest.mock('../models/team', () => ({
+  updateMany: jest.fn(),
+}));
+jest.mock('../models/badge', () => ({}));
+jest.mock('../utilities/nodeCache', () =>
+  jest.fn(() => ({
+    removeCache: jest.fn(),
+    getCache: jest.fn(() => null),
+    setCache: jest.fn(),
+  })),
+);
+jest.mock('../models/followUp', () => ({
+  findOneAndDelete: jest.fn(),
+}));
+jest.mock('../models/task', () => ({
+  updateMany: jest.fn(),
+}));
+jest.mock('../models/hgnFormResponse', () => ({}));
+jest.mock('../services/userService', () => ({}));
+jest.mock('../utilities/permissions', () => ({
+  hasPermission: jest.fn(),
+  canRequestorUpdateUser: jest.fn(),
+}));
+jest.mock('../utilities/emailSender', () => jest.fn());
+jest.mock('../utilities/objectUtils', () => ({
+  deepCopyMongooseObjectWithLodash: jest.fn((value) => value),
+}));
+jest.mock('../startup/logger', () => ({
+  logInfo: jest.fn(),
+  logException: jest.fn(),
+}));
+jest.mock('./reportsController', () => () => ({}));
+
+const mongoose = require('mongoose');
+const Team = require('../models/team');
+const Task = require('../models/task');
+const followUp = require('../models/followUp');
+const { hasPermission, canRequestorUpdateUser } = require('../utilities/permissions');
+const { mockReq, mockRes } = require('../test');
+const userProfileController = require('./userProfileController');
+
+describe('userProfileController deleteUserProfile', () => {
+  const userId = '65cf6c3706d8ac105827bb2e';
+  const mockUserProfileModel = {
+    findById: jest.fn(),
+    deleteOne: jest.fn(),
+  };
+
+  const makeSut = () => userProfileController(mockUserProfileModel, {});
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    hasPermission.mockResolvedValue(true);
+    canRequestorUpdateUser.mockResolvedValue(true);
+    mockUserProfileModel.findById.mockResolvedValue({
+      _id: userId,
+      email: 'volunteer@example.org',
+    });
+    mockUserProfileModel.deleteOne.mockResolvedValue({ deletedCount: 1 });
+    followUp.findOneAndDelete.mockResolvedValue({});
+    Task.updateMany.mockResolvedValue({ modifiedCount: 1 });
+    Team.updateMany.mockResolvedValue({ modifiedCount: 1 });
+    mockRes.status.mockReturnThis();
+
+    mockReq.body = {
+      ...mockReq.body,
+      userId,
+      option: 'delete',
+      role: 'Volunteer',
+      requestor: {
+        ...mockReq.body.requestor,
+        requestorId: '507f1f77bcf86cd799439011',
+      },
+    };
+  });
+
+  test('removes deleted users from tasks and teams using both string and ObjectId matches', async () => {
+    const { deleteUserProfile } = makeSut();
+
+    await deleteUserProfile(mockReq, mockRes);
+
+    const expectedObjectId = new mongoose.Types.ObjectId(userId);
+    const expectedMatchedUserIds = [userId, expectedObjectId];
+
+    expect(mockUserProfileModel.deleteOne).toHaveBeenCalledWith({ _id: userId });
+    expect(followUp.findOneAndDelete).toHaveBeenCalledWith({ userId });
+    expect(Task.updateMany).toHaveBeenCalledWith(
+      { 'resources.userID': { $in: expectedMatchedUserIds } },
+      { $pull: { resources: { userID: { $in: expectedMatchedUserIds } } } },
+    );
+    expect(Team.updateMany).toHaveBeenCalledWith(
+      { 'members.userId': { $in: expectedMatchedUserIds } },
+      { $pull: { members: { userId: { $in: expectedMatchedUserIds } } } },
+    );
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.send).toHaveBeenCalledWith({ message: 'Executed Successfully' });
+  });
+});

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -21,8 +21,7 @@ const Badge = require('../models/badge');
 const yearMonthDayDateValidator = require('../utilities/yearMonthDayDateValidator');
 const cacheClosure = require('../utilities/nodeCache');
 const followUp = require('../models/followUp');
-const task = require('../models/task');
-const team = require('../models/team');
+const Task = require('../models/task');
 const HGNFormResponses = require('../models/hgnFormResponse');
 const userService = require('../services/userService');
 const { hasPermission, canRequestorUpdateUser } = require('../utilities/permissions');
@@ -1429,24 +1428,19 @@ const createControllerMethods = function (UserProfile, Project, cache) {
       await UserProfile.deleteOne({ _id: userId });
       // delete followUp for deleted user
       await followUp.findOneAndDelete({ userId });
-      // Validate and convert userId to ObjectId for proper matching in MongoDB
-      let userIdObject;
-      try {
-        userIdObject = new mongoose.Types.ObjectId(userId);
-      } catch (idError) {
-        // If conversion fails, userId might already be an ObjectId or invalid
-        logger.logInfo(`Invalid userId format for ObjectId conversion: ${userId}`);
-        userIdObject = userId;
+      const matchedUserIds = [userId];
+      if (mongoose.Types.ObjectId.isValid(userId)) {
+        matchedUserIds.push(new mongoose.Types.ObjectId(userId));
       }
       // delete user from task-resources
-      await task.updateMany(
-        { 'resources.userID': userIdObject },
-        { $pull: { resources: { userID: userIdObject } } },
+      await Task.updateMany(
+        { 'resources.userID': { $in: matchedUserIds } },
+        { $pull: { resources: { userID: { $in: matchedUserIds } } } },
       );
       // delete user from teams-members
-      await team.updateMany(
-        { 'members.userId': userIdObject },
-        { $pull: { members: { userId: userIdObject } } },
+      await Team.updateMany(
+        { 'members.userId': { $in: matchedUserIds } },
+        { $pull: { members: { userId: { $in: matchedUserIds } } } },
       );
       res.status(200).send({ message: 'Executed Successfully' });
       auditIfProtectedAccountUpdated({

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -1429,8 +1429,15 @@ const createControllerMethods = function (UserProfile, Project, cache) {
       await UserProfile.deleteOne({ _id: userId });
       // delete followUp for deleted user
       await followUp.findOneAndDelete({ userId });
-      // Convert userId to ObjectId for proper matching in MongoDB
-      const userIdObject = new mongoose.Types.ObjectId(userId);
+      // Validate and convert userId to ObjectId for proper matching in MongoDB
+      let userIdObject;
+      try {
+        userIdObject = new mongoose.Types.ObjectId(userId);
+      } catch (idError) {
+        // If conversion fails, userId might already be an ObjectId or invalid
+        logger.logInfo(`Invalid userId format for ObjectId conversion: ${userId}`);
+        userIdObject = userId;
+      }
       // delete user from task-resources
       await task.updateMany(
         { 'resources.userID': userIdObject },

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -1429,13 +1429,18 @@ const createControllerMethods = function (UserProfile, Project, cache) {
       await UserProfile.deleteOne({ _id: userId });
       // delete followUp for deleted user
       await followUp.findOneAndDelete({ userId });
+      // Convert userId to ObjectId for proper matching in MongoDB
+      const userIdObject = new mongoose.Types.ObjectId(userId);
       // delete user from task-resources
       await task.updateMany(
-        { 'resources.userID': userId },
-        { $pull: { resources: { userID: userId } } },
+        { 'resources.userID': userIdObject },
+        { $pull: { resources: { userID: userIdObject } } },
       );
       // delete user from teams-members
-      await team.updateMany({ 'members.userId': userId }, { $pull: { members: { userId } } });
+      await team.updateMany(
+        { 'members.userId': userIdObject },
+        { $pull: { members: { userId: userIdObject } } },
+      );
       res.status(200).send({ message: 'Executed Successfully' });
       auditIfProtectedAccountUpdated({
         requestorId: req.body.requestor.requestorId,

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -1432,16 +1432,18 @@ const createControllerMethods = function (UserProfile, Project, cache) {
       if (mongoose.Types.ObjectId.isValid(userId)) {
         matchedUserIds.push(new mongoose.Types.ObjectId(userId));
       }
-      // delete user from task-resources
-      await Task.updateMany(
-        { 'resources.userID': { $in: matchedUserIds } },
-        { $pull: { resources: { userID: { $in: matchedUserIds } } } },
-      );
-      // delete user from teams-members
-      await Team.updateMany(
-        { 'members.userId': { $in: matchedUserIds } },
-        { $pull: { members: { userId: { $in: matchedUserIds } } } },
-      );
+
+      await Promise.all([
+        // Use raw collection updates so string user ids in existing records are not cast away.
+        Task.collection.updateMany(
+          { 'resources.userID': { $in: matchedUserIds } },
+          { $pull: { resources: { userID: { $in: matchedUserIds } } } },
+        ),
+        Team.collection.updateMany(
+          { 'members.userId': { $in: matchedUserIds } },
+          { $pull: { members: { userId: { $in: matchedUserIds } } } },
+        ),
+      ]);
       res.status(200).send({ message: 'Executed Successfully' });
       auditIfProtectedAccountUpdated({
         requestorId: req.body.requestor.requestorId,

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -1165,14 +1165,9 @@ const createControllerMethods = function (UserProfile, Project, cache) {
 
       // Verify the update was successful by fetching the user directly from DB
       const verificationUser = await UserProfile.findById(userId, 'bioPosted firstName lastName');
-      console.log(
-        `Database verification - User: ${verificationUser.firstName} ${verificationUser.lastName}, bioPosted: ${verificationUser.bioPosted}`,
-      );
 
       if (verificationUser.bioPosted !== bioPosted) {
-        console.error(
-          `WARNING: Database update failed! Expected: ${bioPosted}, Actual: ${verificationUser.bioPosted}`,
-        );
+        console.error('WARNING: Database update failed for bio status.');
         return res.status(500).json({ error: 'Failed to update bio status in database.' });
       }
 

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -21,6 +21,8 @@ const Badge = require('../models/badge');
 const yearMonthDayDateValidator = require('../utilities/yearMonthDayDateValidator');
 const cacheClosure = require('../utilities/nodeCache');
 const followUp = require('../models/followUp');
+const task = require('../models/task');
+const team = require('../models/team');
 const HGNFormResponses = require('../models/hgnFormResponse');
 const userService = require('../services/userService');
 const { hasPermission, canRequestorUpdateUser } = require('../utilities/permissions');
@@ -1427,6 +1429,13 @@ const createControllerMethods = function (UserProfile, Project, cache) {
       await UserProfile.deleteOne({ _id: userId });
       // delete followUp for deleted user
       await followUp.findOneAndDelete({ userId });
+      // delete user from task-resources
+      await task.updateMany(
+        { 'resources.userID': userId },
+        { $pull: { resources: { userID: userId } } },
+      );
+      // delete user from teams-members
+      await team.updateMany({ 'members.userId': userId }, { $pull: { members: { userId } } });
       res.status(200).send({ message: 'Executed Successfully' });
       auditIfProtectedAccountUpdated({
         requestorId: req.body.requestor.requestorId,


### PR DESCRIPTION
# Description
This PR takes over from PR #1748 (originally by Ujjwal, then Yu Yan).

Users that were deleted were not removed from Projects that they were assigned to. This PR ensures that when a user is deleted, they are also removed from Task->Resources (Which is responsible for Projects) and Teams->Members. 

<img width="737" height="219" alt="image" src="https://github.com/user-attachments/assets/e164b6d2-719e-49bd-b0cd-1a0531d4cc37" />


## Related PRS (if any):
- Original PR: #1748

## Main changes explained:
- Modified `userProfileController.js`'s `deleteUserProfile` function to remove the deleted userIds from other collections (tasks and teams)

## How to test:
1. Check into current branch
2. Run `npm run build` and `npm start` to run this PR locally
3. Create users to test the fix (Other Links -> User Management -> Create New User)
4. Add the user to your project task and team
5. Verify that the userId is visible in `tasks` and `teams` collections

<img width="1259" height="881" alt="Screenshot 2025-09-23 212426" src="https://github.com/user-attachments/assets/a0b4b9c7-d73b-4899-ac53-0e0f52bc1b50" />

6. Send the delete user postman request to `http://localhost:4500/api/userProfile/{userId_to_delete}` with the body:

```json
{
  "userId": {userId_to_delete},
  "option": "delete",
  "requestor": {
    "requestorId": {admin_userId}
  }
}