### PR TITLE
Purav taking over for Nirali: core team members additional hours carryover

### DIFF
--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -187,7 +187,7 @@ const userHelper = function () {
         .localeData()
         .ordinal(totalInfringements)}</b> blue square of 5.</p>`;
     } else {
-      let hrThisweek = weeklycommittedHours || 0 + coreTeamExtraHour;
+      let hrThisweek = weeklycommittedHours || 0;
       const remainHr = timeRemaining || 0;
       hrThisweek += remainHr;
       finalParagraph = `Please complete ALL owed time this week (${
@@ -552,9 +552,6 @@ const userHelper = function () {
               );
 
               const { timeSpent_hrs: timeSpent } = results[0];
-              const weeklycommittedHours = user.weeklycommittedHours + (user.missedHours ?? 0);
-              const timeNotMet = timeSpent < weeklycommittedHours;
-              const timeRemaining = weeklycommittedHours - timeSpent;
 
               let isNewUser = false;
               const userStartDate = moment.tz(
@@ -699,6 +696,12 @@ const userHelper = function () {
               // No extra hours is needed if blue squares isn't over 5.
               // length +1 is because new infringement hasn't been created at this stage.
               const coreTeamExtraHour = Math.max(0, oldInfringements.length + 1 - 5);
+              const weeklycommittedHours =
+                user.weeklycommittedHours +
+                (user.missedHours ?? 0) +
+                (person.role === 'Core Team' ? coreTeamExtraHour : 0);
+              const timeNotMet = timeSpent < weeklycommittedHours;
+              const timeRemaining = Math.max(weeklycommittedHours - timeSpent, 0);
               const utcStartMoment = moment(pdtStartOfLastWeek).add(1, 'second');
               const utcEndMoment = moment(pdtEndOfLastWeek)
                 .subtract(1, 'day')
@@ -749,7 +752,7 @@ const userHelper = function () {
                       .localeData()
                       .ordinal(
                         oldInfringements.length + 1,
-                      )} blue square. So you should have completed ${weeklycommittedHours + coreTeamExtraHour} hours and you completed ${timeSpent.toFixed(
+                      )} blue square. So you should have completed ${weeklycommittedHours} hours and you completed ${timeSpent.toFixed(
                       2,
                     )} hours.`;
                   } else {
@@ -773,7 +776,7 @@ const userHelper = function () {
                       .localeData()
                       .ordinal(
                         oldInfringements.length + 1,
-                      )} blue square. So you should have completed ${weeklycommittedHours + coreTeamExtraHour} hours and you completed ${timeSpent.toFixed(
+                      )} blue square. So you should have completed ${weeklycommittedHours} hours and you completed ${timeSpent.toFixed(
                       2,
                     )} hours.`;
                   } else {


### PR DESCRIPTION

<img width="778" height="558" alt="Screenshot 2026-05-14 at 2 45 59 PM" src="https://github.com/user-attachments/assets/30197207-081f-49ab-ad90-db705e8d5a29" />
<img width="709" height="542" alt="Screenshot 2026-05-14 at 2 46 13 PM" src="https://github.com/user-attachments/assets/48a0bcd0-1a75-4ecf-b8fa-f53dba276032" />
<img width="1380" height="2378" alt="image" src="https://github.com/user-attachments/assets/b90cf351-9da8-4419-b96f-2cd6c65064bd" />

Description

Implements the fix for Core Team members’ missed hours carryover logic when blue squares exceed five. Previously, missed hours were carried over to the next week, but the additional hours associated with having more than five blue squares were not consistently included in the following week’s required commitment. This update ensures Core Team members receive additional required hours based on their blue square count (e.g., 6th blue square = +1 hour, 7th blue square = +2 hours), and those hours are carried into subsequent weeks correctly. Email messaging and infringement descriptions were also updated to accurately reflect the required weekly commitment and owed hours.

Implements: PRIORITY MEDIUM - Yubo/Jae: Make Core Team members’ additional hours process properly (Fixes #1141 & #1281 → PR #1612)

#Related PRs (if any):
#Frontend PR: N/A
Backend PR: This PR

Main changes explained:
Updated applyMissedHourForCoreTeam() to include additional Core Team hours when blue squares exceed five.
Added infringement adjustment logic to calculate extra required hours based on blue square count.
Updated assignBlueSquareForTimeNotMet() to include carried-over Core Team additional hours in weekly commitment calculations.
Fixed weekly required hour calculations to include:
committed weekly hours
previous missed hours
additional Core Team hours (after 5 blue squares)
Updated infringement descriptions to reflect accurate completed vs required hours for Core Team members.
Updated getInfringementEmailBody() to correctly display required hours and prevent double-counting of additional Core Team hours.
Added batch processing (bulkWrite) for updating missed hours to reduce database operations and improve efficiency.

How to test:
Check out the current branch:
git checkout nirali-core-team-members-hours
npm install
npm start
1.  Clear browser cache/site data.
2. Log in as an admin user.
3. Create or use a Core Team member with:
4. more than 5 blue squares
5. weekly committed hours set
6. previous missed hours
7. Log fewer hours than required for the week.
8. Run the blue square/missed hours cron logic.
9. Verify:
10. missed hours carry over correctly
11. additional Core Team hours are included (6th blue square = +1, 7th = +2, etc.)
12. Next week's required hours are calculated correctly
13. infringement descriptions show the required hours
14. blue square emails display the correct owed hours without duplication
15. Test edge cases:
16. Core Team member with fewer than 5 blue squares
17. Core Team member with exactly 6th and 7th blue square
18. User meeting all required hours

Note:

The fix ensures Core Team-specific additional hour rules are consistently applied across missed hour carryover, weekly commitment validation, infringement descriptions, and blue square email calculations.
