### PR TITLE
Diya 🔥 fix(cron): Fixed Weekly Summary Cron

### DIFF
--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -40,6 +40,8 @@ const reportHelper = require('./reporthelper')();
 // eslint-disable-next-line no-promise-executor-return
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const COMPANY_EMAILS = ['onecommunityglobal@gmail.com', 'jae@onecommunityglobal.org']; // DO NOT REMOVE - USED IN WEEKLY SUMMARY EMAILS AND BLUE SQUARE CRON
+
 const userHelper = function () {
   // Update format to "MMM-DD-YY" from "YYYY-MMM-DD" (Confirmed with Jae)
   const earnedDateBadge = () => {
@@ -441,7 +443,7 @@ const userHelper = function () {
         emailBody,
         null,
         null,
-        emailString,
+        COMPANY_EMAILS,
       );
     } catch (err) {
       logger.logException(err);
@@ -868,7 +870,7 @@ const userHelper = function () {
                     'New Infringement Assigned',
                     emailBody,
                     null,
-                    ['onecommunityglobal@gmail.com', 'jae@onecommunityglobal.org'],
+                    COMPANY_EMAILS,
                     status.email,
                     [...new Set([...emailsBCCs])],
                   );
@@ -1926,14 +1928,8 @@ const userHelper = function () {
           administrativeContent,
         ),
         null,
-        ['onecommunityglobal@gmail.com', 'jae@onecommunityglobal.org'],
+        COMPANY_EMAILS,
         emailAddress,
-        // Don't change this is to CC!
-        [...new Set([...bccEmails])],
-        null,
-        ['onecommunityglobal@gmail.com', 'jae@onecommunityglobal.org'],
-        emailAddress,
-        // Don't change this is to CC!
         [...new Set([...bccEmails])],
       );
     });


### PR DESCRIPTION
# Description
Fixes a bug where weekly summary cron job emails were failing to send due to Gmail's 552-5.3.4 header size limit. The `Reply-To` header was being set to a comma-separated string of all user emails (~34,000 bytes), exceeding Gmail's 32,768 byte per header limit. Additionally, refactored hardcoded email arrays across blue square cron jobs into a shared `COMPANY_EMAILS` constant.

## Related PRs:
None

## Main changes explained:
- Added `COMPANY_EMAILS` constant in `userHelper.js` containing the two core org emails, to avoid repetition and make future updates easier
- Updated `emailWeeklySummariesForAllUsers` to pass `COMPANY_EMAILS` as `replyTo` instead of the full `emailString` (all user emails), which was causing the Gmail header size error
- Updated `assignBlueSquareForTimeNotMet` to use `COMPANY_EMAILS` instead of the inline hardcoded array for the `cc` field
- Updated `notifyInfringements` to use `COMPANY_EMAILS` instead of the inline hardcoded array for the `cc` field, and removed the duplicate arguments that were being passed to `emailSender`

## How to test:
1. Check out the current branch
2. Run `npm install` and start the server
3. Trigger the weekly summaries cron job manually using the script below
```bash
const mongoose = require('mongoose');
require('dotenv').config();
const userHelperFactory = require('./userHelper');
async function main() {
  try {
    const mongoUri = process.env.MONGO_URI || process.env.MONGODB_URI;
    if (!mongoUri) {
      throw new Error('Missing MONGO_URI / MONGODB_URI in environment.');
    }
    await mongoose.connect(mongoUri, {
      maxPoolSize: 10,
      serverSelectionTimeoutMS: 30000,
      socketTimeoutMS: 45000,
    });
    console.log('✅ Connected to MongoDB');
    const userhelper = userHelperFactory();
    console.log('🚀 Running emailWeeklySummariesForAllUsers()...\n\n');
    await userhelper.emailWeeklySummariesForAllUsers();
    console.log('\n\n✅ emailWeeklySummariesForAllUsers() finished');
    await mongoose.disconnect();
    process.exit(0);
  } catch (err) {
    console.error('❌ Script failed:', err);
    process.exit(1);
  }
}
module.exports = { main };
if (require.main === module) {
  main()
    .then(() => {
      console.log('Script completed successfully');
      process.exit(0);
    })
    .catch((err) => {
      console.error('Script failed:', err);
      process.exit(1);
    });
}
```
4. You can setup gmail oauth or just use logs to verify the difference in the reply-to addresses.
5. Verify the `Reply-To` header on the received email shows the org emails, not a giant list of all users

## Note:
The root cause of the email failure was `emailString` (a comma-separated list of all ~2000+ user emails) being passed as the `replyTo` argument to `emailSender`, which Nodemailer set directly as the `Reply-To` header value. Gmail rejects headers exceeding 32,768 bytes. The fix passes `COMPANY_EMAILS` (2 addresses) instead. The `emailString` list remains in the email body as intended for admin reference.