### PR TITLE
Shravan: add kitchen recipe model, controller, and substitute ingredient…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8928,6 +8928,20 @@
       "version": "1.0.0",
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",

--- a/src/controllers/kitchenRecipeController.js
+++ b/src/controllers/kitchenRecipeController.js
@@ -1,0 +1,71 @@
+const kitchenRecipeController = function (KitchenRecipe) {
+  const getRecipes = function (req, res) {
+    KitchenRecipe.find()
+      .then((recipes) => {
+        res.status(200).send(recipes);
+      })
+      .catch((error) => {
+        res.status(500).send({ message: error.message || 'Error fetching recipes' });
+      });
+  };
+
+  const getRecipeById = function (req, res) {
+    const { recipeId } = req.params;
+    KitchenRecipe.findById(recipeId)
+      .then((recipe) => {
+        if (!recipe) {
+          return res.status(404).send({ message: 'Recipe not found' });
+        }
+        return res.status(200).send(recipe);
+      })
+      .catch((error) => {
+        res.status(500).send({ message: error.message || 'Error fetching recipe' });
+      });
+  };
+
+  const substituteIngredient = function (req, res) {
+    const { recipeId } = req.params;
+    const { ingredientId, substituteName, quantity } = req.body;
+
+    if (!ingredientId || !substituteName || !quantity) {
+      return res.status(400).send({
+        message: 'ingredientId, substituteName, and quantity are required',
+      });
+    }
+
+    return KitchenRecipe.findById(recipeId)
+      .then((recipe) => {
+        if (!recipe) {
+          return res.status(404).send({ message: 'Recipe not found' });
+        }
+
+        const ingredient = recipe.ingredients.id(ingredientId);
+        if (!ingredient) {
+          return res.status(404).send({ message: 'Ingredient not found in recipe' });
+        }
+
+        ingredient.name = substituteName;
+        ingredient.quantity = quantity;
+        ingredient.isAvailable = true;
+        recipe.updatedAt = Date.now();
+
+        return recipe.save().then((updatedRecipe) => {
+          res.status(200).send({
+            message: 'Ingredient substituted',
+            recipe: updatedRecipe,
+          });
+        });
+      })
+      .catch((error) => {
+        res.status(500).send({ message: error.message || 'Error substituting ingredient' });
+      });
+  };
+
+  return {
+    getRecipes,
+    getRecipeById,
+    substituteIngredient,
+  };
+};
+
+module.exports = kitchenRecipeController;

--- a/src/models/kitchenRecipe.js
+++ b/src/models/kitchenRecipe.js
@@ -1,0 +1,29 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const ingredientSchema = new Schema({
+  name: { type: String, required: true },
+  quantity: { type: String, required: true },
+  isOnsite: { type: Boolean, default: false },
+  isAvailable: { type: Boolean, default: true },
+});
+
+const kitchenRecipeSchema = new Schema({
+  name: { type: String, required: true },
+  type: { type: String, required: true },
+  description: { type: String },
+  prepTime: { type: Number },
+  servings: { type: Number },
+  difficulty: { type: String, enum: ['Easy', 'Medium', 'Hard'] },
+  tags: [{ type: String }],
+  hasPriorityIngredients: { type: Boolean, default: false },
+  onsitePercentage: { type: Number, default: 0 },
+  ingredients: [ingredientSchema],
+  instructions: [{ type: String }],
+  createdBy: { type: Schema.Types.ObjectId, ref: 'userProfile' },
+  createdAt: { type: Date, default: Date.now },
+  updatedAt: { type: Date, default: Date.now },
+});
+
+module.exports = mongoose.model('kitchenRecipe', kitchenRecipeSchema, 'kitchenRecipes');

--- a/src/routes/kitchenRecipeRouter.js
+++ b/src/routes/kitchenRecipeRouter.js
@@ -1,0 +1,18 @@
+const express = require('express');
+
+const routes = function (KitchenRecipe) {
+  const controller = require('../controllers/kitchenRecipeController')(KitchenRecipe);
+  const kitchenRecipeRouter = express.Router();
+
+  kitchenRecipeRouter.route('/kitchenandinventory/recipes').get(controller.getRecipes);
+
+  kitchenRecipeRouter.route('/kitchenandinventory/recipes/:recipeId').get(controller.getRecipeById);
+
+  kitchenRecipeRouter
+    .route('/kitchenandinventory/recipes/:recipeId/substitute')
+    .put(controller.substituteIngredient);
+
+  return kitchenRecipeRouter;
+};
+
+module.exports = routes;

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -382,6 +382,10 @@ const summaryDashboardRouter = require('../routes/summaryDashboard.routes');
 // Actual Cost
 const actualCostRouter = require('../routes/actualCostRouter')();
 
+// Kitchen and Inventory
+const kitchenRecipe = require('../models/kitchenRecipe');
+const kitchenRecipeRouter = require('../routes/kitchenRecipeRouter')(kitchenRecipe);
+
 module.exports = function (app) {
   app.use('/api/bm/summary-dashboard', summaryDashboardRouter);
   app.use('/api', forgotPwdRouter);
@@ -496,7 +500,6 @@ module.exports = function (app) {
   app.use('/api', toolUtilizationRouter);
   // lb dashboard
 
-
   app.use('/api', toolAvailabilityRouter);
   app.use('/api', projectCostTrackingRouter);
 
@@ -563,4 +566,7 @@ module.exports = function (app) {
   app.use('/api', materialCostRouter);
 
   app.use('/api/lp', lessonPlanSubmissionRouter);
+
+  // Kitchen and Inventory
+  app.use('/api', kitchenRecipeRouter);
 };


### PR DESCRIPTION
# Description
Implements Phase 6 - Kitchen Inventory Management - Backend support for the Recipes module and substitute ingredient functionality.

Adds the kitchen recipe Mongoose model, controller with three endpoints, and route registration. The substitute ingredient endpoint allows the frontend to replace unavailable ingredients in a recipe with available alternatives from inventory, persisting the change to MongoDB.

## Related PRs (if any):
This backend PR is related to the frontend PR in the HighestGoodNetworkApp repository on branch `shravan-substitute-ingredient`.
To test this backend PR you need to checkout the `shravan-substitute-ingredient` frontend PR.

## Main changes explained:
- Create file `src/models/kitchenRecipe.js` for introducing the kitchen recipe Mongoose model with embedded ingredient subdocuments (name, quantity, isOnsite, isAvailable)
- Create file `src/controllers/kitchenRecipeController.js` for introducing getRecipes, getRecipeById, and substituteIngredient controller functions
- Create file `src/routes/kitchenRecipeRouter.js` for registering three endpoints: `GET /kitchenandinventory/recipes`, `GET /kitchenandinventory/recipes/:recipeId`, and `PUT /kitchenandinventory/recipes/:recipeId/substitute`
- Update file `src/startup/routes.js` for adding the kitchenRecipe model require, router require, and app.use registration

## How to test:
1. Check into branch `shravan-substitute-ingredient-backend`
2. Do `npm install` and `npm start` to run this PR locally
3. Log in via `POST /api/login` with admin credentials to get a token
4. Test `GET /api/kitchenandinventory/recipes` with the Authorization header and verify it returns all recipes
5. Test `GET /api/kitchenandinventory/recipes/:recipeId` and verify it returns a single recipe
6. Test `PUT /api/kitchenandinventory/recipes/:recipeId/substitute` with body `{"ingredientId": "INGREDIENT_ID", "substituteName": "White Pepper", "quantity": "1 tsp"}` and verify the ingredient name, quantity, and isAvailable fields are updated in the response
7. Run `GET /api/kitchenandinventory/recipes` again and verify the substitution persisted
8. Test with missing fields (no ingredientId, no substituteName, no quantity) and verify a 400 error is returned
9. Test with an invalid recipeId and verify a 500 error is returned
10. Test with a valid recipeId but invalid ingredientId and verify a 404 "Ingredient not found" error is returned

## Screenshots or videos of changes

#### Get All Recipes

<img width="1470" height="956" alt="Screenshot 2026-04-18 at 12 31 30 AM" src="https://github.com/user-attachments/assets/a3123b7d-130d-4bba-abd6-7968f3f1a2b6" />

#### PUT substitute (success)

<img width="1451" height="312" alt="Screenshot 2026-04-18 at 12 34 33 AM" src="https://github.com/user-attachments/assets/b6420f2f-02cc-4823-a67a-c16bdfcb70b9" />

#### PUT substitute (validation error)

<img width="1470" height="146" alt="Screenshot 2026-04-18 at 12 37 10 AM" src="https://github.com/user-attachments/assets/7e76e869-8e1c-45cf-9a73-e3c561839f29" />

#### GET single recipe 

<img width="1470" height="514" alt="Screenshot 2026-04-18 at 12 37 49 AM" src="https://github.com/user-attachments/assets/d06f5989-e532-4007-9086-4f13d48d216c" />

## Note:
This is the first backend PR for the Kitchen and Inventory portal. The kitchenRecipes collection needs to be populated with recipe data for the endpoints to return results. The frontend PR includes a fallback to mock data if the backend is unavailable. The substitute endpoint updates the ingredient name, quantity, and sets isAvailable to true. The Reorder endpoint will be implemented in a future deliverable.