### PR TITLE
Diya 🔥 fix(timeOff): Fixed BS emails for timeoff

### DIFF
--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -756,7 +756,7 @@ const userHelper = function () {
       requestForTimeOffEmailBody = `<span style="color: blue;">You had scheduled time off From ${startingDateStr}, To ${endingDateStr}, due to: <b>${requestForTimeOffreason}</b></span>`;
     }
 
-    if (timeNotMet || !hasWeeklySummary) {
+    if ((timeNotMet || !hasWeeklySummary) && !hasTimeOffRequest) {
       const description = buildInfringementDescription(
         person,
         timeNotMet,
@@ -1340,7 +1340,7 @@ const userHelper = function () {
     if (metHours) return null;
 
     // Priority 2: 85–99% hours, got a blue square today, fewer than 4 total
-    if (nearMiss && hasTodayBlueSquare && infringementCount < 4) {
+    if (nearMiss && hasTodayBlueSquare && infringementCount < 4 && !hasTimeOff) {
       return 'MISSED_HOURS_BY_<15%';
     }
 


### PR DESCRIPTION
# Description
Fixes blue square infringement emails being incorrectly sent to users with an approved time-off request covering the affected week. This specifically affected Mentor Members (who have no hours requirement, weeklycommittedHours = 0) whose only failure condition was a missing weekly summary — previously, an approved time-off request only swapped the email's description text instead of suppressing the email entirely.
Also fixes the "close enough, blue square removed" auto-reply email firing for users whose near-miss on hours was covered by approved time off.

**Fixes:** Blue square / infringement emails sent despite approved time-off request

## Main changes explained:
- `processUserForBlueSquare` in `src/helpers/userHelper.js`: added `&& !hasTimeOffRequest` to the condition gating infringement creation and email queuing. An approved time-off request now fully suppresses the blue square and its email, rather than only changing the email's description text.
- `resolveAutoReplyTemplate` in `src/helpers/userHelper.js`: added `&& !hasTimeOff` to the near-miss (85–99% hours) branch, so the "you completed close enough to your total hours" auto-reply doesn't fire when the near-miss was covered by approved time off.

## How to test:
1. Create a Mentor Member (or any role with weeklycommittedHours = 0) test user
2. Submit a time-off request covering last week, do not submit a summary
3. Trigger `assignBlueSquareForTimeNotMet` manually
4. Verify no infringement is added and no email is sent
5. Verify a user WITHOUT a time-off request in the same state still gets the blue square + email as before
6. Create a user with hours in the 85–99% range and an approved time-off request covering the week
7. Trigger `weeklyAutoReplyEmailFunction` manually
8. Verify no "close enough" reply email is sent

## Note:
`hasTimeOffRequest` was already computed in both functions but wasn't applied to whether the infringement/email fired at all — only to the description text in one case. Other auto-reply branches (65–84.9% and 25–64.9% hours check-ins, and the 4th-blue-square warning) still fire regardless of time-off status — left as-is pending a product decision on whether those should also be suppressed.