### PR TITLE
Diya 🔥 fix(login): Fixed login issues

### DIFF
--- a/src/startup/cors.js
+++ b/src/startup/cors.js
@@ -10,6 +10,8 @@ module.exports = function (app) {
     'http://127.0.0.1:3001',
     'http://127.0.0.1:4173',
     'http://127.0.0.1:5173',
+    'https://dev.highestgood.com',
+    'https://highestgoodnetwork.netlify.app',
   ]);
 
   app.use(


### PR DESCRIPTION
# Description
Fixes login and API failures caused by CORS rejecting requests from the deployed frontend origins. The allowedOrigins set in cors.js only contained localhost entries, blocking all requests from the dev and production deployments.

## Related PRS (if any):
None

## Main changes explained:
- Updated `startup/cors.js` — added https://dev.highestgood.com and https://highestgoodnetwork.netlify.app to the allowedOrigins set

## How to test:
1. Check out current branch and deploy to dev
2. Go to https://dev.highestgood.com/login
3. Log in with valid credentials — verify login succeeds with no CORS error
4. Go to https://highestgoodnetwork.netlify.app/login
5. Log in with valid credentials — verify login succeeds with no CORS error
6. Verify API calls throughout the app work normally (dashboard loads, data fetches, etc.)

## Note:
This is a backend-only change. The Sentry issue HGN-MT-DEV-HEROKU-MMP (2K events, escalating) confirmed the missing origin. Only the origin is needed — no trailing slash or path.