### PR TITLE
Diya fix(weeklyReport): Fixed Stars Visible on Hours Logged

### DIFF
--- a/src/helpers/reporthelper.js
+++ b/src/helpers/reporthelper.js
@@ -175,6 +175,7 @@ const reporthelper = function () {
     results.forEach((result) => {
       // create Array(4) to hold totalSeconds for each week
       result.totalSeconds = [0, 0, 0, 0];
+      result.totalTangibleSeconds = [0, 0, 0, 0];
 
       if (!result.timeEntries || result.timeEntries.length === 0) return;
       const isSingleWeekRequest = startWeekIndex === endWeekIndex;
@@ -192,12 +193,20 @@ const reporthelper = function () {
         if (index >= 0 && index < 4) {
           result.totalSeconds[index] =
             (result.totalSeconds[index] || 0) + (entry.totalSeconds || 0);
+          if (entry.isTangible) {
+            result.totalTangibleSeconds[index] =
+              (result.totalTangibleSeconds[index] || 0) + (entry.totalSeconds || 0);
+          }
         }
       });
 
       result.totalSeconds = result.totalSeconds.map((seconds) =>
         seconds === 0 ? undefined : seconds,
       );
+      result.totalTangibleSeconds = result.totalTangibleSeconds.map((seconds) =>
+        seconds === 0 ? undefined : seconds,
+      );
+
       if (result.endDate) {
         result.finalWeekIndex = absoluteDifferenceInWeeks(result.endDate, pstEnd);
       } else {


### PR DESCRIPTION
# Description
Fixes stars on the Weekly Summaries Report being awarded based on both tangible and intangible time. Stars should only be awarded when a user logs sufficient **tangible** time over their weekly committed hours threshold. Previously, `totalSeconds` included all time entries regardless of `isTangible`, causing stars to appear even when the over-threshold hours were intangible.

**Fixes:** Weekly Summaries Report stars incorrectly, including intangible time in threshold calculation

## Related PRs:
This backend PR is related to frontend PR [#5242](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5242).

## Main changes explained:
- Updated `src/helpers/reportHelper.js` to build a parallel `totalTangibleSeconds` array alongside the existing `totalSeconds` array — `totalSeconds` remains unchanged (tangible + intangible, used for hours display), while `totalTangibleSeconds` contains only tangible time entries and is used by the frontend exclusively for star calculation

## How to test:
See frontend PR [#5242](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5242) for full testing instructions.

## Note:
`totalSeconds` is intentionally kept as tangible + intangible since it drives the "Hours logged: X / Y" display on the report. Only the star calculation uses `totalTangibleSeconds`.