### PR TITLE
Diya 🔥 fix(multiple): Fixed Weekly Summary Cron + BS History

### DIFF
--- a/src/cronjobs/userProfileJobs.js
+++ b/src/cronjobs/userProfileJobs.js
@@ -23,7 +23,7 @@ const userProfileJobs = () => {
         await userhelper.deleteExpiredTokens();
       }
       await userhelper.awardNewBadges();
-      await userhelper.weeklyCompanySummaryEmail();
+      // await userhelper.weeklyCompanySummaryEmail(); - function does not exist, restore when added
     },
     null,
     false,

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -1059,18 +1059,33 @@ const userHelper = function () {
 
   const deleteBlueSquareAfterYear = async () => {
     const nowLA = moment().tz('America/Los_Angeles');
-
     logger.logInfo(`Job for deleting blue squares older than 1 year starting at ${nowLA.format()}`);
-
     const cutOffDate = nowLA.clone().subtract(1, 'year').format('YYYY-MM-DD');
 
     try {
+      // Step 1: For active users, move expired infringements to oldInfringements before deleting
+      const usersWithExpired = await userProfile.find(
+        {
+          isActive: true,
+          infringements: { $elemMatch: { date: { $lte: cutOffDate } } },
+        },
+        '_id infringements',
+      );
+
+      for (const user of usersWithExpired) {
+        const expired = user.infringements.filter((inf) => inf.date <= cutOffDate);
+        if (expired.length === 0) continue;
+        await userProfile.findByIdAndUpdate(user._id, {
+          $push: { oldInfringements: { $each: expired } },
+        });
+      }
+
+      // Step 2: Pull expired infringements from all users
       const results = await userProfile.updateMany(
         {},
         {
           $pull: {
             infringements: { date: { $lte: cutOffDate } },
-            oldInfringements: { date: { $lte: cutOffDate } }, // clean up old ones too
           },
         },
       );


### PR DESCRIPTION
# Description

Fixes two bugs in the weekly cron job that have been causing the weekly summary email to stop sending since May 3rd, and improves blue square expiry handling to preserve historical records.

Fixes # (Weekly Summary Email not sending - Priority High)

## Related PRs:
None

## Main changes explained:

- **`cron.js`** — Removed `weeklyCompanySummaryEmail()` call which was throwing `TypeError: userhelper.weeklyCompanySummaryEmail is not a function` every Sunday, crashing the entire cron job callback and preventing all subsequent jobs from running including `emailWeeklySummariesForAllUsers`

- **`userHelper.js`** — Rewrote `deleteBlueSquareAfterYear`:
  - For active users: expired infringements (older than 1 year) are now moved to `oldInfringements` before being removed from `infringements`, preserving a permanent historical record
  - For inactive users: expired infringements are still just deleted (no history needed)
  - Previously the function wiped both `infringements` and `oldInfringements` for all users with no `isActive` filter — expired records were being permanently lost

## How to test:

1. Check out this branch and start the backend locally
2. Confirm `weeklyCompanySummaryEmail` no longer appears in the cron file
3. To test `emailWeeklySummariesForAllUsers` manually, run:
```js
const mongoose = require('mongoose');
require('dotenv').config();
const userHelperFactory = require('./src/helpers/userHelper');
async function main() {
  await mongoose.connect(process.env.MONGO_URI);
  const userhelper = userHelperFactory();
  await userhelper.emailWeeklySummariesForAllUsers();
  await mongoose.disconnect();
}
main();
```
4. Confirm it completes without errors, and the logs show users being processed
5. To test `deleteBlueSquareAfterYear`, temporarily add a test infringement dated over a year ago to an active user, run the function manually, and confirm it moves to `oldInfringements` instead of being deleted

## Notes:
- `weeklyCompanySummaryEmail` was called outside the `if (SUNDAY)` block, meaning it crashed the cron every week, not just Sundays
- `oldInfringements` may occasionally contain duplicates if the weekly `processWeeklySummariesByUserId` cron already moved the same infringement — this is cosmetic only and does not affect functionality
- Emails only send in production (`NODE_ENV=production`), so local testing is safe