### PR TITLE
Sayali: 🔥 change promotion-eligibility endpoint from GET to POST to resolve req.body.requestor undefined issue in production

### DIFF
--- a/src/routes/promotionEligibilityRouter.js
+++ b/src/routes/promotionEligibilityRouter.js
@@ -12,7 +12,7 @@ const routes = function (userProfile, timeEntry, task, PromotionEligibility) {
   );
   const router = express.Router();
 
-  router.route('/promotion-eligibility').get(controller.getPromotionEligibilityData);
+  router.route('/promotion-eligibility').post(controller.getPromotionEligibilityData);
 
   router.route('/promote-members').post(controller.promoteMembers);
 


### PR DESCRIPTION
# Description
Fixes production bug where Promotion Eligibility table showed "Failed to load Reviewers" error.
The GET /api/promotion-eligibility endpoint was checking req.body.requestor for permissions, but GET requests don't reliably carry a body in production environments, causing req.body.requestor to be undefined and the permission check to fail with 403.
Fix: Changed the endpoint from GET to POST so req.body.requestor is always populated by the auth middleware.

## Related PRS (if any):
Frontend PR required: update promotionActions.js to call axios.post instead of axios.get for PROMOTION_ELIGIBILITY endpoint.
…
## Main changes explained:
Updated src/routes/promotionEligibilityRouter.js — changed /promotion-eligibility route from .get() to .post()
…
## How to test:

1. Check out branch Sayali_Fix_PromotionEligibility_Requestor
2. Run npm install, npm run build, npm run start
3. Ensure frontend is running on localhost:5173
4. Log in as admin
5. Navigate to localhost:5173/pr-dashboard/promotion-eligibility
6. Verify table loads with reviewer data (no "Failed to load Reviewers" error)
7. Verify dark mode works

## Screenshots or videos of changes:
<img width="1919" height="874" alt="image" src="https://github.com/user-attachments/assets/5b7ec3c1-eec6-44e9-a9ce-fabf83ab4074" />

## Note:
This is a backend-only fix. A corresponding frontend PR is needed to change axios.get to axios.post in promotionActions.js.
