### PR TITLE
Diya 🔥 fix(bsFlow): Fixed Blue Square flow

### DIFF
--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -1539,12 +1539,8 @@ const createControllerMethods = function (UserProfile, Project, cache) {
         },
         {
           path: 'infringements',
-          select: '_id date description createdDate',
-          options: { sort: { date: -1 } },
-        },
-        {
-          path: 'oldInfringements',
-          select: '_id date description createdDate',
+          select:
+            '_id date description createdDate manullyAssigned manullyAssignedBy editedBy ccdUsers reasons reason',
           options: { sort: { date: -1 } },
         },
       ])
@@ -1554,44 +1550,11 @@ const createControllerMethods = function (UserProfile, Project, cache) {
           return res.status(400).send({ error: 'This is not a valid user' });
         }
 
-        const current = Array.isArray(user.infringements) ? user.infringements : [];
-        const old = Array.isArray(user.oldInfringements) ? user.oldInfringements : [];
-
-        const combined = [...current, ...old];
-
-        // build date -> best record
-        const byDate = new Map();
-
-        for (const inf of combined) {
-          if (!inf?.date) continue;
-
-          const existing = byDate.get(inf.date);
-          if (!existing) {
-            byDate.set(inf.date, inf);
-            continue;
-          }
-
-          const a = inf.createdDate ? new Date(inf.createdDate).getTime() : 0;
-          const b = existing.createdDate ? new Date(existing.createdDate).getTime() : 0;
-
-          if (a > b) {
-            byDate.set(inf.date, inf);
-            continue;
-          }
-
-          const ida = String(inf._id || '');
-          const idb = String(existing._id || '');
-          if (ida > idb) {
-            byDate.set(inf.date, inf);
-          }
-        }
-
-        const infringements = Array.from(byDate.values()).sort((a, b) =>
-          a.date < b.date ? 1 : a.date > b.date ? -1 : 0,
-        );
+        const infringements = Array.isArray(user.infringements)
+          ? [...user.infringements].sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0))
+          : [];
 
         user.set('infringements', infringements, { strict: false });
-        user.set('oldInfringements', undefined, { strict: false });
 
         cache.setCache(`user-${userid}`, JSON.stringify(user));
         return res.status(200).send(user);
@@ -2507,10 +2470,12 @@ const createControllerMethods = function (UserProfile, Project, cache) {
           userid,
           {
             $push: { infringements: newInfringement },
-            $inc: { infringementCount: 1 },
           },
           { new: true },
         );
+        await UserProfile.findByIdAndUpdate(userid, {
+          $set: { infringementCount: status.infringements.length },
+        });
 
         await userHelper.notifyInfringements(
           originalinfringements,
@@ -2531,7 +2496,7 @@ const createControllerMethods = function (UserProfile, Project, cache) {
 
         // update alluser cache if we have cache
         if (isUserInCache) {
-          allUserData.splice(userIdx, 1, userData);
+          allUserData.splice(userIdx, 1, status);
           cache.setCache('allusers', JSON.stringify(allUserData));
         }
       } catch (error) {
@@ -2650,19 +2615,15 @@ const createControllerMethods = function (UserProfile, Project, cache) {
             infringements: { _id: new mongoose.Types.ObjectId(blueSquareId) },
             oldInfringements: { _id: new mongoose.Types.ObjectId(blueSquareId) },
           },
-          $inc: { infringementCount: -1 },
         },
         { new: true },
       );
 
       if (!updated) return res.status(404).send('No valid records found');
 
-      // Clamp count to 0 in case it was already 0 — one more atomic op, still no .save()
-      if (updated.infringementCount < 0) {
-        await UserProfile.findByIdAndUpdate(userId, {
-          $set: { infringementCount: 0 },
-        });
-      }
+      await UserProfile.findByIdAndUpdate(userId, {
+        $set: { infringementCount: updated.infringements.length },
+      });
 
       await userHelper.notifyInfringements(
         originalinfringements,

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -1069,9 +1069,8 @@ const userHelper = function () {
         {},
         {
           $pull: {
-            infringements: {
-              date: { $lte: cutOffDate },
-            },
+            infringements: { date: { $lte: cutOffDate } },
+            oldInfringements: { date: { $lte: cutOffDate } }, // clean up old ones too
           },
         },
       );


### PR DESCRIPTION
# Description

Fixes multiple critical bugs in the Blue Square infringement system, causing incorrect counts, stale data being served from cache, and `oldInfringements` bleeding back into the active infringements list shown on user profiles.

**Fixes:** Blue Square count mismatch, stale cache serving incorrect infringement data, `oldInfringements` merge causing phantom blue squares (High)

## Related PRs (if any):
This backend PR is related to the frontend [PR #5289](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5289)

## Main changes explained:
- Updated `getUserById` in `userProfileController.js` to stop merging `oldInfringements` back into the active `infringements` array — profile page now shows only real current infringements from the DB, sorted by date descending. Also removed `oldInfringements` from the populate query entirely
- Updated `addInfringements` to sync `infringementCount` to `infringements.length` after every add using `$set` instead of `$inc` to prevent count drift. Also fixed stale cache bug where `userData` (old snapshot) was being written back into the `allusers` cache instead of `status` (updated document)
- Updated `deleteInfringements` to sync `infringementCount` to `infringements.length` after every delete using `$set`, replacing the previous `$inc: -1` + clamp logic which was error-prone
- Updated `deleteBlueSquareAfterYear` in `userHelper.js` to also clean up `oldInfringements` older than one year, preventing stale historical entries from accumulating indefinitely

## How to test:
1. Check out current branch
2. Run `npm install` and `npm run dev`
3. Log in as an admin user
4. Navigate to any user profile
5. Add a blue square — verify `infringements` array length and `infringementCount` match in DB
6. Edit the blue square — verify description and `editedBy` are updated correctly in DB
7. Delete the blue square — verify `infringements` array length and `infringementCount` match in DB
8. Hard refresh the profile page — verify the UI shows only the infringements actually in the DB, not any from `oldInfringements`
9. Verify the blue square count in the email notification matches the actual count in DB

## Note:
The root cause of the phantom blue squares was `getUserById` merging `oldInfringements` (a backup array written by the cron job) back into the displayed `infringements` list. Since `oldInfringements` accumulates duplicates across multiple cron runs (same entries pushed weekly with `$push` instead of `$addToSet`), users were seeing far more blue squares than actually existed in their active `infringements` array. The `infringementCount` drift was caused by `$inc` operations not being properly compensated on deletes and never being reset to match the actual array length.