### PR TITLE
Diya 🔥 fix(bsEmails): Fixed Email Threading on BS Emails

### DIFF
--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -824,6 +824,8 @@ const userHelper = function () {
           replyTo: status.email,
           bcc: emailsBCCs,
           startDate: person.startDate,
+          recipientUserId: String(status._id),
+          weekStart: pdtStartOfLastWeek.format('YYYY-MM-DD'),
         });
       } else if (!timeNotMet && !hasWeeklySummary) {
         usersRequiringBlueSqNotification.push(personId);
@@ -899,7 +901,11 @@ const userHelper = function () {
           email.cc,
           email.replyTo,
           email.bcc,
-          { type: 'blue_square_assignment' },
+          {
+            type: 'blue_square_assignment',
+            recipientUserId: email.recipientUserId,
+            weekStart: email.weekStart,
+          },
         );
       }
 


### PR DESCRIPTION
# Description

Implements [email threading](https://www.loom.com/share/bd8c3a6b3a044afb854001507242a01f) so that automated blue square follow-up emails (missed summary reminders, hours check-ins, early team member notices, 4th blue square warnings) appear in the same Gmail thread as the original "New Infringement Assigned" email, rather than as separate disconnected emails.

## Related PRs (if any):
Builds on top of PR #2257 (weekly auto-reply email hierarchy fix).

## Main changes explained:

**`helpers/userHelper.js`**

- **Updated `processUserForBlueSquare`**: Added `recipientUserId` and `weekStart` to `emailQueue.push` so these values are carried through to the send step.

- **Updated `assignBlueSquareForTimeNotMet`**: Passed `recipientUserId` and `weekStart` into the `emailSender` opts when flushing the email queue, so the original infringement email now activates the `EmailThread` threading infrastructure in `emailSender.js`. Previously these were missing, meaning no `threadKey` was computed and no thread root was ever stored.

- **`sendBlueSquareEmail`** already passed `recipientUserId` and `weekStart` correctly for auto-reply emails — no change needed there.

## How it works

`emailSender.js` has an existing `EmailThread` model that stores a `threadRootMessageId` keyed by `threadKey` (computed as `blue_square_assignment:<userId>:<weekStart>`). When the original infringement email sends at midnight, it creates this thread root. When the auto-reply emails send at 4 AM with the same `threadKey`, they find the existing thread root and set `In-Reply-To` and `References` headers pointing to it — which causes Gmail to group them into the same thread.

## How to test:

1. Check out this branch and run `npm install`
2. Manually trigger the full flow for a test user using `src/scripts/testEmailJobs/js`:
```js
const weekStart = moment().tz('America/Los_Angeles').startOf('week').subtract(1, 'week').format('YYYY-MM-DD');

// Step 1: simulate the midnight assignment email
await userhelper.assignBlueSquareForTimeNotMet();
// (or insert an EmailThread doc manually for the test user's threadKey)

// Step 2: simulate the 4 AM auto-reply
await userhelper.weeklyAutoReplyEmailFunction({
  targetUserId: '<test_user_id>',
  emailOverride: '<your_test_email>',
});
```
3. Check the test inbox — both emails should appear in the same Gmail thread
4. Verify the auto-reply shows `In-Reply-To` in its raw headers (Gmail → three dots → Show original)

## Screenshots or videos of changes:
See related discussion — Jae's manual replies already thread correctly via subject line; this change makes the automated replies do the same via proper RFC `In-Reply-To`/`References` headers.

## Note:
- This fix is **pending live testing** to confirm Gmail threads the emails correctly end-to-end. The logic is sound but email threading ultimately depends on Gmail's server-side behaviour.
- The `EmailThread` model and all threading header logic in `emailSender.js` were already in place — this PR purely connects `userHelper.js` to that existing infrastructure by passing the missing `recipientUserId` and `weekStart` fields through.
- The `threadKey` format is `blue_square_assignment:<userId>:<weekStart>` — both the assignment email and all auto-replies must use the same `userId` and `weekStart` for threading to work. This is guaranteed since both derive `weekStart` from `pdtStartOfLastWeek.format('YYYY-MM-DD')` and `userId` from `String(status._id)` / `String(user._id)`.