### PR TITLE
Diya 🔥 fix(report): Fixed Weekly Summary Report

### DIFF
--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -266,34 +266,23 @@ const reporthelper = function () {
    * @param {Object} results An array of user objects with selected fields.
    * @return {Object} An array of user objects with properly sorted weeklySummaries by due date.
    */
+  // refactor that handles any week index without hardcoded cases
+
   const formatSummaries = function (results) {
     return results.map((user) => {
       const { weeklySummaries: wS } = user;
-      const wSummaries = [];
 
-      if (Array.isArray(wS) && wS.length && wS.length < 3) {
-        // Common cases for the first entry.
-        if (getTheWeek(wS[0].dueDate) === 0) wSummaries[0] = { ...wS[0] };
-        if (getTheWeek(wS[0].dueDate) === 1) {
-          wSummaries[0] = null;
-          wSummaries[1] = { ...wS[0] };
+      if (!Array.isArray(wS) || !wS.length || wS.length >= 3) return user;
+
+      const wSummaries = [];
+      wS.forEach((entry) => {
+        const weekIndex = getTheWeek(entry.dueDate);
+        if (weekIndex >= 0) {
+          wSummaries[weekIndex] = { ...entry };
         }
-        // When single entry.
-        if (wS.length === 1) {
-          // Special case when first entry belongs to week before last.
-          if (getTheWeek(wS[0].dueDate) === 2) {
-            wSummaries[0] = null;
-            wSummaries[1] = null;
-            wSummaries[2] = { ...wS[0] };
-          }
-        } else {
-          // When two entries.
-          if (getTheWeek(wS[1].dueDate) === 1) wSummaries[1] = { ...wS[1] };
-          if (getTheWeek(wS[1].dueDate) === 2) wSummaries[2] = { ...wS[1] };
-        }
-        user = { ...user, weeklySummaries: wSummaries };
-      }
-      return user;
+      });
+
+      return { ...user, weeklySummaries: wSummaries };
     });
   };
 


### PR DESCRIPTION
# Description
Fixes a bug where the "Three Weeks Ago" tab in the Weekly Summaries report was not displaying any summary data, even when a summary existed in the database.

## Related PRs (if any):
N/A

## Main changes explained:
- Updated `formatSummaries` in `reportHelper.js` to dynamically map weekly summary entries to their correct week index using `getTheWeek`, replacing hardcoded logic that only handled week indices 0, 1, and 2. Week 3 entries were previously silently dropped before reaching the API response.

## How to test:
1. Check out the current branch
2. Run `npm install` and start the server
3. Clear site data/cache
4. Log in as an admin user
5. Navigate to Reports → Weekly Summaries
6. Select the **Three Weeks Ago** tab
7. Verify that a user who submitted a summary three weeks ago has it displayed correctly
8. Update the summary from three weeks ago for your logged-in user if needed to verify

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/179a137e-bb61-4171-a66b-f7abcc078326

## Note:
The root cause was in `formatSummaries` — the function only handled week indices 0–2, so any entry with a `dueDate` belonging to week 3 was mapped to nothing and returned as an empty array in the API response.