### PR TITLE
Diya 🔥 fix(teams): Show Inactive Teams

### DIFF
--- a/src/controllers/teamController.js
+++ b/src/controllers/teamController.js
@@ -30,11 +30,6 @@ const teamcontroller = function (Team) {
         },
       },
       {
-        $match: {
-          isActive: true,
-        },
-      },
-      {
         $group: {
           _id: {
             teamId: '$_id',


### PR DESCRIPTION
## Description
Fixes a bug where inactive teams disappeared from the Teams page after a page reload. When a team was set to inactive, it would correctly appear in the Inactive Teams tab before reload, but after reload, it was missing from both the Active and Inactive tabs.

## Related PRs:
None

## Main changes explained:
- Update `src/controllers/teamController.js` — remove `$match: { isActive: true }` stage from the `getAllTeams` aggregation pipeline so all teams, regardless of status, are returned to the frontend

## How to test:
1. Check out this branch
2. Run `npm install` and start the backend server
3. Clear site data/cache
4. Log in as an Owner or Admin
5. Go to the Teams page
6. Set any team to inactive via the status toggle
7. Verify the team appears in the Inactive Teams tab and the inactive count increments
8. Reload the page
9. Verify the team still appears in the Inactive Teams tab after reload and is not visible in the Active Teams tab
10. Verify the Total Teams, Active Teams, and Inactive Teams counts are all correct after reload

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/1c9e74ab-172a-4752-ace6-0880627c8be0
