### PR TITLE
Diya 🔥 fix(userProj): Fixed User Projects View

### DIFF
--- a/src/controllers/projectController.js
+++ b/src/controllers/projectController.js
@@ -402,10 +402,12 @@ const projectController = function (Project) {
         return;
       }
       const { projects } = user;
-      const projectList = await Project.find(
-        { _id: { $in: projects }, isActive: { $ne: false } },
-        '_id projectName category',
-      );
+
+      const projectList =
+        (await Project.find(
+          { _id: { $in: projects }, isActive: { $ne: false } },
+          '_id projectName category',
+        )) || [];
       const result = projectList
         .map((p) => {
           p = p.toObject();
@@ -464,8 +466,12 @@ const projectController = function (Project) {
         });
 
         const assignPromise = userProfile
-          .updateMany({ _id: { $in: assignlist } }, { $addToSet: { projects: project._id } })
+          .updateMany(
+            { _id: { $in: assignlist } },
+            { $addToSet: { projects: project._id, projectHistory: project._id } },
+          )
           .exec();
+
         const unassignPromise = userProfile
           .updateMany({ _id: { $in: unassignlist } }, { $pull: { projects: project._id } })
           .exec();

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -105,6 +105,7 @@ const userProfileSchema = new Schema({
   adminLinks: [{ _id: Schema.Types.ObjectId, Name: String, Link: String }],
   teams: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'team' }],
   projectHistory: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'project' }],
+  projects: [{ type: mongoose.SchemaTypes.ObjectId, ref: 'project' }],
   badgeCollection: [
     {
       badge: { type: mongoose.SchemaTypes.ObjectId, ref: 'badge' },


### PR DESCRIPTION
# Description

Fixes a bug where assigned projects were not displaying on the user profile Projects tab. The root cause was that `projects` was referenced in schema indexes but never defined as an actual schema field, causing Mongoose to silently return `undefined` when reading it — even though MongoDB was storing the data correctly.

Fixes # (High) Projects assigned to users not visible on UI

## Related PRs (if any):
No frontend changes required.

## Main changes explained:

- **`src/models/userProfile.js`** — Added missing `projects` field definition to the schema. The field was already indexed (`projects: 1`) but never declared, causing Mongoose to return `undefined` on reads despite MongoDB storing the data correctly
- **`src/controllers/projectController.js`** — Updated `assignProjectToUsers` to write to both `projects` (active assignments) and `projectHistory` (permanent log) on assign; unassign only removes from `projects`, leaving `projectHistory` intact as intended

## How to test:

1. Check out this branch
2. Run `npm install` and start the server
3. Log in as an admin/owner user
4. Navigate to a user profile → Projects tab
5. Assign a project to the user and verify it appears in the UI immediately
6. Switch to another tab and back — verify the project persists
7. Hard refresh the page — verify the project still shows
8. Unassign the project and verify it disappears from the Projects tab
9. Confirm the project still appears in `projectHistory` in the DB after unassign

## Screenshots or videos of changes:
https://github.com/user-attachments/assets/0d5620a3-027b-46c4-8eae-d9602e2cbef9


## Note:

`projects` = currently active assignments (can be removed). `projectHistory` = permanent log of all projects ever assigned (never removed). The schema already had indexes on `projects` anticipating this field — it was simply never defined, which is why MongoDB stored it fine but Mongoose couldn't read it back.