### PR TITLE
Sayali: add projectHistory tracking and getAllTimeprojectMembership endpoint

### DIFF
--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -5,7 +5,7 @@ const timeentry = require('../models/timeentry');
 const task = require('../models/task');
 const wbs = require('../models/wbs');
 const userProfile = require('../models/userProfile');
-// const { hasPermission } = require('../utilities/permissions');
+const { hasPermission } = require('../utilities/permissions');
 const helper = require('../utilities/permissions');
 const escapeRegex = require('../utilities/escapeRegex');
 const logger = require('../startup/logger');
@@ -492,7 +492,6 @@ const projectController = function (Project) {
    */
   const getprojectMembership = async function (req, res) {
     try {
-      // GETs usually have no body; prefer req.user populated by your auth middleware.
       const requestor =
         (req.user && (req.user._id || req.user.id)) || req.query?.requestor || req.body?.requestor;
 
@@ -514,7 +513,7 @@ const projectController = function (Project) {
 
       const results = await userProfile
         .find(
-          { projects: projectId },
+          { projects: mongoose.Types.ObjectId(projectId) },
           { firstName: 1, lastName: 1, profilePic: 1, _id: 1, isActive: 1 },
         )
         .sort({ firstName: 1, lastName: 1 });
@@ -524,6 +523,32 @@ const projectController = function (Project) {
       logger?.logException?.(error);
       return res.status(500).send('Error fetching project members');
     }
+  };
+  const getAllTimeprojectMembership = async function (req, res) {
+    const { projectId } = req.params;
+    if (!mongoose.Types.ObjectId.isValid(projectId)) {
+      res.status(400).send('Invalid request');
+      return;
+    }
+    const requestor =
+      (req.user && (req.user._id || req.user.id)) || req.query?.requestor || req.body?.requestor;
+    const getProjMembers = await hasPermission(requestor, 'getProjectMembers');
+    const postTask = await hasPermission(requestor, 'postTask');
+    const updateTask = await hasPermission(requestor, 'updateTask');
+    const suggestTask = await hasPermission(requestor, 'suggestTask');
+    const getId = getProjMembers || postTask || updateTask || suggestTask;
+    userProfile
+      .find(
+        { projectHistory: projectId },
+        { firstName: 1, lastName: 1, isActive: 1, profilePic: 1, _id: getId },
+      )
+      .sort({ firstName: 1, lastName: 1 })
+      .then((results) => {
+        res.status(200).send(results);
+      })
+      .catch((error) => {
+        res.status(500).send(error);
+      });
   };
 
   /**
@@ -555,7 +580,6 @@ const projectController = function (Project) {
         res.status(200).json(results);
       })
       .catch((error) => {
-        console.error('Summary query error:', error);
         res.status(500).send(error);
       });
   };
@@ -667,6 +691,7 @@ const projectController = function (Project) {
     getprojectMembershipSummary,
     searchProjectMembers,
     getProjectsWithActiveUserCounts,
+    getAllTimeprojectMembership,
   };
 };
 

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -501,6 +501,18 @@ const createControllerMethods = function (UserProfile, Project, cache) {
 
       const addedProjects = newProjects.filter((id) => !oldProjects.includes(id));
       const removedProjects = oldProjects.filter((id) => !newProjects.includes(id));
+      // update the projects history
+      const changedProjectHistoryIds = Array.from(new Set(oldProjects.concat(newProjects))).map(
+        (id) => mongoose.Types.ObjectId(id),
+      );
+
+      const existingProjectIds = new Set(record.projectHistory.map((id) => id.toString()));
+
+      const newProjectIds = changedProjectHistoryIds.filter(
+        (id) => !existingProjectIds.has(id.toString()),
+      );
+
+      record.projectHistory.push(...newProjectIds);
       const changedProjectIds = [...addedProjects, ...removedProjects].map((id) =>
         mongoose.Types.ObjectId(id),
       );
@@ -2896,6 +2908,25 @@ const createControllerMethods = function (UserProfile, Project, cache) {
       return res.status(500).send({ error: 'Internal server error' });
     }
   };
+  const getProjectHistory = async function (req, res) {
+    try {
+      const { userId } = req.params;
+      const user = await UserProfile.findById(userId);
+      const projectHistory = [...user.projectHistory];
+      res.status(200).send(projectHistory);
+    } catch (error) {
+      res.status(500).send(error);
+    }
+  };
+
+  const postClearProjectHistory = async function (req, res) {
+    try {
+      const result = await UserProfile.updateMany({}, { $set: { projectHistory: [] } });
+      res.status(200).send({ message: 'Project history cleared for all users', result });
+    } catch (error) {
+      res.status(500).send({ message: 'Error clearing project history', error });
+    }
+  };
 
   const getAllMembersSkillsAndContact = async function (req, res) {
     try {
@@ -3107,6 +3138,8 @@ const createControllerMethods = function (UserProfile, Project, cache) {
     updateProfileImageFromWebsite,
     getUserByAutocomplete,
     getUserProfileBasicInfo,
+    getProjectHistory,
+    postClearProjectHistory,
     updateUserInformation,
     getAllMembersSkillsAndContact,
     replaceTeamCodeForUsers,

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -104,7 +104,7 @@ const userProfileSchema = new Schema({
   personalLinks: [{ _id: Schema.Types.ObjectId, Name: String, Link: { type: String } }],
   adminLinks: [{ _id: Schema.Types.ObjectId, Name: String, Link: String }],
   teams: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'team' }],
-  projects: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'project' }],
+  projectHistory: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'project' }],
   badgeCollection: [
     {
       badge: { type: mongoose.SchemaTypes.ObjectId, ref: 'badge' },

--- a/src/routes/projectRouter.js
+++ b/src/routes/projectRouter.js
@@ -26,6 +26,10 @@ const routes = function (project) {
     .get(controller.getprojectMembership);
 
   projectRouter
+    .route('/project/:projectId/alltimeusers/')
+    .get(controller.getAllTimeprojectMembership);
+
+  projectRouter
     .route('/project/:projectId/users/summary')
     .get(controller.getprojectMembershipSummary);
 

--- a/src/routes/userProfileRouter.js
+++ b/src/routes/userProfileRouter.js
@@ -29,6 +29,8 @@ const routes = function (userProfile, project) {
     .get(param('name').exists(), controller.searchUsersByName);
 
   userProfileRouter.route('/userProfile/update').patch(controller.updateUserInformation);
+  userProfileRouter.route('/userProfile/:userId/projectHistory/').get(controller.getProjectHistory);
+  userProfileRouter.route('/clearAllProjectHistory/').post(controller.postClearProjectHistory);
   userProfileRouter.route('/userProfile/basicInfo').get(controller.getUserProfileBasicInfo);
 
   // Endpoint to retrieve basic user profile information after verifying access permission based on the request source.


### PR DESCRIPTION
<img width="728" height="680" alt="image" src="https://github.com/user-attachments/assets/b770cadf-4659-4bc4-af03-8e1103dd64fb" />

# Description
Fixes #1 (Priority Medium) - Fix the Projects Report incomplete Members list when the ALL-TIME button is selected.

## Related PRs (if any):
This backend PR is related to frontend https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5225
To test this backend PR you need to checkout frontend branch: Sayali-Fix-AllTime-Members-ProjectReport

## Main changes explained:
- Added `projectHistory` field to `userProfile` model to track all projects a user has ever been assigned to, even after unassignment
- Added `getAllTimeprojectMembership` endpoint (`GET /api/project/:projectId/alltimeusers/`) that queries users by `projectHistory` instead of `projects`
- Updated `putUserProfile` in `userProfileController.js` to update `projectHistory` whenever a user's projects change
- Added `getProjectHistory` and `postClearProjectHistory` utility functions
- Added new routes in `projectRouter.js` and `userProfileRouter.js`
- Fixed `getprojectMembership` to use `mongoose.Types.ObjectId` for proper ObjectId matching

## How to test:
1. Checkout branch `Sayali-Fix-AllTime-Members-Backend`
2. Run `npm install` and `npm run build` then `npm run start`
3. Also checkout frontend branch `Sayali-Fix-AllTime-Members-ProjectReport`
4. Clear site data/cache, log as admin user
5. Go to Reports → Reports → Projects → select any project
6. Verify ACTIVE tab shows only currently assigned members
7. Remove a user from the project
8. Verify ACTIVE count drops but ALL-TIME count remains the same

## Screenshots or videos of changes:
<img width="1919" height="895" alt="image" src="https://github.com/user-attachments/assets/c3ace9d4-6fb8-40b6-a2b9-b02f8488ad88" />
<img width="1919" height="486" alt="image" src="https://github.com/user-attachments/assets/78b39468-41be-4cb3-b5f8-06a40b2b291a" />

## Note:
This PR works together with frontend https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5225 Both must be merged together for the fix to work.