### PR TITLE
Diya 🔥 fix(teamCodes): Fixed - Display only active Team Codes

### DIFF
--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -751,6 +751,7 @@ const reportsController = function () {
       }
 
       const teamCodes = await UserProfile.distinct('teamCode', {
+        isActive: true,
         teamCode: { $nin: [null, ''] },
       });
 


### PR DESCRIPTION
# Description

Fixes a bug where the team code suggestions dropdown was returning team codes from inactive users, polluting the list with stale and test codes.

**Fixes:** Team code suggestions showing inactive team codes (Low)

## Related PRs (if any):
N/A — backend only fix.

## Main changes explained:
- Updated `getAllDistinctTeamCodes` in the reports controller to add `isActive: true` to the `UserProfile.distinct` query, ensuring only team codes belonging to active users are returned

## How to test:
1. Check out current branch
2. Run `npm install` and `npm run dev`
3. Hit `GET /api/reports/weeklysummaries/teamcodes`
4. Verify the response returns 93 team codes instead of 95
5. Verify all returned codes belong to currently active users

## Screenshots or videos of changes:
Before:
<img width="197" height="36" alt="Screenshot 2026-05-20 at 1 39 27 AM" src="https://github.com/user-attachments/assets/5f8e72f4-8c5a-4763-909d-20e73ae56002" />

After:
<img width="264" height="34" alt="Screenshot 2026-05-20 at 1 39 17 AM" src="https://github.com/user-attachments/assets/a244e281-7eba-4963-a361-b161a5d3e87d" />


## Note:
`UserProfile.distinct` returns unique values across all matching documents. Without the `isActive: true` filter, codes shared between active and inactive users still appeared — but 2 codes that existed exclusively on inactive users were being surfaced incorrectly. The fix brings this endpoint in line with `getReportTeamCodes` which already filters by active members.