### PR TITLE
Handika - API endpoint for fetching application times data in Job Analytics

### DIFF
--- a/src/controllers/jobAnalytics/applicationTimeController.js
+++ b/src/controllers/jobAnalytics/applicationTimeController.js
@@ -27,8 +27,21 @@ const applicationTimeController = function () {
     }
   };
 
+  const getUniqueRoles = async (req, res) => {
+    try {
+      const uniqueRoles = await ApplicationTimeModel.distinct('role');
+      return res.status(200).json({
+        data: uniqueRoles,
+        count: uniqueRoles.length,
+      });
+    } catch (error) {
+      res.status(400).json({ error: 'failed to fetch roles. Please try again later.' });
+    }
+  };
+
   return {
     getApplicationTimes,
+    getUniqueRoles,
   };
 };
 

--- a/src/controllers/jobAnalytics/applicationTimeController.js
+++ b/src/controllers/jobAnalytics/applicationTimeController.js
@@ -1,0 +1,35 @@
+const ApplicationTimeModel = require('../../models/jobAnalytics/applicationTime');
+
+const applicationTimeController = function () {
+  const getApplicationTimes = async (req, res) => {
+    try {
+      const { startDate, roles } = req.query;
+
+      const query = {};
+
+      // add startDate to query
+      if (startDate) query.createdAt = { $gte: new Date(startDate) };
+
+      // add roles to query
+      if (roles) {
+        const roleList = roles.split(',').map((role) => role.trim());
+        if (roleList.length > 0) query.role = { $in: roleList };
+      }
+
+      const applicationTimes = await ApplicationTimeModel.find(query);
+
+      return res.status(200).json({
+        data: applicationTimes,
+        count: applicationTimes.length,
+      });
+    } catch (error) {
+      res.status(400).json({ error: 'failed to fetch application times. Please try again later.' });
+    }
+  };
+
+  return {
+    getApplicationTimes,
+  };
+};
+
+module.exports = applicationTimeController;

--- a/src/models/jobAnalytics/applicationTime.js
+++ b/src/models/jobAnalytics/applicationTime.js
@@ -1,0 +1,60 @@
+const mongoose = require('mongoose');
+
+const applicationTimeSchema = new mongoose.Schema(
+  {
+    location: {
+      country: {
+        type: String,
+        required: true,
+      },
+      state: {
+        type: String,
+        required: true,
+      },
+    },
+    deviceType: {
+      type: String,
+      required: true,
+    },
+    isOutlier: {
+      type: Boolean,
+      default: false,
+    },
+    role: {
+      type: String,
+      required: true,
+    },
+    userId: {
+      type: String,
+      required: true,
+    },
+    jobId: {
+      type: String,
+      required: true,
+    },
+    jobTitle: {
+      type: String,
+      required: true,
+    },
+    clickedAt: {
+      type: Date,
+    },
+    appliedAt: {
+      type: Date,
+    },
+    timeTaken: {
+      type: Number,
+    },
+    sessionId: {
+      type: String,
+      required: true,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+const ApplicationTimeModel = mongoose.model('ApplicationTime', applicationTimeSchema);
+
+module.exports = ApplicationTimeModel;

--- a/src/routes/jobAnalytics/applicationTimeRoutes.js
+++ b/src/routes/jobAnalytics/applicationTimeRoutes.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const applicationTimeController =
+  require('../../controllers/jobAnalytics/applicationTimeController')();
+
+const router = express.Router();
+
+router.route('/application-time').get(applicationTimeController.getApplicationTimes);
+
+module.exports = router;

--- a/src/routes/jobAnalytics/applicationTimeRoutes.js
+++ b/src/routes/jobAnalytics/applicationTimeRoutes.js
@@ -5,5 +5,6 @@ const applicationTimeController =
 const router = express.Router();
 
 router.route('/application-time').get(applicationTimeController.getApplicationTimes);
+router.route('/application-time/roles').get(applicationTimeController.getUniqueRoles);
 
 module.exports = router;

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -225,6 +225,7 @@ const weeklySummariesFilterRouter = require('../routes/weeklySummariesFilterRout
 const jobAnalyticsRoutes = require('../routes/jobAnalytics');
 
 const materialCostRouter = require('../routes/materialCostRouter')();
+const applicationTimeRoutes = require('../routes/jobAnalytics/applicationTimeRoutes');
 
 // bm dashboard
 const bmLoginRouter = require('../routes/bmdashboard/bmLoginRouter')();
@@ -546,6 +547,7 @@ module.exports = function (app) {
   app.use('/api', taskCommentRouter);
   app.use('/api/popularity-enhanced', popularityEnhancedRoutes);
   app.use('/api', jobHitsAndApplicationsRoutes);
+  app.use('/api/analytics', applicationTimeRoutes);
 
   // bm dashboard
   app.use('/api/bm', bmLoginRouter);


### PR DESCRIPTION
# Description
This is the API endpoint for fetching the application time in job analytics.

## Related PRS (if any):
This backend PR is related to the frontend side's [PR 5043](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5043)

## Main changes explained:
- Create src/controllers/jobAnalytics/applicationTimeController.js for fetching the application times data
- Create src/models/jobAnalytics/applicationTime.js for MongoDB schema
- Create src/routes/jobAnalytics/applicationTimeRoutes.js for defining the API endpoint routes
- Update src/startup/routes.js for connecting the API endpoint on the backend side

## How to test:
1. check into `handika/job-posting-page-analytics-backend` branch
2. do `npm install` and `npm run dev` to run this PR locally
4. log as admin user (If you're using Postman to test this API endpoint, add `Authorization` in the key and `JWT token` that you received when you login as the value)
5. call the API endpoint [http://localhost:4500/api/analytics/application-time](http://localhost:4500/api/analytics/application-time). Optional params: `startDate=2025-06-28T14:52:56.012Z`, `roles=Software Engineer, Manager` (`roles` is comma-separated if there are more than one value being passed)
7. verify whether the API endpoint returns the correct data

## Screenshots or videos of changes:
<img width="1242" height="864" alt="image" src="https://github.com/user-attachments/assets/e0e6f4c2-4d1a-474e-a845-a6a21a6003ce" />
<img width="1237" height="855" alt="image" src="https://github.com/user-attachments/assets/c476246f-d70c-4a9d-b673-121700fe25a4" />

## Note:
None.
