### PR TITLE
Manoj - Enhance Material Usage Dashboard with Interactive and Informational Features(Backend)

### DIFF
--- a/src/controllers/bmdashboard/toolUtilizationController.js
+++ b/src/controllers/bmdashboard/toolUtilizationController.js
@@ -1,159 +1,174 @@
 const mongoose = require('mongoose');
 
 const toolUtilizationController = (BuildingTool) => {
+  // Shared helper: compute utilization data for a given set of tools and date range
+  const computeUtilizationForRange = (tools, rangeStart, rangeEnd) => {
+    const totalHours = (rangeEnd - rangeStart) / (1000 * 60 * 60);
+
+    // Group tools by itemType
+    const toolGroups = {};
+    tools.forEach((toolItem) => {
+      if (!toolItem.itemType) return;
+      const toolName = toolItem.itemType.name || 'Unknown Tool';
+      const toolTypeId = toolItem.itemType._id.toString();
+      if (!toolGroups[toolTypeId]) {
+        toolGroups[toolTypeId] = { name: toolName, tools: [] };
+      }
+      toolGroups[toolTypeId].tools.push(toolItem);
+    });
+
+    // Calculate utilization per tool group
+    const utilizationData = Object.values(toolGroups).map((group) => {
+      let totalCheckedOutHours = 0;
+      let totalDowntimeHours = 0;
+      let toolCount = 0;
+
+      group.tools.forEach((toolItem) => {
+        toolCount += 1;
+
+        const relevantLogs = (toolItem.logRecord || []).filter((log) => {
+          const logDate = new Date(log.date);
+          return logDate >= rangeStart && logDate <= rangeEnd;
+        });
+
+        relevantLogs.sort((a, b) => new Date(a.date) - new Date(b.date));
+
+        let checkedOutTime = 0;
+        let lastCheckOut = null;
+
+        relevantLogs.forEach((log) => {
+          if (log.type === 'Check Out') {
+            lastCheckOut = new Date(log.date);
+          } else if (log.type === 'Check In' && lastCheckOut) {
+            const checkInTime = new Date(log.date);
+            const hoursCheckedOut = (checkInTime - lastCheckOut) / (1000 * 60 * 60);
+            checkedOutTime += Math.max(0, hoursCheckedOut);
+            lastCheckOut = null;
+          }
+        });
+
+        if (lastCheckOut) {
+          const hoursCheckedOut = (rangeEnd - lastCheckOut) / (1000 * 60 * 60);
+          checkedOutTime += Math.max(0, hoursCheckedOut);
+        }
+
+        if (relevantLogs.length === 0 && toolItem.logRecord && toolItem.logRecord.length > 0) {
+          const sortedAllLogs = [...toolItem.logRecord].sort(
+            (a, b) => new Date(b.date) - new Date(a.date),
+          );
+          const lastLog = sortedAllLogs[0];
+          if (lastLog && lastLog.type === 'Check Out') {
+            const lastCheckOutDate = new Date(lastLog.date);
+            if (lastCheckOutDate < rangeStart) {
+              checkedOutTime = totalHours;
+            }
+          }
+        }
+
+        totalCheckedOutHours += checkedOutTime;
+      });
+
+      totalDowntimeHours = totalHours * toolCount - totalCheckedOutHours;
+
+      const totalPossibleHours = totalHours * toolCount;
+      const utilizationRate =
+        totalPossibleHours > 0 ? Math.round((totalCheckedOutHours / totalPossibleHours) * 100) : 0;
+
+      return {
+        name: group.name,
+        utilizationRate,
+        downtime: Math.round(totalDowntimeHours * 10) / 10,
+        count: toolCount,
+      };
+    });
+
+    utilizationData.sort((a, b) => b.utilizationRate - a.utilizationRate);
+    return utilizationData;
+  };
+
+  // Split a date range into N weekly buckets
+  const buildWeeklyBuckets = (rangeStart, rangeEnd, numWeeks = 4) => {
+    const buckets = [];
+    for (let i = 0; i < numWeeks; i += 1) {
+      const bucketStart = new Date(rangeEnd);
+      bucketStart.setDate(rangeEnd.getDate() - (numWeeks - i) * 7);
+      const bucketEnd = new Date(rangeEnd);
+      bucketEnd.setDate(rangeEnd.getDate() - (numWeeks - i - 1) * 7);
+      const label = `Week of ${bucketStart.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+      })}`;
+      buckets.push({ label, start: bucketStart, end: bucketEnd });
+    }
+    return buckets;
+  };
+
   const getUtilization = async (req, res) => {
     try {
-      const { tool, project, startDate, endDate } = req.query;
+      const { tool, project, startDate, endDate, groupBy } = req.query;
 
       // Build filter for tools
       const toolFilter = {};
 
-      // Filter by tool type if specified
       if (tool && tool !== 'ALL') {
         if (mongoose.Types.ObjectId.isValid(tool)) {
           toolFilter.itemType = mongoose.Types.ObjectId(tool);
         }
       }
 
-      // Filter by project if specified
       if (project && project !== 'ALL') {
         if (mongoose.Types.ObjectId.isValid(project)) {
           toolFilter.project = mongoose.Types.ObjectId(project);
         }
       }
 
-      // Fetch tools with their log records
-      // For discriminator models, we need to filter by __t field
+      // Fetch all matching tools once
       const tools = await BuildingTool.find({
         ...toolFilter,
-        __t: 'tool_item', // Filter for tool items only (discriminator field)
+        __t: 'tool_item',
       })
         .populate('itemType', 'name')
         .populate('project', 'name')
         .lean();
 
-      // Calculate date range
-      const start = startDate ? new Date(startDate) : null;
-      const end = endDate ? new Date(endDate) : null;
-
-      // If no date range specified, use last 30 days as default
+      // Resolve date range
       const defaultEnd = new Date();
       const defaultStart = new Date();
       defaultStart.setDate(defaultStart.getDate() - 30);
 
-      const rangeStart = start || defaultStart;
-      const rangeEnd = end || defaultEnd;
-      const totalHours = (rangeEnd - rangeStart) / (1000 * 60 * 60); // Convert to hours
+      const rangeStart = startDate ? new Date(startDate) : defaultStart;
+      const rangeEnd = endDate ? new Date(endDate) : defaultEnd;
 
-      // Group tools by itemType (tool name)
-      const toolGroups = {};
+      // --- groupBy=week: return weekly bucketed avg utilization ---
+      if (groupBy === 'week') {
+        const buckets = buildWeeklyBuckets(rangeStart, rangeEnd, 4);
 
-      tools.forEach((toolItem) => {
-        if (!toolItem.itemType) return; // Skip if no itemType
-
-        const toolName = toolItem.itemType.name || 'Unknown Tool';
-        const toolTypeId = toolItem.itemType._id.toString();
-
-        if (!toolGroups[toolTypeId]) {
-          toolGroups[toolTypeId] = {
-            name: toolName,
-            tools: [],
-          };
-        }
-
-        toolGroups[toolTypeId].tools.push(toolItem);
-      });
-
-      // Calculate utilization for each tool type
-      const utilizationData = Object.values(toolGroups).map((group) => {
-        let totalCheckedOutHours = 0;
-        let totalDowntimeHours = 0;
-        let toolCount = 0;
-
-        group.tools.forEach((toolItem) => {
-          toolCount += 1;
-
-          // Filter log records by date range
-          const relevantLogs = (toolItem.logRecord || []).filter((log) => {
-            const logDate = new Date(log.date);
-            return logDate >= rangeStart && logDate <= rangeEnd;
-          });
-
-          // Sort logs by date
-          relevantLogs.sort((a, b) => new Date(a.date) - new Date(b.date));
-
-          // Calculate checked out time
-          let checkedOutTime = 0;
-          let lastCheckOut = null;
-
-          relevantLogs.forEach((log) => {
-            if (log.type === 'Check Out') {
-              lastCheckOut = new Date(log.date);
-            } else if (log.type === 'Check In' && lastCheckOut) {
-              const checkInTime = new Date(log.date);
-              const hoursCheckedOut = (checkInTime - lastCheckOut) / (1000 * 60 * 60);
-              checkedOutTime += Math.max(0, hoursCheckedOut);
-              lastCheckOut = null;
-            }
-          });
-
-          // If still checked out at the end of the range
-          if (lastCheckOut) {
-            const hoursCheckedOut = (rangeEnd - lastCheckOut) / (1000 * 60 * 60);
-            checkedOutTime += Math.max(0, hoursCheckedOut);
-          }
-
-          // If no logs in range, check if tool was checked out before range start
-          if (relevantLogs.length === 0 && toolItem.logRecord && toolItem.logRecord.length > 0) {
-            const sortedAllLogs = [...toolItem.logRecord].sort(
-              (a, b) => new Date(b.date) - new Date(a.date),
-            );
-            const lastLog = sortedAllLogs[0];
-            if (lastLog && lastLog.type === 'Check Out') {
-              const lastCheckOutDate = new Date(lastLog.date);
-              if (lastCheckOutDate < rangeStart) {
-                // Tool was checked out before range start, count entire range as checked out
-                checkedOutTime = totalHours;
-              }
-            }
-          }
-
-          totalCheckedOutHours += checkedOutTime;
+        const weeklyData = buckets.map(({ label, start, end }) => {
+          const utilizationData = computeUtilizationForRange(tools, start, end);
+          const avgUtilization =
+            utilizationData.length > 0
+              ? Math.round(
+                  (utilizationData.reduce((sum, t) => sum + t.utilizationRate, 0) /
+                    utilizationData.length) *
+                    10,
+                ) / 10
+              : 0;
+          return { week: label, avgUtilization };
         });
 
-        // Calculate downtime (time not checked out)
-        totalDowntimeHours = totalHours * toolCount - totalCheckedOutHours;
+        return res.status(200).json(weeklyData);
+      }
 
-        // Calculate utilization rate
-        const totalPossibleHours = totalHours * toolCount;
-        const utilizationRate =
-          totalPossibleHours > 0
-            ? Math.round((totalCheckedOutHours / totalPossibleHours) * 100)
-            : 0;
-
-        return {
-          name: group.name,
-          utilizationRate,
-          downtime: Math.round(totalDowntimeHours * 10) / 10, // Round to 1 decimal place
-          count: toolCount,
-        };
-      });
-
-      // Sort by utilization rate (descending)
-      utilizationData.sort((a, b) => b.utilizationRate - a.utilizationRate);
-
-      res.status(200).json(utilizationData);
+      // --- Default: return per-tool utilization ---
+      const utilizationData = computeUtilizationForRange(tools, rangeStart, rangeEnd);
+      return res.status(200).json(utilizationData);
     } catch (err) {
       console.error('Error calculating tool utilization:', err);
-      res.status(500).json({
-        error: `Server error: ${err.message}`,
-      });
+      res.status(500).json({ error: `Server error: ${err.message}` });
     }
   };
 
-  return {
-    getUtilization,
-  };
+  return { getUtilization };
 };
 
 module.exports = toolUtilizationController;

--- a/src/controllers/bmdashboard/toolUtilizationController.js
+++ b/src/controllers/bmdashboard/toolUtilizationController.js
@@ -135,6 +135,7 @@ const toolUtilizationController = (BuildingTool) => {
           name: group.name,
           utilizationRate,
           downtime: Math.round(totalDowntimeHours * 10) / 10, // Round to 1 decimal place
+          count: toolCount,
         };
       });
 


### PR DESCRIPTION
# Description
<img width="692" height="587" alt="Screenshot 2026-04-16 at 6 46 27 PM" src="https://github.com/user-attachments/assets/690e9468-bee9-4e58-b694-b52be4d836b8" />

## Related PRS (if any):
To test this backend PR you need to checkout the [PR#5162](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5162) frontend PR.
…

## Main changes explained:
Frontend (UtilizationChart.jsx)

1. Enhanced tooltips — full name, utilization, downtime, count
2. Summary banner — total tools, avg utilization, top tool, total downtime
3. Comparison toggle — consistent with Apply button flow
4. Increased Only filter — visible only when comparison is ON
5. Download CSV/PDF — reflects current filters
6. 4-week trend line chart with linear regression trend line
7.  Mock data commented out, real API calls active

Frontend (UtilizationChart.module.css)

1. Summary banner styles
2. Comparison toggle styles
3. Download dropdown styles
4. Trend section styles
5. Full dark mode support

Backend (toolUtilizationController.js)

1. count field added to per-tool response
2. groupBy=week support — single API call for trend data
3. computeUtilizationForRange extracted as shared helper
5. No breaking changes to existing behavior

## How to test:
1. check into current branch
2. do `npm install` and `npm run start` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to /UtilizationChart
6. verify above listed functionalities and also with dark mode.

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/017ce385-0763-4235-9998-f5ef4ffffcb1

