### PR TITLE
Diya 🔥 fix(emails): Fixed Email Formats

### DIFF
--- a/src/controllers/dashBoardController.spec.js
+++ b/src/controllers/dashBoardController.spec.js
@@ -23,7 +23,7 @@ function getEmailMessageForForgotPassword(user, ranPwd) {
     <p>Use it now to log in. Then store it in a safe place or change it on your Profile Page to something easier for you to remember. </p>
     <p>If it wasn’t you that requested this password change, you can ignore this email. Otherwise, use the password above to log in and you’ll be directed to the “Change Password” page where you can set a new custom one. </p>
     <p>Thank you,<p>
-    <p>One Community</p>`;
+    <p>One Community Admin Team</p>`;
 }
 
 const makeSut = () => {

--- a/src/controllers/forgotPwdcontroller.js
+++ b/src/controllers/forgotPwdcontroller.js
@@ -10,7 +10,7 @@ function getEmailMessageForForgotPassword(user, ranPwd) {
     <p>Use it now to log in. Then store it in a safe place or change it on your Profile Page to something easier for you to remember. </p>
     <p>If it wasn’t you that requested this password change, you can ignore this email. Otherwise, use the password above to log in and you’ll be directed to the “Change Password” page where you can set a new custom one. </p>
     <p>Thank you,<p>
-    <p>One Community</p>`;
+    <p>One Community Admin Team</p>`;
   return message;
 }
 

--- a/src/controllers/profileInitialSetupController.js
+++ b/src/controllers/profileInitialSetupController.js
@@ -29,20 +29,20 @@ function sendLinkMessage(Link) {
     <p>Please complete all fields and be accurate. If you have any questions or need assistance during the profile setup process, please contact your manager.</p>
     <p>Thank you and welcome!</p>
     <p>With Gratitude,</p>
-    <p>One Community</p>`;
+    <p>One Community Admin Team</p>`;
   return message;
 }
 
 function sendRefreshedLinkMessage(Link) {
   const message = `<p>Hello,</p>
-    <p>You setup link is refreshed! Welcome to the One Community Highest Good Network! We’re excited to have you as a new member of our team.<br>
+    <p>Your setup link is refreshed! Welcome to the One Community Highest Good Network! We’re excited to have you as a new member of our team.<br>
     To work as a member of our volunteer team, you need to complete the following profile setup by:</p>   
     <p><a href="${Link}">Click to Complete Profile</a>  </p>
     <p><b>Please complete the profile setup within 21 days of this invite. </b></p>
     <p>Please complete all fields and be accurate. If you have any questions or need assistance during the profile setup process, please contact your manager.</p>
     <p>Thank you and welcome!</p>
     <p>With Gratitude,</p>
-    <p>One Community</p>`;
+    <p>One Community Admin Team</p>`;
   return message;
 }
 
@@ -52,7 +52,7 @@ function sendCancelLinkMessage() {
     <p>If you have any questions or need assistance during the profile setup process, please contact your manager.</p>
     <p>Thank you and welcome!</p>
     <p>With Gratitude,</p>
-    <p>One Community</p>`;
+    <p>One Community Admin Team</p>`;
   return message;
 }
 
@@ -109,7 +109,7 @@ function informManagerMessage(user) {
     </table> 
     <br>
     <p>Thank you,</p>
-    <p>One Community</p>`;
+    <p>One Community Admin Team</p>`;
   return message;
 }
 

--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -1306,7 +1306,7 @@ const taskController = function (Task) {
         <p>The following task is available to review:</p>
         <p><b>${taskName}</b></p>
         <p>Thank you,</p>
-        <p>One Community</p>`;
+        <p>One Community Admin Team</p>`;
 
     return text;
   };

--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -114,7 +114,7 @@ const notifyTaskOvertimeEmailBody = async (userProfile, task) => {
       <p><b>Hours Logged : ${hoursLogged.toFixed(2)}</b></p>
       <p><b>Please connect with your manager to explain what happened and submit a new hours estimation for completion.</b></p>
       <p>Thank you,</p>
-      <p>One Community</p>`;
+      <p>One Community Admin Team</p>`;
     emailSender(
       userProfile.email,
       'Logged more hours than estimated for a task',
@@ -420,7 +420,7 @@ const addEditHistory = async (
           .localeData()
           .ordinal(recentInfringements.length)}</b> blue square of 5.</p>
         <p>Thank you,<p>
-        <p>One Community</p>
+        <p>One Community Admin Team</p>
         <!-- Adding multiple non-breaking spaces -->
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
         <hr style="border-top: 1px dashed #000;"/>

--- a/src/controllers/timeOffRequestController.js
+++ b/src/controllers/timeOffRequestController.js
@@ -12,12 +12,12 @@ const userNotificationEmail = (name, action = '') => {
     <p>We wanted to inform you that your scheduled time-off request has been deleted.</p>
     <p>No further action is needed on your part regarding this request.</p>
     <p>Thank you,</p>
-    <p>One Community</p>`
+    <p>One Community Admin Team</p>`
       : `<p>Hello,</p>
     <p>Thank you ${name} for scheduling your time off.</p> 
     <p>The Admin and your Managers have been notified of this request and no further action is needed on your part.</p>   
     <p>Thank you,</p>
-    <p>One Community</p>`;
+    <p>One Community Admin Team</p>`;
   return message;
 };
 
@@ -38,7 +38,7 @@ const adminsNotificationEmail = (
   <p>We wanted to update you that this time-off request has been canceled.</p>
   <p>If any schedule adjustments or plans were made, please take note to revert them accordingly.</p>
   <p>Thank you for your understanding,</p>
-  <p>One Community</p>`
+  <p>One Community Admin Team</p>`
       : `<p>Hello,</p>
     <p>${firstName} ${lastName} has requested the following week off: <b>${moment(startDate).format(
       'MM-DD-YYYY',
@@ -47,7 +47,7 @@ const adminsNotificationEmail = (
     <p>If you need to, please make a note of this in your schedule and make any necessary plans for their action item(s).<br>
      As an additional reminder, their name in the Leaderboard and Tasks list will also reflect their absence for the time they are off.</p>
      <p>Thank you,</p>
-    <p>One Community</p>`;
+    <p>One Community Admin Team</p>`;
   return message;
 };
 

--- a/src/controllers/warningsController.js
+++ b/src/controllers/warningsController.js
@@ -98,7 +98,7 @@ const sendEmailToUser = async (
          <p>Moving forward, please ensure you don’t create situations where we need to keep doing this for you. Repeated requests for the same thing require unnecessary administrative attention and may result in a blue square being issued if it happens again.</p>
          <p>The Admin member who issued the warning is ${monitorData.firstName} ${monitorData.lastName} and their email is ${monitorData.email}. Please comment on your Google Doc and tag them using this email if you have any questions.</p>
          <p>With Gratitude,</p>
-         <p>One Community</p>`;
+         <p>One Community Admin Team</p>`;
   } else if (sendEmail === 'issue blue square') {
     subject = `IMPORTANT: You have been issued a blue square`;
     emailTemplate = `<p>Hello ${currentUserName},</p>
@@ -107,7 +107,7 @@ const sendEmailToUser = async (
     <p>Please carefully review the previous communications you’ve received to fully understand what is being requested. If anything is unclear, feel free to ask questions—the Admin team is here to help.</p>
     <p>The Admin member who issued this blue square is ${monitorData.firstName} ${monitorData.lastName} and can be reached at ${monitorData.email}. If you have any questions, please comment on your Google Doc and tag them using this email.</p>
     <p>With Gratitude,</p>
-    <p>One Community</p>`;
+    <p>One Community Admin Team</p>`;
   } else if (sendEmail === 'issue two warnings blue square') {
     subject = `IMPORTANT: You have been issued a blue square`;
     emailTemplate = `<p>Hello ${currentUserName},</p>
@@ -116,7 +116,7 @@ const sendEmailToUser = async (
     <p>Please carefully review the previous communications you’ve received to fully understand what is being requested. If anything is unclear, feel free to ask questions—the Admin team is here to help.</p>
     <p>The Admin member who issued this blue square is ${monitorData.firstName} ${monitorData.lastName} and can be reached at ${monitorData.email}. If you have any questions, please comment on your Google Doc and tag them using this email.</p>
     <p>With Gratitude,</p>
-    <p>One Community</p>`;
+    <p>One Community Admin Team</p>`;
   } else if (sendEmail === 'issue two warnings') {
     subject = `IMPORTANT: Please read this email and take note so you don’t get a blue square`;
     bccList = null;
@@ -127,7 +127,7 @@ const sendEmailToUser = async (
     <p>Moving forward, please ensure you don’t create situations where we need to keep doing this for you. Repeated requests for the same thing require unnecessary administrative attention and will likely result in a blue square being issued if it happens again.</p>
     <p>The Admin member who issued this warning is ${monitorData.firstName} ${monitorData.lastName} and can be reached at ${monitorData.email}. If you have any questions, please comment on your Google Doc and tag them using this email.</p>
     <p>With Gratitude,</p>
-    <p>One Community</p>`;
+    <p>One Community Admin Team</p>`;
   } else if (sendEmail === 'issue warning and blue square') {
     subject = `IMPORTANT: You have been issued a blue square and a warning`;
     emailTemplate = `<p>Hello ${currentUserName},</p>
@@ -136,7 +136,7 @@ const sendEmailToUser = async (
     <p>Please carefully review the previous communications you’ve received to fully understand what is being requested. If anything is unclear, feel free to ask questions—the Admin team is here to help.</p>
     <p>The Admin member who issued this blue square is ${monitorData.firstName} ${monitorData.lastName} and can be reached at ${monitorData.email}. If you have any questions, please comment on your Google Doc and tag them using this email.</p>
     <p>With Gratitude,</p>
-    <p>One Community</p>`;
+    <p>One Community Admin Team</p>`;
   } else if (sendEmail === 'issue blue square and warning') {
     subject = `IMPORTANT: You have been issued a blue square and a warning`;
     emailTemplate = `<p>Hello ${currentUserName},</p>
@@ -145,7 +145,7 @@ const sendEmailToUser = async (
     <p>Please carefully review the previous communications you’ve received to fully understand what is being requested. If anything is unclear, feel free to ask questions—the Admin team is here to help.</p>
     <p>The Admin member who issued this blue square is ${monitorData.firstName} ${monitorData.lastName} and can be reached at ${monitorData.email}. If you have any questions, please comment on your Google Doc and tag them using this email.</p>
     <p>With Gratitude,</p>
-    <p>One Community</p>`;
+    <p>One Community Admin Team</p>`;
   }
 
   emailSender(

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -33,12 +33,9 @@ const notificationService = require('../services/notificationService');
 const { NEW_USER_BLUE_SQUARE_NOTIFICATION_MESSAGE } = require('../constants/message');
 const timeUtils = require('../utilities/timeUtils');
 const Team = require('../models/team');
-const BlueSquareEmailAssignmentModel = require('../models/BlueSquareEmailAssignment');
-const Timer = require('../models/timer');
 
 const DEFAULT_CC_EMAILS = ['onecommunityglobal@gmail.com', 'jae@onecommunityglobal.org'];
 const DEFAULT_BCC_EMAILS = ['onecommunityhospitality@gmail.com'];
-const DEFAULT_REPLY_TO = ['jae@onecommunityglobal.org'];
 const { COMPANY_TZ } = require('../constants/company');
 
 const delay = (ms) =>
@@ -292,14 +289,14 @@ const userHelper = function () {
       }
     }
     // add administrative content
-    const text = `Dear <b>${firstName} ${lastName}</b>,
+    const text = `Good Morning <b>${firstName}</b>,
         <p>Oops, it looks like something happened and you’ve managed to get a blue square.</p>
         <p><b>Date Assigned:</b> ${moment(new Date(infringement.date)).format('M-D-YYYY')}</p>\
         <p><b>Description:</b> ${emailDescription}</p>
         ${descrInfringement}
         ${finalParagraph}
-        <p>Thank you,<p>
-        <p>One Community</p>
+        <p>With Gratitude,<p>
+        <p>One Community Admin Team</p>
         <!-- Adding multiple non-breaking spaces -->
           &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
         <hr style="border-top: 1px dashed #000;"/>
@@ -1104,7 +1101,7 @@ const userHelper = function () {
 
   const missedSummaryTemplate = (firstname) =>
     `<div style="font-family: Arial, sans-serif;">
-    Dear ${firstname},
+    Good Morning ${firstname},
     <div><br></div>
     <div>When you read this, please input your summary into the software. When you do, please be sure to put it in using the tab for "Last Week".</div>
     <div><br></div>
@@ -1112,9 +1109,8 @@ const userHelper = function () {
     <div><br></div>
     <div><strong>Reply all</strong> to this email once you've done this, so I know to review what you've submitted. Do this before tomorrow (Monday) at 3 PM (Pacific Time) and I'll remove this blue square.</div>
     <div><br></div>
-    <div>With Gratitude,</div>
-    <div><br></div>
-    <div>One Community</div>
+    <p>With Gratitude,<p>
+    <p>One Community Admin Team</p>
   </div>`;
 
   /**
@@ -1377,53 +1373,49 @@ const userHelper = function () {
     switch (templateNo) {
       case 'MISSED_HOURS_BY_<15%':
         return `<div style="font-family: Arial, sans-serif;">
-            Good Morning, ${firstName},
+            Good Morning ${firstName},
             <div><br></div>
             <div>You completed close enough to your total hours for us to remove this blue square. Please be sure to complete the minimum or more of your hours from now on though.</div>
             <div><br></div>
-            <div>With Gratitude,</div>
-            <div><br></div>
-            <div>One Community</div>
+            <p>With Gratitude,</p>
+            <p>One Community Admin Team</p>
           </div>`;
       case 'COMPLETED_HOURS_65%_84.9%':
         return `<div style="font-family: Arial, sans-serif;">
-            Good Morning, ${firstName},
+            Good Morning ${firstName},
             <div><br></div>
             <div>We're checking in to see if everything is ok with you. You completed most but not all of your hours this last week. Is everything ok?</div>
             <div><br></div>
             <div>Please <strong>reply all</strong> to let us know.</div>
             <div><br></div>
-            <div>With Gratitude,</div>
-            <div><br></div>
-            <div>One Community</div>
+            <p>With Gratitude,<p>
+            <p>One Community Admin Team</p>
           </div>`;
       case 'COMPLETED_HOURS_25%_64.9%':
         return `<div style="font-family: Arial, sans-serif;">
-            Good Morning, ${firstName},
+            Good Morning ${firstName},
             <div><br></div>
             <div>This email is checking in to see if everything is ok with you. You completed some but not all of your hours this last week. Is everything ok? Is there a reason you didn't use the blue square scheduler on your Profile Page to schedule the week off?</div>
             <div><br></div>
             <div>Please <strong>reply all</strong> to let us know.</div>
             <div><br></div>
-            <div>With Gratitude,</div>
-            <div><br></div>
-            <div>One Community</div>
+            <p>With Gratitude,</p>
+            <p>One Community Admin Team</p>
           </div>`;
       case '<1MON_ONE_BLUESQUARE':
         return `<div style="font-family: Arial, sans-serif;">
-            Good Morning, ${firstName},
+            Good Morning ${firstName},
             <div><br></div>
             <div>It's very unusual for someone to get a blue square in their first few weeks on the team. This email is to check in with you to see if everything is ok and if you are still wanting to volunteer with us.</div>
             <div><br></div>
             <div>Please <strong>reply all</strong> to let us know.</div>
             <div><br></div>
-            <div>With Gratitude,</div>
-            <div><br></div>
-            <div>One Community</div>
+            <p>With Gratitude,</p>
+            <p>One Community Admin Team</p>
           </div>`;
       case '<2MON_TWO_BLUESQUARE':
         return `<div style="font-family: Arial, sans-serif;">
-            Good Morning, ${firstName},
+            Good Morning ${firstName},
             <div><br></div>
             <div>We noticed that you've received <strong>two blue squares</strong> within your first couple of months on the team, which is somewhat unusual. We're reaching out to check in, understand what happened, and see if this role still aligns with your interests, availability, and energy.</div>
             <div><br></div>
@@ -1431,13 +1423,12 @@ const userHelper = function () {
             <div><br></div>
             <div>Looking forward to your response.</div>
             <div><br></div>
-            <div>With Gratitude,</div>
-            <div><br></div>
-            <div>One Community</div>
+            <p>With Gratitude,</p>
+            <p>One Community Admin Team</p>
           </div>`;
       case '<1MON_TWO_BLUESQUARE':
         return `<div style="font-family: Arial, sans-serif;">
-            Good Morning, ${firstName},
+            Good Morning ${firstName},
             <div><br></div>
             <div>We noticed that you've received <strong>two blue squares</strong> within your first few weeks on the team, which is quite unusual. When this happens, we start to wonder whether this position is the right fit for you and if you still wish to continue volunteering with us.</div>
             <div><br></div>
@@ -1447,13 +1438,12 @@ const userHelper = function () {
             <div><br></div>
             <div>Looking forward to your response.</div>
             <div><br></div>
-            <div>With Gratitude,</div>
-            <div><br></div>
-            <div>One Community</div>
+            <p>With Gratitude,</p>
+            <p>One Community Admin Team</p>
           </div>`;
       case '<2MON_THREE_BLUESQUARE':
         return `<div style="font-family: Arial, sans-serif;">
-            Good Morning, ${firstName},
+            Good Morning ${firstName},
             <div><br></div>
             <div>It's very unusual for people to get 3 blue squares in less than 2 months on the team. We're writing to check in with you to see if A) everything is OK and B) if you still have the time and desire to continue with us?</div>
             <div><br></div>
@@ -1461,35 +1451,32 @@ const userHelper = function () {
             <div><br></div>
             <div>Looking forward to your response.</div>
             <div><br></div>
-            <div>Sincerely,</div>
-            <div><br></div>
-            <div>One Community</div>
+            <p>Sincerely,</p>
+            <p>One Community Admin Team</p>
           </div>`;
       case '4TH_BLUE_SQUARE':
         return `<div style="font-family: Arial, sans-serif;">
-            Good Morning, ${firstName},
+            Good Morning ${firstName},
             <div><br></div>
             <div>We wanted to reach out because you've received <strong>four blue squares</strong>. As you may know, we allow a maximum of <strong>five</strong>, so we want to ensure you're aware that you are nearing the limit.</div>
             <div><br></div>
             <div>We appreciate your contributions and hope to see you avoiding any further blue squares. Please let us know if you have any concerns or need support in this.</div>
             <div><br></div>
-            <div>With Gratitude,</div>
-            <div><br></div>
-            <div>One Community</div>
+            <p>With Gratitude,</p>
+            <p>One Community Admin Team</p>
           </div>`;
       case 'SCHEDULED_TIME_OFF':
         return `<div style="font-family: Arial, sans-serif;">
-            Good Morning, ${firstName},
+            Good Morning ${firstName},
             <div><br></div>
             <div>Thank you for scheduling off the time you needed. Advanced notice like this is helpful and appreciated.</div>
             <div><br></div>
-            <div>With Gratitude,</div>
-            <div><br></div>
-            <div>One Community</div>
+            <p>With Gratitude,</p>
+            <p>One Community Admin Team</p>
           </div>`;
       case 'SCHEDULED_TIME_OFF_AND_4TH_BLUE_SQUARE':
         return `<div style="font-family: Arial, sans-serif;">
-            Good Morning, ${firstName},
+            Good Morning ${firstName},
             <div><br></div>
             <div>Thank you for scheduling off the time you needed. Advanced notice like this is helpful and appreciated. And as you may know, we allow a maximum of <strong>five</strong> blue squares.</div>
             <div><br></div>
@@ -1497,9 +1484,8 @@ const userHelper = function () {
             <div><br></div>
             <div>We appreciate your contributions, please let us know if you have any concerns or need support in this.</div>
             <div><br></div>
-            <div>With Gratitude,</div>
-            <div><br></div>
-            <div>One Community</div>
+            <p>With Gratitude,<p>
+            <p>One Community Admin Team</p>
           </div>`;
       default:
         console.error(`Unknown email template: ${templateNo}`);
@@ -2772,8 +2758,7 @@ const userHelper = function () {
       <p>For a smooth transition, Please confirm all your work with this individual has been wrapped up and nothing further is needed on their part until they return on ${moment(reactivationDate).format('M-D-YYYY')}. </p>
 
       <p>With Gratitude, </p>
-
-      <p>One Community</p>`;
+      <p>One Community Admin Team</p>`;
       emailSender(email, subject, emailBody, null, recipients, email);
     } else if (endDate && isSet && sendThreeWeeks) {
       const subject = `IMPORTANT: The last day for ${firstName} ${lastName} has been set in the Highest Good Network`;
@@ -2781,12 +2766,10 @@ const userHelper = function () {
 
       <p>Please note that the final day for ${firstName} ${lastName} has been set in the Highest Good Network as ${moment(endDate).format('M-D-YYYY')}.</p>
       <p>This is more than 3 weeks from now, but you should still start confirming all your work is being wrapped up with this individual and nothing further will be needed on their part after this date. </p>
-
       <p>An additional reminder email will be sent in their final 2 weeks.</p>
 
       <p>With Gratitude, </p>
-
-      <p>One Community</p>`;
+      <p>One Community Admin Team</p>`;
       emailSender(email, subject, emailBody, null, recipients, email);
     } else if (endDate && isSet && followup) {
       subject = `IMPORTANT: The last day for ${firstName} ${lastName} has been set in the Highest Good Network`;
@@ -2796,8 +2779,7 @@ const userHelper = function () {
       <p> This is coming up soon. For a smooth transition, please confirm all your work is wrapped up with this individual and nothing further will be needed on their part after this date. </p>
 
       <p>With Gratitude, </p>
-
-      <p>One Community</p>`;
+      <p>One Community Admin Team</p>`;
       emailSender(email, subject, emailBody, null, recipients, email);
     } else if (endDate && isSet) {
       subject = `IMPORTANT: The last day for ${firstName} ${lastName} has been set in the Highest Good Network`;
@@ -2807,8 +2789,7 @@ const userHelper = function () {
       <p> For a smooth transition, Please confirm all your work with this individual has been wrapped up and nothing further is needed on their part. </p>
 
       <p>With Gratitude, </p>
-
-      <p>One Community</p>`;
+      <p>One Community Admin Team</p>`;
       emailSender(email, subject, emailBody, null, recipients, email);
     } else if (endDate) {
       subject = `IMPORTANT: ${firstName} ${lastName} has been deactivated in the Highest Good Network`;
@@ -2818,8 +2799,7 @@ const userHelper = function () {
       <p>For a smooth transition, Please confirm all your work with this individual has been wrapped up and nothing further is needed on their part. </p>
 
       <p>With Gratitude, </p>
-
-      <p>One Community</p>`;
+      <p>One Community Admin Team</p>`;
       emailSender(email, subject, emailBody, null, recipients, email);
     }
   };


### PR DESCRIPTION
# Description
Fixes several formatting/consistency issues and a bug across the automated blue square / infringement email system, all reported by Jae in the same feedback round.

Fixes # (bug list priority medium: email formatting/copy consistency across blue square notification templates)

## Related PRs (if any):
N/A — backend only, single-repo change (`src/helpers/userHelper.js`).

## Main changes explained:
- Removed unused imports (`BlueSquareEmailAssignmentModel`, `Timer`) and unused constant (`DEFAULT_REPLY_TO`) from `src/helpers/userHelper.js`.
- Removed the comma from every "Good Morning, {firstName}," greeting across all email templates (`WeeklyReminderEmailBody` cases, `missedSummaryTemplate`, `getInfringementEmailBody`) so it reads "Good Morning {firstName}" — matches how a person would actually write it.
- Fixed `getInfringementEmailBody` to greet with first name only (previously included last name, and used "Dear" instead of "Good Morning" — inconsistent with every other template in the system).
- Updated sign-off across all email templates from "With Gratitude, One Community" to "With Gratitude, One Community Admin Team" (and "Sincerely, One Community Admin Team" for the one template using "Sincerely") so recipients understand a person is monitoring these automated emails.

## How to test:
1. Check out current branch
2. Run `npm install` and `npm run dev`
3. Trigger `assignBlueSquareForTimeNotMet` manually (or wait for Sunday cron) with a test user who is missing a weekly summary and/or hours
4. Verify the "New Infringement Assigned" email:
   - Greets with "Good Morning {firstName}" (no comma, first name only, no last name)
   - Signs off with "With Gratitude, One Community Admin Team"
5. Trigger `weeklyAutoReplyEmailFunction` manually for a user matching each of the reply templates (near-miss hours, 2nd/3rd/4th blue square, etc.)
6. Verify each reply email uses the same greeting/sign-off format
7. Confirm a user with an approved time-off request covering the affected week receives no blue square and no email of any kind (regression check from earlier fix in this same file)

## Note:
The Gmail sender display name ("HGN Emails") is a Gmail account setting (Settings → Accounts and Import → Send mail as → Edit info), not something controlled by `emailSender.js`, so it's out of scope for this PR and should be updated directly in the Gmail account if desired.