### PR TITLE
Diya 🔥 fix(bs): Fixed Blue Square Issues

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -2542,68 +2542,80 @@ const createControllerMethods = function (UserProfile, Project, cache) {
 
   const editInfringements = async function (req, res) {
     if (!(await hasPermission(req.body.requestor, 'editInfringements'))) {
-      res.status(403).send('You are not authorized to edit blue square');
-      return;
+      return res.status(403).send('You are not authorized to edit blue square');
     }
+
     const { userId, blueSquareId } = req.params;
     const { dateStamp, summary, reasons } = req.body;
 
-    // Get requestor info for edit tracking
     const requestorId = req.body.requestor?.requestorId || req.body.requestor;
     let requestorProfile = null;
     if (requestorId) {
       requestorProfile = await UserProfile.findById(requestorId).select('firstName lastName');
     }
 
-    UserProfile.findById(userId, async (err, record) => {
-      if (err || !record) {
-        res.status(404).send('No valid records found');
-        return;
-      }
+    try {
+      // Fetch original for notification comparison only — never used for .save()
+      const original = await UserProfile.findById(userId).select('infringements');
+      if (!original) return res.status(404).send('No valid records found');
 
-      const originalinfringements = record?.infringements ?? [];
+      const originalinfringements = original.infringements ?? [];
 
-      record.infringements = originalinfringements.map((blueSquare) => {
-        if (blueSquare._id.equals(blueSquareId)) {
-          blueSquare.date = dateStamp ?? blueSquare.date;
-          blueSquare.description = summary ?? blueSquare.description;
-          if (Array.isArray(reasons)) {
-            blueSquare.reasons = reasons;
-          }
-          // Track edit history
-          if (!blueSquare.editedBy) {
-            blueSquare.editedBy = [];
-          }
-          blueSquare.editedBy.push({
-            firstName: requestorProfile?.firstName || 'Unknown',
-            lastName: requestorProfile?.lastName || 'Unknown',
-            userId: requestorId,
-            date: new Date(),
-          });
-        }
-        return blueSquare;
+      // Find the existing editedBy array for this blue square
+      const existingSquare = originalinfringements.find((bs) => bs._id.equals(blueSquareId));
+      if (!existingSquare) return res.status(404).send('Blue square not found');
+
+      const updatedEditedBy = [
+        ...(existingSquare.editedBy || []),
+        {
+          firstName: requestorProfile?.firstName || 'Unknown',
+          lastName: requestorProfile?.lastName || 'Unknown',
+          userId: requestorId,
+          date: new Date(),
+        },
+      ];
+
+      // Atomic update — only touches the matched subdocument
+      const updateFields = {
+        'infringements.$[elem].editedBy': updatedEditedBy,
+      };
+      if (dateStamp !== undefined) updateFields['infringements.$[elem].date'] = dateStamp;
+      if (summary !== undefined) updateFields['infringements.$[elem].description'] = summary;
+      if (Array.isArray(reasons)) updateFields['infringements.$[elem].reasons'] = reasons;
+
+      const status = await UserProfile.findByIdAndUpdate(
+        userId,
+        { $set: updateFields },
+        {
+          arrayFilters: [{ 'elem._id': new mongoose.Types.ObjectId(blueSquareId) }],
+          new: true,
+        },
+      );
+
+      if (!status) return res.status(404).send('No valid records found');
+
+      await userHelper.notifyInfringements(
+        originalinfringements,
+        status.infringements,
+        status.firstName,
+        status.lastName,
+        status.email,
+        status.role,
+        status.startDate,
+        status.jobTitle[0],
+        status.weeklycommittedHours,
+      );
+
+      return res.status(200).json({
+        _id: status._id,
+        infringements: status.infringements,
       });
-
-      record
-        .save()
-        .then(async (results) => {
-          await userHelper.notifyInfringements(
-            originalinfringements,
-            results.infringements,
-            results.firstName,
-            results.lastName,
-            results.email,
-            results.role,
-            results.startDate,
-            results.jobTitle[0],
-            results.weeklycommittedHours,
-          );
-          res.status(200).json({
-            _id: record._id,
-          });
-        })
-        .catch((error) => res.status(400).send(error));
-    });
+    } catch (error) {
+      return res.status(500).json({
+        message: error?.message || 'Unknown error',
+        name: error?.name,
+      });
+    }
   };
 
   const deleteInfringements = async function (req, res) {
@@ -2618,7 +2630,6 @@ const createControllerMethods = function (UserProfile, Project, cache) {
       if (!userId || !blueSquareId) {
         return res.status(400).send('Missing userId or blueSquareId');
       }
-
       if (!mongoose.Types.ObjectId.isValid(userId)) {
         return res.status(400).send(`Invalid userId: ${userId}`);
       }
@@ -2626,33 +2637,50 @@ const createControllerMethods = function (UserProfile, Project, cache) {
         return res.status(400).send(`Invalid blueSquareId: ${blueSquareId}`);
       }
 
-      const updated = await UserProfile.findOneAndUpdate(
-        { _id: userId },
+      // Fetch original for notification comparison
+      const original = await UserProfile.findById(userId).select('infringements');
+      if (!original) return res.status(404).send('No valid records found');
+      const originalinfringements = original.infringements ?? [];
+
+      // Single atomic operation — $pull + $inc together, no .save() needed
+      const updated = await UserProfile.findByIdAndUpdate(
+        userId,
         {
           $pull: {
-            infringements: { _id: blueSquareId },
-            oldInfringements: { _id: blueSquareId },
+            infringements: { _id: new mongoose.Types.ObjectId(blueSquareId) },
+            oldInfringements: { _id: new mongoose.Types.ObjectId(blueSquareId) },
           },
+          $inc: { infringementCount: -1 },
         },
         { new: true },
       );
 
-      if (!updated) {
-        return res.status(404).send('No valid records found');
+      if (!updated) return res.status(404).send('No valid records found');
+
+      // Clamp count to 0 in case it was already 0 — one more atomic op, still no .save()
+      if (updated.infringementCount < 0) {
+        await UserProfile.findByIdAndUpdate(userId, {
+          $set: { infringementCount: 0 },
+        });
       }
 
-      const stillThere =
-        (updated.infringements || []).some((x) => String(x._id) === String(blueSquareId)) ||
-        (updated.oldInfringements || []).some((x) => String(x._id) === String(blueSquareId));
+      await userHelper.notifyInfringements(
+        originalinfringements,
+        updated.infringements,
+        updated.firstName,
+        updated.lastName,
+        updated.email,
+        updated.role,
+        updated.startDate,
+        updated.jobTitle[0],
+        updated.weeklycommittedHours,
+      );
 
-      if (stillThere) {
-        return res.status(500).send('Delete did not persist (still present after update)');
-      }
-
-      updated.infringementCount = Math.max(0, (updated.infringements || []).length);
-      await updated.save();
-
-      return res.status(200).json({ _id: updated._id, deleted: blueSquareId });
+      return res.status(200).json({
+        _id: updated._id,
+        deleted: blueSquareId,
+        infringements: updated.infringements,
+      });
     } catch (error) {
       return res.status(500).json({
         message: error?.message || 'Unknown error',

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -590,7 +590,7 @@ const userHelper = function () {
       userStartDate.isAfter(pdtEndOfLastWeek) ||
       (userStartDate.isAfter(pdtStartOfLastWeek) &&
         userStartDate.isBefore(pdtEndOfLastWeek) &&
-        timeUtils.getDayOfWeekStringFromUTC(person.startDate) > 1)
+        timeUtils.getDayOfWeekStringFromUTC(person.startDate) > 1) // ← > 1 means after Monday
     ) {
       return true;
     }
@@ -721,12 +721,12 @@ const userHelper = function () {
       if (moment(inf.date).diff(cutOffDate) >= 0) {
         oldInfringements.push(inf);
       } else {
-        break;
+        continue;
       }
     }
 
     if (oldInfringements.length) {
-      userProfile.findByIdAndUpdate(
+      await userProfile.findByIdAndUpdate(
         personId,
         { $push: { oldInfringements: { $each: oldInfringements, $slice: -10 } } },
         { new: true },
@@ -1164,7 +1164,6 @@ const userHelper = function () {
     const totalInfringements = newCurrent.length;
     let newInfringements = [];
     let historyInfringements = 'No Previous Infringements.';
-    console.log('ORIGINAL', original);
     if (original.length) {
       const sortedForHistory = [...original].sort((a, b) => new Date(b.date) - new Date(a.date));
 


### PR DESCRIPTION
# Description
Fixes multiple bugs in the Blue Square infringement system, causing data loss, incorrect email history, and race conditions.

## Related PRS (if any):
This backend PR is related to the frontend [PR #5277](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5277)

## Main changes explained:
- Updated `editInfringements` in `userProfileController.js` to replace `findById` + `record.save()` with `findByIdAndUpdate` using `$set` and `arrayFilters` to atomically update only the matched blue square subdocument, preventing race condition data loss
- Updated `deleteInfringements` in `userProfileController.js` to remove `updated.save()` after `$pull`, combining `$pull` and `$inc` into a single atomic operation, and added deletion notification email to notify admins when a blue square is removed
- Both `editInfringements` and `deleteInfringements` now return the full `infringements` array in the response for frontend state sync
- Updated `processUserForBlueSquare` in `userHelper.js` to change `break` to `continue` when collecting infringements within the last year, preventing truncation when infringements are out of chronological order
- Added `await` to the `oldInfringements` push in `processUserForBlueSquare` to prevent fire-and-forget failures on the DB write

## How to test:
1. Check out current branch
2. Run `npm install` and `npm run dev`
3. Log in as an admin user
4. Go to a user profile and add a blue square — verify it appears immediately without refresh
5. Edit the blue square — verify the change persists after page refresh
6. Delete the blue square — verify an email notification is sent to Jae/admin
7. Verify the blue square count updates correctly after each operation
8. Trigger the cron job manually via `assignBlueSquareForTimeNotMet` and verify the email history shows all infringements correctly, not truncated
9. Verify new users who joined Tuesday or later do not receive a blue square for missed hours
 
## Note:
The core bug was that `editInfringements` and `deleteInfringements` were using `findById` + `record.save()` which performs a full document overwrite. This meant any infringements added by the cron job or concurrent operations between the `findById` and `save()` calls would be silently wiped. All writes are now atomic using MongoDB operators. The cron `break` bug also caused email history to appear truncated for users whose infringements were not in strict chronological order.