### PR TITLE
Diya fix(blueSq): 🔥 Fixed Blue Square Bulk Issues

### DIFF
--- a/src/controllers/timeOffRequestController.js
+++ b/src/controllers/timeOffRequestController.js
@@ -144,8 +144,6 @@ const timeOffRequestController = function (TimeOffRequest, Team, UserProfile) {
     try {
       const hasRolePermission = ['Owner', 'Administrator'].includes(req.body.requestor.role);
       const setOwnRequested = req.body.requestor.requestorId === req.body.requestFor;
-      console.log('Has role permission:', hasRolePermission);
-      console.log('Is setting own request:', setOwnRequested);
 
       if (
         !(await hasPermission(req.body.requestor, 'manageTimeOffRequests')) &&
@@ -156,12 +154,7 @@ const timeOffRequestController = function (TimeOffRequest, Team, UserProfile) {
         return;
       }
 
-      const { duration, startingDate, reason, requestFor } = req.body;
-
-      console.log('Duration:', duration);
-      console.log('Starting Date:', startingDate);
-      console.log('Reason:', reason);
-      console.log('Request For:', requestFor);
+      const { duration, startingDate, reason, reasonType, requestFor } = req.body;
       if (!duration || !startingDate || !reason || !requestFor) {
         res.status(400).send('bad request');
         return;
@@ -174,6 +167,7 @@ const timeOffRequestController = function (TimeOffRequest, Team, UserProfile) {
       const newTimeOffRequest = new TimeOffRequest();
       newTimeOffRequest.requestFor = mongoose.Types.ObjectId(requestFor);
       newTimeOffRequest.reason = reason;
+      newTimeOffRequest.reasonType = reasonType || 'vacationTime';
       newTimeOffRequest.startingDate = startDate.toDate();
       newTimeOffRequest.endingDate = endDate.toDate();
       newTimeOffRequest.duration = Number(duration);
@@ -258,7 +252,7 @@ const timeOffRequestController = function (TimeOffRequest, Team, UserProfile) {
         res.status(403).send('You are not authorized to set time off requests.');
         return;
       }
-      const { duration, startingDate, reason } = req.body;
+      const { duration, startingDate, reason, reasonType } = req.body;
       if (!duration || !startingDate || !reason || !requestId) {
         res.status(400).send('bad request');
         return;
@@ -270,6 +264,7 @@ const timeOffRequestController = function (TimeOffRequest, Team, UserProfile) {
 
       const updateData = {
         reason,
+        reasonType: reasonType || 'vacationTime',
         startingDate: startDate.toDate(),
         endingDate: endDate.toDate(),
         duration,

--- a/src/controllers/timeOffRequestController.spec.js
+++ b/src/controllers/timeOffRequestController.spec.js
@@ -622,6 +622,7 @@ describe('timeOffRequestController.js module', () => {
 
       const mockUpdateData = {
         reason: timeOffReason,
+        reasonType: 'vacationTime',
         startingDate: startDate.toDate(),
         endingDate: endDate.toDate(),
         duration: timeOffDuration,
@@ -632,6 +633,7 @@ describe('timeOffRequestController.js module', () => {
         duration: timeOffDuration,
         startingDate: timeOffStartingDate,
         reason: timeOffReason,
+        reasonType: 'vacationTime',
       };
 
       const error = 'Time off request not found';
@@ -689,6 +691,7 @@ describe('timeOffRequestController.js module', () => {
 
       const mockUpdateData = {
         reason: timeOffReason,
+        reasonType: 'vacationTime',
         startingDate: startDate.toDate(),
         endingDate: endDate.toDate(),
         duration: timeOffDuration,
@@ -699,6 +702,7 @@ describe('timeOffRequestController.js module', () => {
         duration: timeOffDuration,
         startingDate: timeOffStartingDate,
         reason: timeOffReason,
+        reasonType: 'vacationTime',
       };
 
       hasPermission.mockImplementation(async () => true);
@@ -754,6 +758,7 @@ describe('timeOffRequestController.js module', () => {
 
       const mockUpdateData = {
         reason: timeOffReason,
+        reasonType: 'vacationTime',
         startingDate: startDate.toDate(),
         endingDate: endDate.toDate(),
         duration: timeOffDuration,

--- a/src/controllers/timeOffRequestController.spec.js
+++ b/src/controllers/timeOffRequestController.spec.js
@@ -769,6 +769,7 @@ describe('timeOffRequestController.js module', () => {
         duration: timeOffDuration,
         startingDate: timeOffStartingDate,
         reason: timeOffReason,
+        reasonType: 'vacationTime',
       };
 
       const error = new Error('Some error occcurred during operation findByIdAndUpdate()');

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -2450,8 +2450,8 @@ const createControllerMethods = function (UserProfile, Project, cache) {
         // Add reasons array for more detailed categorization
         reasons: processedReasons,
         // Track if manually assigned (via API call) vs CRON job
-        manullyAssigned: true,
-        manullyAssignedBy: requestorProfile
+        manuallyAssigned: true,
+        manuallyAssignedBy: requestorProfile
           ? {
               firstName: requestorProfile.firstName,
               lastName: requestorProfile.lastName,

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -1062,7 +1062,7 @@ const userHelper = function () {
 
     logger.logInfo(`Job for deleting blue squares older than 1 year starting at ${nowLA.format()}`);
 
-    const cutOffDate = nowLA.clone().subtract(1, 'year').toDate();
+    const cutOffDate = nowLA.clone().subtract(1, 'year').format('YYYY-MM-DD');
 
     try {
       const results = await userProfile.updateMany(

--- a/src/models/timeOffRequest.js
+++ b/src/models/timeOffRequest.js
@@ -2,13 +2,20 @@ const mongoose = require('mongoose');
 
 const { Schema } = mongoose;
 
-const timeOffRequest = new Schema({
-  requestFor: { type: mongoose.SchemaTypes.ObjectId, ref: 'userProfile' },
-  reason: { type: 'String', required: true },
-  startingDate: { type: Date, required: true },
-  endingDate: { type: Date },
-  duration: { type: Number, required: true }, // in weeks
-
-}, { timestamps: true });
+const timeOffRequest = new Schema(
+  {
+    requestFor: { type: mongoose.SchemaTypes.ObjectId, ref: 'userProfile' },
+    reason: { type: 'String', required: true },
+    reasonType: {
+      type: String,
+      enum: ['vacationTime', 'other'],
+      default: 'vacationTime',
+    },
+    startingDate: { type: Date, required: true },
+    endingDate: { type: Date },
+    duration: { type: Number, required: true }, // in weeks
+  },
+  { timestamps: true },
+);
 
 module.exports = mongoose.model('timeOffRequest', timeOffRequest, 'timeOffRequests');

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -158,12 +158,12 @@ const userProfileSchema = new Schema({
         enum: ['time not met', 'missing summary', 'missed video call', 'late reporting', 'other'],
       },
       // Track if blue square was manually assigned (true) or by CRON job (false/undefined)
-      manullyAssigned: {
+      manuallyAssigned: {
         type: Boolean,
         default: false,
       },
       // Track who manually assigned the blue square
-      manullyAssignedBy: {
+      manuallyAssignedBy: {
         firstName: { type: String },
         lastName: { type: String },
         userId: { type: mongoose.Schema.Types.ObjectId, ref: 'userProfile' },


### PR DESCRIPTION
# Description

Fixes a bug where `deleteBlueSquareAfterYear` was incorrectly deleting all infringements regardless of age, and adds `reasonType` support to time-off requests.

**Bug:** `cutOffDate` in `deleteBlueSquareAfterYear` was computed as a JS `Date` object, but the `date` field in the `infringements` array is stored as a `YYYY-MM-DD` string. MongoDB's `$lte` comparison between a `Date` and a string produced incorrect results, causing all infringements to be pulled on every Sunday cron run.

Fixes # (High) Blue square infringements deleted incorrectly by weekly cron job
Implements # Time-off request reason type categorization

## Related PRs (if any):
This backend PR is related to the frontend [PR #5323](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5323)

## Main changes explained:

- **`src/helpers/userHelper.js`** — Fixed `cutOffDate` in `deleteBlueSquareAfterYear` to use `.format('YYYY-MM-DD')` instead of `.toDate()`, matching the string format stored in the DB so `$lte` comparison works correctly
- **`src/models/timeOffRequest.js`** — Added `reasonType` field to the schema with enum `['vacationTime', 'other']` and default `'vacationTime'`
- **`src/controllers/timeOffRequestController.js`** — Added `reasonType` to request body destructuring for both create and update flows; defaults to `'vacationTime'` if not provided; removed leftover debug `console.log` statements
- **`src/models/userProfile.js`** — `manuallyAssignedBy` field alignment to ensure it is consistently included on blue square infringement objects
- **`src/controllers/userProfileController.js`** — `manuallyAssignedBy` is now consistently included when building the blue square infringement object on manual assignment

## How to test:

1. Check out this branch and the corresponding frontend branch
2. Run `npm install` and start the server
3. Clear site data/cache
4. **deleteBlueSquareAfterYear fix:**
   - Manually assign a blue square with a date older than 1 year to a test user
   - Trigger `deleteBlueSquareAfterYear` (via test script or cron)
   - Verify only the infringement older than 1 year was removed; recent infringements remain intact
5. **reasonType:**
   - Submit a time-off request from the frontend with `reasonType` set to `'other'`
   - Verify the field is saved correctly in the DB
   - Edit the request and confirm `reasonType` persists
   - Submit a request without `reasonType` and confirm it defaults to `'vacationTime'`
6. **manuallyAssignedBy:**
   - Manually assign a blue square to a user as an admin
   - Verify the infringement object in the DB includes `manuallyAssigned: true` and `manuallyAssignedBy` with the correct assigner info

## Screenshots or videos of changes:
[BlueSquareReasonTypes - DB](https://www.dropbox.com/scl/fi/7mt2o1zs4qeob5d2kyn1h/BlueSquareReasonTypes-DB.png?rlkey=gopjzgbi6e9qrirsefh0x301b&st=8spe1w7f&dl=0)

## Note:
The root cause of the delete bug was a type mismatch — `infringement.date` is stored as a plain `YYYY-MM-DD` string (set via `moment().utc().format('YYYY-MM-DD')`), not an ISODate. Lexicographic string comparison works correctly for zero-padded ISO dates, so the fix is safe. Long-term, migrating `date` to a proper `Date` type in the schema would be more robust.

The `reasonType` field defaults to `'vacationTime'` for backward compatibility with existing time-off requests created before this change.