### PR TITLE
Diya 🔥 fix(wsEmail): Weekly Summary Email Users

### DIFF
--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -288,6 +288,7 @@ const userHelper = function () {
 
     try {
       const results = await reportHelper.weeklySummaries(weekIndex, weekIndex);
+      const activeResults = results.filter((user) => user.isActive === true);
       // checks for userProfiles who are eligible to receive the weeklySummary Reports
       const userProfileResults = await userProfile.find(
         { getWeeklyReport: true },
@@ -306,12 +307,12 @@ const userHelper = function () {
       const weeklySummaryNotRequiredMessage =
         '<div><b>Weekly Summary:</b> <span style="color: green;"> Not required for this user </span></div>';
 
-      results.sort((a, b) =>
+      activeResults.sort((a, b) =>
         `${a.firstName} ${a.lastName}`.localeCompare(`${b.firstName} ${b.lastName}`),
       );
 
-      for (let i = 0; i < results.length; i += 1) {
-        const result = results[i];
+      for (let i = 0; i < activeResults.length; i += 1) {
+        const result = activeResults[i];
         const {
           firstName,
           lastName,


### PR DESCRIPTION
# Description
Fixes a bug where the weekly summary cron job email was including inactive users in the report. The `weeklySummaries` aggregation intentionally fetches both active and inactive users (to support the final week reporting feature on the UI), but the cron job email should only include active users.

## Related PRs (if any):
None

## Main changes explained:
- Updated `emailWeeklySummariesForAllUsers` in `userHelper.js` to filter results to only active users before building the email body, using `results.filter(user => user.isActive === true)`

## How to test:
1. Check out the current branch
2. Run `npm install` and start the server
3. Trigger the weekly summaries cron job manually
4. Verify the email only contains active users
5. Verify inactive users are not included in the email body or the emails list at the bottom
6. Use logs to verify