### PR TITLE
Diya 🔥 fix(bs): Fixed Blue Square Deletion Issue

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -2497,39 +2497,44 @@ const createControllerMethods = function (UserProfile, Project, cache) {
       }
 
       const originalinfringements = record?.infringements ?? [];
-      // record.infringements = originalinfringements.concat(req.body.blueSquare);
-      record.infringements = originalinfringements.concat(newInfringement);
-      record.infringementCount += 1;
 
-      console.log('Original infringements:', originalinfringements);
-      console.log('Record infringements:', record.infringements);
+      try {
+        // ← KEY FIX: use $push instead of record.save() to avoid overwriting
+        // cron-assigned infringements added between findById and save
+        const status = await UserProfile.findByIdAndUpdate(
+          userid,
+          {
+            $push: { infringements: newInfringement },
+            $inc: { infringementCount: 1 },
+          },
+          { new: true },
+        );
 
-      record
-        .save()
-        .then(async (results) => {
-          await userHelper.notifyInfringements(
-            originalinfringements,
-            results.infringements,
-            results.firstName,
-            results.lastName,
-            results.email,
-            results.role,
-            results.startDate,
-            results.jobTitle[0],
-            results.weeklycommittedHours,
-          );
-          res.status(200).json({
-            _id: record._id,
-            infringements: record.infringements,
-          });
+        await userHelper.notifyInfringements(
+          originalinfringements,
+          status.infringements,
+          status.firstName,
+          status.lastName,
+          status.email,
+          status.role,
+          status.startDate,
+          status.jobTitle[0],
+          status.weeklycommittedHours,
+        );
 
-          // update alluser cache if we have cache
-          if (isUserInCache) {
-            allUserData.splice(userIdx, 1, userData);
-            cache.setCache('allusers', JSON.stringify(allUserData));
-          }
-        })
-        .catch((error) => res.status(400).send(error));
+        res.status(200).json({
+          _id: status._id,
+          infringements: status.infringements,
+        });
+
+        // update alluser cache if we have cache
+        if (isUserInCache) {
+          allUserData.splice(userIdx, 1, userData);
+          cache.setCache('allusers', JSON.stringify(allUserData));
+        }
+      } catch (error) {
+        res.status(400).send(error);
+      }
     });
   };
 


### PR DESCRIPTION
# Description
Fixes a race condition where manually adding a blue square on Sunday overwrites the cron-assigned blue square issued at midnight. The bug occurred because `addInfringements` used `findById` + `record.save()` which fetched a stale snapshot of the document before the cron's `$push` completed, then overwrote the entire infringements array on save.

**Fixes:** Blue square race condition — [manually added blue square deletes cron-assigned blue square on Sunday](https://www.loom.com/share/322503d2af3e441c88332ef95a5552ba)

## Related PRs (if any):
N/A — backend only fix.

## Main changes explained:
- Updated `src/controllers/userProfileController.js` `addInfringements` function to replace `record.infringements = ...; record.save()` with `findByIdAndUpdate` using `$push` so the new infringement is added atomically without overwriting any other infringements added between the `findById` and save calls

## How to test:
1. Check out current branch
2. Run `npm install` and `npm run dev`
3. Trigger the cron job manually or simulate it by calling `assignBlueSquareForTimeNotMet` directly
4. Immediately after, manually add a blue square via the UI for the same user
5. Verify both blue squares are present after refresh
6. Verify only the new infringement is added, not duplicated

## Note:
This is a race condition specific to Sunday when the cron runs at midnight. The cron uses `$push` atomically but the manual controller was doing a read-modify-write which could lose the cron's update if both operations overlapped.