### PR TITLE
Chirag: Update pagination to be applicable only when specified

### DIFF
--- a/src/controllers/eventController.js
+++ b/src/controllers/eventController.js
@@ -72,10 +72,11 @@ function getPagination(page, limit, total) {
 }
 
 function formatEvent(event, userId) {
+  event.status = updateEventStatus(event);
+
   const eventObj = event.toObject();
   const waitlist = Array.isArray(event.waitlist) ? event.waitlist : [];
 
-  eventObj.status = updateEventStatus(event);
   eventObj.waitlistCount = waitlist.length;
   eventObj.waitlistEnabled = event.currentAttendees >= event.maxAttendees;
 
@@ -88,9 +89,9 @@ function formatEvent(event, userId) {
   return eventObj;
 }
 
-const getEvents = async (req, res) => {
+const getEvents = async function (req, res) {
   try {
-    const { page, limit, type, location, sortBy, userId } = req.query;
+    const { page, limit, type, location, sortBy } = req.query;
 
     validateQuery({ type, location, sortBy });
 
@@ -104,7 +105,7 @@ const getEvents = async (req, res) => {
       .skip(skip)
       .limit(limitNumber);
 
-    const formattedEvents = events.map((event) => formatEvent(event, userId));
+    const formattedEvents = events.map((event) => formatEvent(event, safeQuery.userId));
 
     res.json({
       events: formattedEvents,
@@ -127,34 +128,16 @@ const getEvents = async (req, res) => {
   }
 };
 
-const getEventById = async (req, res) => {
-  const { id } = req.params;
-
-  try {
-    const event = await Event.findById(id).populate('resources.userID');
-    if (!event) {
-      return res.status(404).json({ error: 'Event not found' });
-    }
-    event.status = updateEventStatus(event);
-
-    res.json(event);
-  } catch (error) {
-    res.status(500).json({
-      error: 'Failed to fetch event',
-      details: error.message,
-    });
-  }
-};
-
 const autoPromoteFromWaitlist = (event) => {
   const promotedUsers = [];
 
   while (event.currentAttendees < event.maxAttendees && event.waitlist.length > 0) {
     const nextEntry = event.waitlist.shift();
-    if (nextEntry?.userId) {
-      event.currentAttendees += 1;
-      promotedUsers.push(nextEntry.userId);
-    }
+
+    if (!nextEntry?.userId) continue;
+    console.log(`Auto-promoting user from waitlist for event ${event._id}`);
+    event.currentAttendees += 1;
+    promotedUsers.push(nextEntry.userId);
   }
 
   return promotedUsers;
@@ -195,6 +178,7 @@ const joinWaitlist = async (req, res) => {
   try {
     const { eventId } = req.params;
     const { userId } = req.body;
+    console.log('Join waitlist request received');
 
     if (!userId || !mongoose.Types.ObjectId.isValid(userId)) {
       return res.status(400).json({ error: 'Invalid userId' });
@@ -223,6 +207,7 @@ const joinWaitlist = async (req, res) => {
       position,
     });
   } catch (error) {
+    console.error('JOIN WAITLIST ERROR:', error);
     res.status(500).json({
       error: 'Failed to join waitlist',
       details: error.message,
@@ -232,6 +217,7 @@ const joinWaitlist = async (req, res) => {
 
 const sendWaitlistNotification = async (user, event) => {
   // TODO: Integrate with real notification service (email/queue)
+  console.log(`Sending waitlist notification for event ${event._id}`);
 };
 
 const leaveEvent = async (req, res) => {
@@ -302,7 +288,6 @@ const leaveWaitlist = async (req, res) => {
 
 module.exports = {
   getEvents,
-  getEventById,
   getEventLocations,
   getEventTypes,
   createEvent,

--- a/src/controllers/eventController.js
+++ b/src/controllers/eventController.js
@@ -11,7 +11,7 @@ const updateEventStatus = (event) => {
 };
 
 const getEvents = async (req, res) => {
-  const { page = 1, limit = 9, type = '', location = '', sortBy = 'date' } = req.query;
+  const { page, limit, type = '', location = '', sortBy = 'date' } = req.query;
 
   try {
     const validSortFields = ['date', 'title', 'type', 'location', 'currentAttendees'];
@@ -21,15 +21,24 @@ const getEvents = async (req, res) => {
     if (type) query.type = type;
     if (location) query.location = location;
 
-    const pageNumber = Math.max(1, Number(page));
-    const limitNumber = Math.max(1, Number(limit));
-
     const totalEvents = await Event.countDocuments(query);
-    let events = await Event.find(query)
-      .populate('resources.userID')
-      .sort({ [sortField]: 1 })
-      .skip((pageNumber - 1) * limitNumber)
-      .limit(limitNumber);
+    let events = [];
+    let pageNumber = 1;
+    let limitNumber = totalEvents;
+
+    if (page && limit) {
+      pageNumber = Math.max(1, Number(page));
+      limitNumber = Math.max(1, Number(limit));
+      events = await Event.find(query)
+        .populate('resources.userID')
+        .sort({ [sortField]: 1 })
+        .skip((pageNumber - 1) * limitNumber)
+        .limit(limitNumber);
+    } else {
+      events = await Event.find(query)
+        .populate('resources.userID')
+        .sort({ [sortField]: 1 });
+    }
 
     events = events.map((event) => {
       event.status = updateEventStatus(event);

--- a/src/controllers/eventController.js
+++ b/src/controllers/eventController.js
@@ -10,51 +10,62 @@ const updateEventStatus = (event) => {
   return event.status;
 };
 
-const VALID_TYPES = ['Workshop', 'Meeting', 'Webinar', 'Social Gathering'];
-const VALID_LOCATIONS = ['Virtual', 'In person', 'TBD'];
-const VALID_SORT_FIELDS = ['date', 'title', 'type', 'location', 'currentAttendees'];
-
-const sanitizeQuery = (query) => ({
-  page: Number.isInteger(Number(query.page)) ? Math.max(1, Number(query.page)) : 1,
-  limit: Number.isInteger(Number(query.limit))
-    ? Math.min(100, Math.max(1, Number(query.limit)))
-    : 10,
-  type: VALID_TYPES.includes(query.type) ? query.type : undefined,
-  location: VALID_LOCATIONS.includes(query.location) ? query.location : undefined,
-  sortBy: VALID_SORT_FIELDS.includes(query.sortBy) ? query.sortBy : 'date',
-  userId: query.userId && mongoose.Types.ObjectId.isValid(query.userId) ? query.userId : undefined,
-});
+const VALID_TYPES = new Set(['Workshop', 'Meeting', 'Webinar', 'Social Gathering']);
+const VALID_LOCATIONS = new Set(['Virtual', 'In person', 'TBD']);
+const VALID_SORT_FIELDS = new Set(['date', 'title', 'type', 'location', 'currentAttendees']);
 
 const getEvents = async (req, res) => {
-  const safeQuery = sanitizeQuery(req.query);
-
+  const { page, limit, type, location, sortBy } = req.query;
+  let safeQuery = {};
   try {
-    const sortField = safeQuery.sortBy;
+    if (type && !VALID_TYPES.has(type)) {
+      return res.status(400).send('Invalid Type of Event.');
+    }
 
-    const query = { isActive: true };
-    if (safeQuery.type) query.type = safeQuery.type;
-    if (safeQuery.location) query.location = safeQuery.location;
+    if (location && !VALID_LOCATIONS.has(location)) {
+      return res.status(400).send('Invalid Location for the Event.');
+    }
 
-    const totalEvents = await Event.countDocuments(query);
+    if (sortBy && !VALID_SORT_FIELDS.has(sortBy)) {
+      return res.status(400).send('Invalid Type of Event.');
+    }
+
+    let hasPagination = false;
+    if (page && limit) {
+      hasPagination = true;
+    }
+
+    safeQuery = { isActive: true };
+    if (type) {
+      safeQuery.type = type;
+    }
+
+    if (location === 'Virtual') {
+      safeQuery.location = 'Virtual';
+    } else if (location === 'In person') {
+      safeQuery.location = 'In person';
+    } else if (location === 'TBD') {
+      safeQuery.location = 'TBD';
+    }
+
+    const totalEvents = await Event.countDocuments(safeQuery);
     let events = [];
     let pageNumber = 1;
     let limitNumber = totalEvents;
 
-    const hasPagination = req.query.page !== undefined && req.query.limit !== undefined;
-
     if (hasPagination) {
-      pageNumber = safeQuery.page;
-      limitNumber = safeQuery.limit;
+      pageNumber = Math.max(1, Number(page));
+      limitNumber = Math.max(1, Number(limit));
 
-      events = await Event.find(query)
+      events = await Event.find(safeQuery)
         .populate('resources.userID')
-        .sort({ [sortField]: 1 })
+        .sort({ [sortBy]: 1 })
         .skip((pageNumber - 1) * limitNumber)
         .limit(limitNumber);
     } else {
-      events = await Event.find(query)
+      events = await Event.find(safeQuery)
         .populate('resources.userID')
-        .sort({ [sortField]: 1 });
+        .sort({ [sortBy]: 1 });
     }
 
     events = events.map((event) => {

--- a/src/controllers/eventController.js
+++ b/src/controllers/eventController.js
@@ -14,83 +14,101 @@ const VALID_TYPES = new Set(['Workshop', 'Meeting', 'Webinar', 'Social Gathering
 const VALID_LOCATIONS = new Set(['Virtual', 'In person', 'TBD']);
 const VALID_SORT_FIELDS = new Set(['date', 'title', 'type', 'location', 'currentAttendees']);
 
-const getEvents = async (req, res) => {
-  const { page, limit, type, location, sortBy } = req.query;
-  let safeQuery = {};
+function validateQuery({ type, location, sortBy }) {
+  if (type && !VALID_TYPES.has(type)) {
+    throw new Error('Invalid Type of Event.');
+  }
+
+  if (location && !VALID_LOCATIONS.has(location)) {
+    throw new Error('Invalid Location for the Event.');
+  }
+
+  if (sortBy && !VALID_SORT_FIELDS.has(sortBy)) {
+    throw new Error('Invalid Sort Field.');
+  }
+}
+
+function buildSafeQuery(location, type) {
+  const query = { isActive: true };
+
+  if (location === 'Virtual') {
+    query.location = 'Virtual';
+  } else if (location === 'In person') {
+    query.location = 'In person';
+  } else if (location === 'TBD') {
+    query.location = 'TBD';
+  }
+
+  if (type === 'Workshop') {
+    query.type = 'Workshop';
+  } else if (type === 'Meeting') {
+    query.type = 'Meeting';
+  } else if (type === 'Webinar') {
+    query.type = 'Webinar';
+  } else if (type === 'Social Gathering') {
+    query.type = 'Social Gathering';
+  }
+
+  return query;
+}
+
+function getPagination(page, limit, total) {
+  if (!page || !limit) {
+    return {
+      pageNumber: 1,
+      limitNumber: total,
+      skip: 0,
+    };
+  }
+
+  const pageNumber = Math.max(1, Number(page));
+  const limitNumber = Math.max(1, Number(limit));
+
+  return {
+    pageNumber,
+    limitNumber,
+    skip: (pageNumber - 1) * limitNumber,
+  };
+}
+
+function formatEvent(event, userId) {
+  event.status = updateEventStatus(event);
+
+  const eventObj = event.toObject();
+  const waitlist = Array.isArray(event.waitlist) ? event.waitlist : [];
+
+  eventObj.waitlistCount = waitlist.length;
+  eventObj.waitlistEnabled = event.currentAttendees >= event.maxAttendees;
+
+  if (userId) {
+    const index = waitlist.findIndex((entry) => entry.userId?.toString() === userId.toString());
+
+    eventObj.userWaitlistPosition = index !== -1 ? index + 1 : null;
+  }
+
+  return eventObj;
+}
+
+const getEvents = async function (req, res) {
   try {
-    if (type && !VALID_TYPES.has(type)) {
-      return res.status(400).send('Invalid Type of Event.');
-    }
+    const { page, limit, type, location, sortBy } = req.query;
 
-    if (location && !VALID_LOCATIONS.has(location)) {
-      return res.status(400).send('Invalid Location for the Event.');
-    }
+    validateQuery({ type, location, sortBy });
 
-    if (sortBy && !VALID_SORT_FIELDS.has(sortBy)) {
-      return res.status(400).send('Invalid Type of Event.');
-    }
-
-    let hasPagination = false;
-    if (page && limit) {
-      hasPagination = true;
-    }
-
-    safeQuery = { isActive: true };
-    if (type) {
-      safeQuery.type = type;
-    }
-
-    if (location === 'Virtual') {
-      safeQuery.location = 'Virtual';
-    } else if (location === 'In person') {
-      safeQuery.location = 'In person';
-    } else if (location === 'TBD') {
-      safeQuery.location = 'TBD';
-    }
-
+    const safeQuery = buildSafeQuery(location, type);
     const totalEvents = await Event.countDocuments(safeQuery);
-    let events = [];
-    let pageNumber = 1;
-    let limitNumber = totalEvents;
+    const { pageNumber, limitNumber, skip } = getPagination(page, limit, totalEvents);
 
-    if (hasPagination) {
-      pageNumber = Math.max(1, Number(page));
-      limitNumber = Math.max(1, Number(limit));
+    const events = await Event.find(safeQuery)
+      .populate('resources.userID')
+      .sort(sortBy ? { [sortBy]: 1 } : {})
+      .skip(skip)
+      .limit(limitNumber);
 
-      events = await Event.find(safeQuery)
-        .populate('resources.userID')
-        .sort({ [sortBy]: 1 })
-        .skip((pageNumber - 1) * limitNumber)
-        .limit(limitNumber);
-    } else {
-      events = await Event.find(safeQuery)
-        .populate('resources.userID')
-        .sort({ [sortBy]: 1 });
-    }
-
-    events = events.map((event) => {
-      event.status = updateEventStatus(event);
-
-      const eventObj = event.toObject();
-
-      const waitlist = Array.isArray(event.waitlist) ? event.waitlist : [];
-
-      eventObj.waitlistCount = waitlist.length;
-      eventObj.waitlistEnabled = event.currentAttendees >= event.maxAttendees;
-
-      if (safeQuery.userId) {
-        const index = waitlist.findIndex(
-          (entry) => entry.userId?.toString() === safeQuery.userId.toString(),
-        );
-
-        eventObj.userWaitlistPosition = index !== -1 ? index + 1 : null;
-      }
-
-      return eventObj;
-    });
+    const formattedEvents = events.map((event) => formatEvent(event, safeQuery.userId));
 
     res.json({
-      events,
+      events: formattedEvents,
       pagination: {
         total: totalEvents,
         totalPages: Math.ceil(totalEvents / limitNumber),
@@ -99,12 +117,17 @@ const getEvents = async (req, res) => {
       },
     });
   } catch (error) {
+    if (error.message.startsWith('Invalid')) {
+      return res.status(400).send(error.message);
+    }
+
     res.status(500).json({
       error: 'Failed to fetch events',
       details: error.message,
     });
   }
 };
+
 const autoPromoteFromWaitlist = (event) => {
   const promotedUsers = [];
 

--- a/src/controllers/eventController.js
+++ b/src/controllers/eventController.js
@@ -132,11 +132,10 @@ const autoPromoteFromWaitlist = (event) => {
 
   while (event.currentAttendees < event.maxAttendees && event.waitlist.length > 0) {
     const nextEntry = event.waitlist.shift();
-
-    if (!nextEntry?.userId) continue;
-    console.log(`Auto-promoting user from waitlist for event ${event._id}`);
-    event.currentAttendees += 1;
-    promotedUsers.push(nextEntry.userId);
+    if (nextEntry?.userId) {
+      event.currentAttendees += 1;
+      promotedUsers.push(nextEntry.userId);
+    }
   }
 
   return promotedUsers;
@@ -177,7 +176,6 @@ const joinWaitlist = async (req, res) => {
   try {
     const { eventId } = req.params;
     const { userId } = req.body;
-    console.log('Join waitlist request received');
 
     if (!userId || !mongoose.Types.ObjectId.isValid(userId)) {
       return res.status(400).json({ error: 'Invalid userId' });
@@ -206,7 +204,6 @@ const joinWaitlist = async (req, res) => {
       position,
     });
   } catch (error) {
-    console.error('JOIN WAITLIST ERROR:', error);
     res.status(500).json({
       error: 'Failed to join waitlist',
       details: error.message,
@@ -216,7 +213,7 @@ const joinWaitlist = async (req, res) => {
 
 const sendWaitlistNotification = async (user, event) => {
   // TODO: Integrate with real notification service (email/queue)
-  console.log(`Sending waitlist notification for event ${event._id}`);
+  // console.log(`Sending waitlist notification for event ${event._id}`);
 };
 
 const leaveEvent = async (req, res) => {

--- a/src/controllers/eventController.js
+++ b/src/controllers/eventController.js
@@ -88,7 +88,7 @@ function formatEvent(event, userId) {
   return eventObj;
 }
 
-const getEvents = async function (req, res) {
+const getEvents = async (req, res) => {
   try {
     const { page, limit, type, location, sortBy, userId } = req.query;
 
@@ -122,6 +122,25 @@ const getEvents = async function (req, res) {
 
     res.status(500).json({
       error: 'Failed to fetch events',
+      details: error.message,
+    });
+  }
+};
+
+const getEventById = async (req, res) => {
+  const { id } = req.params;
+
+  try {
+    const event = await Event.findById(id).populate('resources.userID');
+    if (!event) {
+      return res.status(404).json({ error: 'Event not found' });
+    }
+    event.status = updateEventStatus(event);
+
+    res.json(event);
+  } catch (error) {
+    res.status(500).json({
+      error: 'Failed to fetch event',
       details: error.message,
     });
   }
@@ -213,7 +232,6 @@ const joinWaitlist = async (req, res) => {
 
 const sendWaitlistNotification = async (user, event) => {
   // TODO: Integrate with real notification service (email/queue)
-  // console.log(`Sending waitlist notification for event ${event._id}`);
 };
 
 const leaveEvent = async (req, res) => {
@@ -284,6 +302,7 @@ const leaveWaitlist = async (req, res) => {
 
 module.exports = {
   getEvents,
+  getEventById,
   getEventLocations,
   getEventTypes,
   createEvent,

--- a/src/controllers/eventController.js
+++ b/src/controllers/eventController.js
@@ -72,11 +72,10 @@ function getPagination(page, limit, total) {
 }
 
 function formatEvent(event, userId) {
-  event.status = updateEventStatus(event);
-
   const eventObj = event.toObject();
   const waitlist = Array.isArray(event.waitlist) ? event.waitlist : [];
 
+  eventObj.status = updateEventStatus(event);
   eventObj.waitlistCount = waitlist.length;
   eventObj.waitlistEnabled = event.currentAttendees >= event.maxAttendees;
 
@@ -91,7 +90,7 @@ function formatEvent(event, userId) {
 
 const getEvents = async function (req, res) {
   try {
-    const { page, limit, type, location, sortBy } = req.query;
+    const { page, limit, type, location, sortBy, userId } = req.query;
 
     validateQuery({ type, location, sortBy });
 
@@ -105,7 +104,7 @@ const getEvents = async function (req, res) {
       .skip(skip)
       .limit(limitNumber);
 
-    const formattedEvents = events.map((event) => formatEvent(event, safeQuery.userId));
+    const formattedEvents = events.map((event) => formatEvent(event, userId));
 
     res.json({
       events: formattedEvents,

--- a/src/controllers/eventController.js
+++ b/src/controllers/eventController.js
@@ -10,6 +10,9 @@ const updateEventStatus = (event) => {
   return event.status;
 };
 
+const VALID_TYPES = ['Workshop', 'Meeting', 'Webinar', 'Social Gathering'];
+const VALID_LOCATIONS = ['Virtual', 'In person', 'TBD'];
+
 const getEvents = async (req, res) => {
   const { page, limit, type = '', location = '', sortBy = 'date' } = req.query;
 
@@ -18,8 +21,8 @@ const getEvents = async (req, res) => {
     const sortField = validSortFields.includes(sortBy) ? sortBy : 'date';
 
     const query = { isActive: true };
-    if (type) query.type = type;
-    if (location) query.location = location;
+    if (type && VALID_TYPES.includes(type)) query.type = type;
+    if (location && VALID_LOCATIONS.includes(location)) query.location = location;
 
     const totalEvents = await Event.countDocuments(query);
     let events = [];

--- a/src/controllers/eventController.js
+++ b/src/controllers/eventController.js
@@ -12,26 +12,40 @@ const updateEventStatus = (event) => {
 
 const VALID_TYPES = ['Workshop', 'Meeting', 'Webinar', 'Social Gathering'];
 const VALID_LOCATIONS = ['Virtual', 'In person', 'TBD'];
+const VALID_SORT_FIELDS = ['date', 'title', 'type', 'location', 'currentAttendees'];
+
+const sanitizeQuery = (query) => ({
+  page: Number.isInteger(Number(query.page)) ? Math.max(1, Number(query.page)) : 1,
+  limit: Number.isInteger(Number(query.limit))
+    ? Math.min(100, Math.max(1, Number(query.limit)))
+    : 10,
+  type: VALID_TYPES.includes(query.type) ? query.type : undefined,
+  location: VALID_LOCATIONS.includes(query.location) ? query.location : undefined,
+  sortBy: VALID_SORT_FIELDS.includes(query.sortBy) ? query.sortBy : 'date',
+  userId: query.userId && mongoose.Types.ObjectId.isValid(query.userId) ? query.userId : undefined,
+});
 
 const getEvents = async (req, res) => {
-  const { page, limit, type = '', location = '', sortBy = 'date' } = req.query;
+  const safeQuery = sanitizeQuery(req.query);
 
   try {
-    const validSortFields = ['date', 'title', 'type', 'location', 'currentAttendees'];
-    const sortField = validSortFields.includes(sortBy) ? sortBy : 'date';
+    const sortField = safeQuery.sortBy;
 
     const query = { isActive: true };
-    if (type && VALID_TYPES.includes(type)) query.type = type;
-    if (location && VALID_LOCATIONS.includes(location)) query.location = location;
+    if (safeQuery.type) query.type = safeQuery.type;
+    if (safeQuery.location) query.location = safeQuery.location;
 
     const totalEvents = await Event.countDocuments(query);
     let events = [];
     let pageNumber = 1;
     let limitNumber = totalEvents;
 
-    if (page && limit) {
-      pageNumber = Math.max(1, Number(page));
-      limitNumber = Math.max(1, Number(limit));
+    const hasPagination = req.query.page !== undefined && req.query.limit !== undefined;
+
+    if (hasPagination) {
+      pageNumber = safeQuery.page;
+      limitNumber = safeQuery.limit;
+
       events = await Event.find(query)
         .populate('resources.userID')
         .sort({ [sortField]: 1 })
@@ -48,15 +62,14 @@ const getEvents = async (req, res) => {
 
       const eventObj = event.toObject();
 
-      eventObj.waitlistCount = event.waitlist?.length || 0;
+      const waitlist = Array.isArray(event.waitlist) ? event.waitlist : [];
 
+      eventObj.waitlistCount = waitlist.length;
       eventObj.waitlistEnabled = event.currentAttendees >= event.maxAttendees;
 
-      const { userId } = req.query;
-
-      if (userId && mongoose.Types.ObjectId.isValid(userId)) {
-        const index = event.waitlist.findIndex(
-          (entry) => entry.userId?.toString() === userId.toString(),
+      if (safeQuery.userId) {
+        const index = waitlist.findIndex(
+          (entry) => entry.userId?.toString() === safeQuery.userId.toString(),
         );
 
         eventObj.userWaitlistPosition = index !== -1 ? index + 1 : null;
@@ -75,10 +88,12 @@ const getEvents = async (req, res) => {
       },
     });
   } catch (error) {
-    res.status(500).json({ error: 'Failed to fetch events', details: error.message });
+    res.status(500).json({
+      error: 'Failed to fetch events',
+      details: error.message,
+    });
   }
 };
-
 const autoPromoteFromWaitlist = (event) => {
   const promotedUsers = [];
 


### PR DESCRIPTION
# Description
<img width="741" height="448" alt="New event creation bug" src="https://github.com/user-attachments/assets/2a3521a1-b7e1-4a02-8f93-325d8a3205b1" />


## Related PRS (if any):
This backend PR is related to OneCommunityGlobal/HighestGoodNetworkApp#5182 frontend PR.

## Main changes explained:
- Updated the GET /events to return all events in default scenarios and paginated results when page and limit are specified.

## How to test:
1. check into current branch
2. do `npm install` and `npm run dev` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. using Postman try hitting the `http://localhost:4500/api/events` -> you should see all the events at once
6. again try hitting `http://localhost:4500/api/events?page=1&limit=10` -> you should see only the first 10 events.

## Screenshots or videos of changes:
<img width="1440" height="900" alt="GET default scenario" src="https://github.com/user-attachments/assets/022460dd-6350-407b-b164-17e56b2e747f" />
<img width="1440" height="900" alt="GET with page and limit" src="https://github.com/user-attachments/assets/769cfd9e-e86b-4ebc-8421-9bfe7ffd7a64" />