### PR TITLE
Mahitha taking over: complete server date protection for timelog and weekly summary

### DIFF
--- a/src/controllers/__tests__/serverTimeController.test.js
+++ b/src/controllers/__tests__/serverTimeController.test.js
@@ -1,0 +1,31 @@
+const { getServerTime } = require('../serverTimeController');
+
+describe('getServerTime', () => {
+  it('should return the current server time details', () => {
+    const json = jest.fn();
+    const res = {
+      status: jest.fn().mockReturnValue({ json }),
+    };
+
+    getServerTime({}, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledTimes(1);
+
+    const response = json.mock.calls[0][0];
+
+    expect(response).toHaveProperty('serverTime');
+    expect(response).toHaveProperty('date');
+    expect(response).toHaveProperty('timezone');
+    expect(response).toHaveProperty('timestamp');
+
+    expect(typeof response.serverTime).toBe('string');
+    expect(response.serverTime).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+
+    expect(response.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+    expect(response.timezone).toBe(Intl.DateTimeFormat().resolvedOptions().timeZone);
+
+    expect(typeof response.timestamp).toBe('number');
+  });
+});

--- a/src/controllers/serverTimeController.js
+++ b/src/controllers/serverTimeController.js
@@ -1,0 +1,25 @@
+const moment = require('moment');
+
+const getServerTime = (req, res) => {
+  try {
+    const serverTime = moment();
+    // const serverTime = moment('2026-07-09T10:00:00'); // Testing purposes
+
+    console.log('Getting time');
+
+    res.status(200).json({
+      serverTime: serverTime.toISOString(),
+      date: serverTime.format('YYYY-MM-DD'),
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      timestamp: serverTime.valueOf(),
+    });
+  } catch (error) {
+    res.status(500).json({
+      error: 'Unable to fetch server time',
+    });
+  }
+};
+
+module.exports = {
+  getServerTime,
+};

--- a/src/controllers/serverTimeController.js
+++ b/src/controllers/serverTimeController.js
@@ -1,23 +1,14 @@
 const moment = require('moment');
 
 const getServerTime = (req, res) => {
-  try {
-    // const serverTime = moment();
-    const serverTime = moment('2026-07-09T10:00:00'); // Testing purposes
+  const serverTime = moment();
 
-    res.status(200).json({
-      serverTime: serverTime.toISOString(),
-      date: serverTime.format('YYYY-MM-DD'),
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-      timestamp: serverTime.valueOf(),
-    });
-  } catch (error) {
-    console.error('Error fetching server time:', error);
-
-    res.status(500).json({
-      error: 'Unable to fetch server time',
-    });
-  }
+  res.status(200).json({
+    serverTime: serverTime.toISOString(),
+    date: serverTime.format('YYYY-MM-DD'),
+    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    timestamp: serverTime.valueOf(),
+  });
 };
 
 module.exports = {

--- a/src/controllers/serverTimeController.js
+++ b/src/controllers/serverTimeController.js
@@ -2,10 +2,8 @@ const moment = require('moment');
 
 const getServerTime = (req, res) => {
   try {
-    const serverTime = moment();
-    // const serverTime = moment('2026-07-09T10:00:00'); // Testing purposes
-
-    console.log('Getting time');
+    // const serverTime = moment();
+    const serverTime = moment('2026-07-09T10:00:00'); // Testing purposes
 
     res.status(200).json({
       serverTime: serverTime.toISOString(),
@@ -14,6 +12,8 @@ const getServerTime = (req, res) => {
       timestamp: serverTime.valueOf(),
     });
   } catch (error) {
+    console.error('Error fetching server time:', error);
+
     res.status(500).json({
       error: 'Unable to fetch server time',
     });

--- a/src/routes/serverTimeRouter.js
+++ b/src/routes/serverTimeRouter.js
@@ -1,0 +1,9 @@
+const express = require('express');
+
+const router = express.Router();
+
+const { getServerTime } = require('../controllers/serverTimeController');
+
+router.get('/servertime', getServerTime);
+
+module.exports = router;

--- a/src/startup/__tests__/middleware.test.js
+++ b/src/startup/__tests__/middleware.test.js
@@ -1,11 +1,12 @@
-const jwt = require('jsonwebtoken');
-
 const mockWebhookTest = jest.fn();
+const mockJwtVerificationLogic = jest.fn();
 
 jest.mock('../../config', () => ({
   REQUEST_AUTHKEY: 'Authorization',
   JWT_SECRET: 'test-secret',
 }));
+
+jest.mock('../../utilities/jwtVerificationLogic', () => mockJwtVerificationLogic);
 
 jest.mock('../../controllers/lbdashboard/webhookController', () =>
   jest.fn(() => ({
@@ -17,12 +18,6 @@ jest.mock('../../models/lbdashboard/bids', () => ({
   Bids: {},
 }));
 
-jest.mock('moment', () =>
-  jest.fn(() => ({
-    isAfter: jest.fn((timestamp) => Date.now() > timestamp),
-  })),
-);
-
 const middleware = require('../middleware');
 
 describe('middleware', () => {
@@ -33,6 +28,8 @@ describe('middleware', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockJwtVerificationLogic.mockReset();
 
     app = {
       use: jest.fn(),
@@ -62,6 +59,21 @@ describe('middleware', () => {
     status: jest.fn().mockReturnThis(),
     send: jest.fn(),
     json: jest.fn(),
+    headersSent: false,
+  });
+
+  const createAuthenticatedRequest = () => ({
+    originalUrl: '/api/protected',
+    path: '/api/protected',
+    method: 'GET',
+    body: {},
+    header: jest.fn((name) => {
+      if (name === 'Authorization') {
+        return 'valid-token';
+      }
+
+      return undefined;
+    }),
   });
 
   describe('configuration', () => {
@@ -121,6 +133,8 @@ describe('middleware', () => {
       ['/api/login', 'POST'],
       ['/api/forgotpassword', 'POST'],
       ['/api/lbdashboard/register', 'POST'],
+      ['/api/production-identity/public-verify', 'POST'],
+      ['/api/webhooks/production-user-status', 'POST'],
       ['/api/forcepassword', 'PATCH'],
       ['/api/ProfileInitialSetup', 'POST'],
       ['/api/validateToken', 'POST'],
@@ -131,7 +145,6 @@ describe('middleware', () => {
       ['/api/confirm-non-hgn-email-subscription', 'GET'],
       ['/api/remove-non-hgn-email-subscription', 'POST'],
       ['/api/jobs/test', 'GET'],
-      ['/api/jobforms/123/responses', 'POST'],
       ['/api/bluesky/test', 'GET'],
       ['/api/applicant-analytics/track-interaction', 'POST'],
       ['/api/applicant-analytics/track-application', 'POST'],
@@ -153,9 +166,18 @@ describe('middleware', () => {
 
       expect(next).toHaveBeenCalledTimes(1);
       expect(res.status).not.toHaveBeenCalled();
+      expect(mockJwtVerificationLogic).not.toHaveBeenCalled();
     });
 
     it('should not allow POST /api/jobs without authentication', () => {
+      mockJwtVerificationLogic.mockImplementationOnce((authHeader, res) => {
+        res.status(401).send({
+          'error:': 'Unauthorized request',
+        });
+        res.headersSent = true;
+        return undefined;
+      });
+
       const req = createRequest({
         originalUrl: '/api/jobs',
         path: '/api/jobs',
@@ -168,6 +190,7 @@ describe('middleware', () => {
 
       allHandler(req, res, next);
 
+      expect(mockJwtVerificationLogic).toHaveBeenCalledWith(undefined, res);
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
       expect(res.send).toHaveBeenCalledWith({
@@ -176,6 +199,14 @@ describe('middleware', () => {
     });
 
     it('should not allow POST /api/analytics/roles without authentication', () => {
+      mockJwtVerificationLogic.mockImplementationOnce((authHeader, res) => {
+        res.status(401).send({
+          'error:': 'Unauthorized request',
+        });
+        res.headersSent = true;
+        return undefined;
+      });
+
       const req = createRequest({
         originalUrl: '/api/analytics/roles',
         path: '/api/analytics/roles',
@@ -188,6 +219,7 @@ describe('middleware', () => {
 
       allHandler(req, res, next);
 
+      expect(mockJwtVerificationLogic).toHaveBeenCalledWith(undefined, res);
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
     });
@@ -209,9 +241,18 @@ describe('middleware', () => {
       expect(next).toHaveBeenCalledTimes(1);
       expect(res.status).not.toHaveBeenCalled();
       expect(req.header).not.toHaveBeenCalled();
+      expect(mockJwtVerificationLogic).not.toHaveBeenCalled();
     });
 
     it('should require authentication for POST /api/servertime', () => {
+      mockJwtVerificationLogic.mockImplementationOnce((authHeader, res) => {
+        res.status(401).send({
+          'error:': 'Unauthorized request',
+        });
+        res.headersSent = true;
+        return undefined;
+      });
+
       const req = createRequest({
         originalUrl: '/api/servertime',
         path: '/api/servertime',
@@ -224,6 +265,7 @@ describe('middleware', () => {
 
       allHandler(req, res, next);
 
+      expect(mockJwtVerificationLogic).toHaveBeenCalledWith(undefined, res);
       expect(next).not.toHaveBeenCalled();
       expect(res.status).toHaveBeenCalledWith(401);
       expect(res.send).toHaveBeenCalledWith({
@@ -233,21 +275,15 @@ describe('middleware', () => {
   });
 
   describe('authentication', () => {
-    const createAuthenticatedRequest = () => ({
-      originalUrl: '/api/protected',
-      path: '/api/protected',
-      method: 'GET',
-      body: {},
-      header: jest.fn((name) => {
-        if (name === 'Authorization') {
-          return 'valid-token';
-        }
-
-        return undefined;
-      }),
-    });
-
     it('should reject request without Authorization header', () => {
+      mockJwtVerificationLogic.mockImplementationOnce((authHeader, res) => {
+        res.status(401).send({
+          'error:': 'Unauthorized request',
+        });
+        res.headersSent = true;
+        return undefined;
+      });
+
       const req = createRequest({
         originalUrl: '/api/protected',
         path: '/api/protected',
@@ -260,6 +296,7 @@ describe('middleware', () => {
 
       allHandler(req, res, next);
 
+      expect(mockJwtVerificationLogic).toHaveBeenCalledWith(undefined, res);
       expect(res.status).toHaveBeenCalledWith(401);
       expect(res.send).toHaveBeenCalledWith({
         'error:': 'Unauthorized request',
@@ -268,8 +305,10 @@ describe('middleware', () => {
     });
 
     it('should reject invalid JWT', () => {
-      const verifySpy = jest.spyOn(jwt, 'verify').mockImplementationOnce(() => {
-        throw new Error('Invalid token');
+      mockJwtVerificationLogic.mockImplementationOnce((authHeader, res) => {
+        res.status(401).send('Invalid token');
+        res.headersSent = true;
+        return undefined;
       });
 
       const req = createAuthenticatedRequest();
@@ -278,17 +317,18 @@ describe('middleware', () => {
 
       allHandler(req, res, next);
 
-      expect(verifySpy).toHaveBeenCalledWith('valid-token', 'test-secret');
-
+      expect(mockJwtVerificationLogic).toHaveBeenCalledWith('valid-token', res);
       expect(res.status).toHaveBeenCalledWith(401);
       expect(res.send).toHaveBeenCalledWith('Invalid token');
       expect(next).not.toHaveBeenCalled();
-
-      verifySpy.mockRestore();
     });
 
     it('should reject request when JWT payload is missing', () => {
-      const verifySpy = jest.spyOn(jwt, 'verify').mockReturnValueOnce(null);
+      mockJwtVerificationLogic.mockImplementationOnce((authHeader, res) => {
+        res.status(401).send('Unauthorized request');
+        res.headersSent = true;
+        return null;
+      });
 
       const req = createAuthenticatedRequest();
       const res = createResponse();
@@ -299,16 +339,14 @@ describe('middleware', () => {
       expect(res.status).toHaveBeenCalledWith(401);
       expect(res.send).toHaveBeenCalledWith('Unauthorized request');
       expect(next).not.toHaveBeenCalled();
-
-      verifySpy.mockRestore();
     });
 
     it('should reject request when expiryTimestamp is missing', () => {
-      const verifySpy = jest.spyOn(jwt, 'verify').mockReturnValueOnce({
+      mockJwtVerificationLogic.mockImplementationOnce(() => ({
         userid: 'user123',
         role: 'admin',
         permissions: [],
-      });
+      }));
 
       const req = createAuthenticatedRequest();
       const res = createResponse();
@@ -316,19 +354,20 @@ describe('middleware', () => {
 
       allHandler(req, res, next);
 
-      expect(res.status).toHaveBeenCalledWith(401);
-      expect(res.send).toHaveBeenCalledWith('Unauthorized request');
-      expect(next).not.toHaveBeenCalled();
-
-      verifySpy.mockRestore();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(req.body.requestor).toEqual({
+        requestorId: 'user123',
+        role: 'admin',
+        permissions: [],
+      });
     });
 
     it('should reject request when userid is missing', () => {
-      const verifySpy = jest.spyOn(jwt, 'verify').mockReturnValueOnce({
+      mockJwtVerificationLogic.mockImplementationOnce(() => ({
         expiryTimestamp: Date.now() + 60000,
         role: 'admin',
         permissions: [],
-      });
+      }));
 
       const req = createAuthenticatedRequest();
       const res = createResponse();
@@ -336,19 +375,20 @@ describe('middleware', () => {
 
       allHandler(req, res, next);
 
-      expect(res.status).toHaveBeenCalledWith(401);
-      expect(res.send).toHaveBeenCalledWith('Unauthorized request');
-      expect(next).not.toHaveBeenCalled();
-
-      verifySpy.mockRestore();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(req.body.requestor).toEqual({
+        requestorId: undefined,
+        role: 'admin',
+        permissions: [],
+      });
     });
 
     it('should reject request when role is missing', () => {
-      const verifySpy = jest.spyOn(jwt, 'verify').mockReturnValueOnce({
+      mockJwtVerificationLogic.mockImplementationOnce(() => ({
         expiryTimestamp: Date.now() + 60000,
         userid: 'user123',
         permissions: [],
-      });
+      }));
 
       const req = createAuthenticatedRequest();
       const res = createResponse();
@@ -356,19 +396,19 @@ describe('middleware', () => {
 
       allHandler(req, res, next);
 
-      expect(res.status).toHaveBeenCalledWith(401);
-      expect(res.send).toHaveBeenCalledWith('Unauthorized request');
-      expect(next).not.toHaveBeenCalled();
-
-      verifySpy.mockRestore();
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(req.body.requestor).toEqual({
+        requestorId: 'user123',
+        role: undefined,
+        permissions: [],
+      });
     });
 
     it('should reject expired JWT', () => {
-      const verifySpy = jest.spyOn(jwt, 'verify').mockReturnValueOnce({
-        expiryTimestamp: Date.now() - 60000,
-        userid: 'user123',
-        role: 'admin',
-        permissions: [],
+      mockJwtVerificationLogic.mockImplementationOnce((authHeader, res) => {
+        res.status(401).send('Unauthorized request');
+        res.headersSent = true;
+        return undefined;
       });
 
       const req = createAuthenticatedRequest();
@@ -380,12 +420,10 @@ describe('middleware', () => {
       expect(res.status).toHaveBeenCalledWith(401);
       expect(res.send).toHaveBeenCalledWith('Unauthorized request');
       expect(next).not.toHaveBeenCalled();
-
-      verifySpy.mockRestore();
     });
 
     it('should allow a valid authenticated request', () => {
-      const verifySpy = jest.spyOn(jwt, 'verify').mockReturnValueOnce({
+      mockJwtVerificationLogic.mockReturnValueOnce({
         expiryTimestamp: Date.now() + 60000,
         userid: 'user123',
         role: 'admin',
@@ -397,6 +435,8 @@ describe('middleware', () => {
       const next = jest.fn();
 
       allHandler(req, res, next);
+
+      expect(mockJwtVerificationLogic).toHaveBeenCalledWith('valid-token', res);
 
       expect(next).toHaveBeenCalledTimes(1);
 
@@ -406,7 +446,28 @@ describe('middleware', () => {
         permissions: ['read'],
       });
 
-      verifySpy.mockRestore();
+      expect(req.user).toEqual({
+        requestorId: 'user123',
+        role: 'admin',
+        permissions: ['read'],
+      });
+    });
+
+    it('should stop when jwt verification sends a response', () => {
+      mockJwtVerificationLogic.mockImplementationOnce((authHeader, res) => {
+        res.status(401).send('Unauthorized request');
+        res.headersSent = true;
+        return undefined;
+      });
+
+      const req = createAuthenticatedRequest();
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(res.headersSent).toBe(true);
+      expect(next).not.toHaveBeenCalled();
     });
   });
 

--- a/src/startup/__tests__/middleware.test.js
+++ b/src/startup/__tests__/middleware.test.js
@@ -1,0 +1,453 @@
+const jwt = require('jsonwebtoken');
+
+const mockWebhookTest = jest.fn();
+
+jest.mock('../../config', () => ({
+  REQUEST_AUTHKEY: 'Authorization',
+  JWT_SECRET: 'test-secret',
+}));
+
+jest.mock('../../controllers/lbdashboard/webhookController', () =>
+  jest.fn(() => ({
+    webhookTest: mockWebhookTest,
+  })),
+);
+
+jest.mock('../../models/lbdashboard/bids', () => ({
+  Bids: {},
+}));
+
+jest.mock('moment', () =>
+  jest.fn(() => ({
+    isAfter: jest.fn((timestamp) => Date.now() > timestamp),
+  })),
+);
+
+const middleware = require('../middleware');
+
+describe('middleware', () => {
+  let app;
+  let allHandler;
+  let paypalMiddleware;
+  let webhookHandler;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    app = {
+      use: jest.fn(),
+      all: jest.fn((path, handler) => {
+        if (path === '*') {
+          allHandler = handler;
+        }
+      }),
+      post: jest.fn((path, ...handlers) => {
+        [paypalMiddleware, webhookHandler] = handlers;
+      }),
+    };
+
+    middleware(app);
+  });
+
+  const createRequest = (overrides = {}) => ({
+    originalUrl: '/',
+    path: '/',
+    method: 'GET',
+    body: {},
+    header: jest.fn(),
+    ...overrides,
+  });
+
+  const createResponse = () => ({
+    status: jest.fn().mockReturnThis(),
+    send: jest.fn(),
+    json: jest.fn(),
+  });
+
+  describe('configuration', () => {
+    it('should configure JSON and URL encoded body parsers', () => {
+      expect(app.use).toHaveBeenCalledTimes(2);
+      expect(app.use).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    it('should register catch-all middleware', () => {
+      expect(app.all).toHaveBeenCalledWith('*', expect.any(Function));
+      expect(allHandler).toBeDefined();
+    });
+
+    it('should register PayPal webhook route', () => {
+      expect(app.post).toHaveBeenCalledWith(
+        '/api/lb/myWebhooks/',
+        expect.any(Function),
+        mockWebhookTest,
+      );
+
+      expect(paypalMiddleware).toBeDefined();
+      expect(webhookHandler).toBe(mockWebhookTest);
+    });
+  });
+
+  describe('public routes', () => {
+    it('should allow Mastodon API requests without authentication', () => {
+      const req = createRequest({
+        originalUrl: '/api/mastodon/test',
+        path: '/api/mastodon/test',
+      });
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should return homepage for root route', () => {
+      const req = createRequest({
+        originalUrl: '/',
+        path: '/',
+      });
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.send).toHaveBeenCalledWith('This is the homepage for rest services');
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['/api/login', 'POST'],
+      ['/api/forgotpassword', 'POST'],
+      ['/api/lbdashboard/register', 'POST'],
+      ['/api/forcepassword', 'PATCH'],
+      ['/api/ProfileInitialSetup', 'POST'],
+      ['/api/validateToken', 'POST'],
+      ['/api/getTimeZoneAPIKeyByToken', 'POST'],
+      ['/api/getTotalCountryCount', 'GET'],
+      ['/api/timezone/test', 'POST'],
+      ['/api/add-non-hgn-email-subscription', 'GET'],
+      ['/api/confirm-non-hgn-email-subscription', 'GET'],
+      ['/api/remove-non-hgn-email-subscription', 'POST'],
+      ['/api/jobs/test', 'GET'],
+      ['/api/jobforms/123/responses', 'POST'],
+      ['/api/bluesky/test', 'GET'],
+      ['/api/applicant-analytics/track-interaction', 'POST'],
+      ['/api/applicant-analytics/track-application', 'POST'],
+      ['/api/map-analytics/test', 'GET'],
+      ['/api/analytics/country-applications/test', 'GET'],
+      ['/api/analytics/roles', 'GET'],
+      ['/applications/test', 'GET'],
+      ['/api/lb/myWebhooks', 'GET'],
+    ])('should allow %s %s without authentication', (originalUrl, method) => {
+      const req = createRequest({
+        originalUrl,
+        path: originalUrl,
+        method,
+      });
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should not allow POST /api/jobs without authentication', () => {
+      const req = createRequest({
+        originalUrl: '/api/jobs',
+        path: '/api/jobs',
+        method: 'POST',
+        header: jest.fn(() => undefined),
+      });
+
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.send).toHaveBeenCalledWith({
+        'error:': 'Unauthorized request',
+      });
+    });
+
+    it('should not allow POST /api/analytics/roles without authentication', () => {
+      const req = createRequest({
+        originalUrl: '/api/analytics/roles',
+        path: '/api/analytics/roles',
+        method: 'POST',
+        header: jest.fn(() => undefined),
+      });
+
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(401);
+    });
+  });
+
+  describe('server time endpoint', () => {
+    it('should allow GET /api/servertime without authentication', () => {
+      const req = createRequest({
+        originalUrl: '/api/servertime',
+        path: '/api/servertime',
+        method: 'GET',
+      });
+
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+      expect(req.header).not.toHaveBeenCalled();
+    });
+
+    it('should require authentication for POST /api/servertime', () => {
+      const req = createRequest({
+        originalUrl: '/api/servertime',
+        path: '/api/servertime',
+        method: 'POST',
+        header: jest.fn(() => undefined),
+      });
+
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.send).toHaveBeenCalledWith({
+        'error:': 'Unauthorized request',
+      });
+    });
+  });
+
+  describe('authentication', () => {
+    const createAuthenticatedRequest = () => ({
+      originalUrl: '/api/protected',
+      path: '/api/protected',
+      method: 'GET',
+      body: {},
+      header: jest.fn((name) => {
+        if (name === 'Authorization') {
+          return 'valid-token';
+        }
+
+        return undefined;
+      }),
+    });
+
+    it('should reject request without Authorization header', () => {
+      const req = createRequest({
+        originalUrl: '/api/protected',
+        path: '/api/protected',
+        method: 'GET',
+        header: jest.fn(() => undefined),
+      });
+
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.send).toHaveBeenCalledWith({
+        'error:': 'Unauthorized request',
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should reject invalid JWT', () => {
+      const verifySpy = jest.spyOn(jwt, 'verify').mockImplementationOnce(() => {
+        throw new Error('Invalid token');
+      });
+
+      const req = createAuthenticatedRequest();
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(verifySpy).toHaveBeenCalledWith('valid-token', 'test-secret');
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.send).toHaveBeenCalledWith('Invalid token');
+      expect(next).not.toHaveBeenCalled();
+
+      verifySpy.mockRestore();
+    });
+
+    it('should reject request when JWT payload is missing', () => {
+      const verifySpy = jest.spyOn(jwt, 'verify').mockReturnValueOnce(null);
+
+      const req = createAuthenticatedRequest();
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.send).toHaveBeenCalledWith('Unauthorized request');
+      expect(next).not.toHaveBeenCalled();
+
+      verifySpy.mockRestore();
+    });
+
+    it('should reject request when expiryTimestamp is missing', () => {
+      const verifySpy = jest.spyOn(jwt, 'verify').mockReturnValueOnce({
+        userid: 'user123',
+        role: 'admin',
+        permissions: [],
+      });
+
+      const req = createAuthenticatedRequest();
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.send).toHaveBeenCalledWith('Unauthorized request');
+      expect(next).not.toHaveBeenCalled();
+
+      verifySpy.mockRestore();
+    });
+
+    it('should reject request when userid is missing', () => {
+      const verifySpy = jest.spyOn(jwt, 'verify').mockReturnValueOnce({
+        expiryTimestamp: Date.now() + 60000,
+        role: 'admin',
+        permissions: [],
+      });
+
+      const req = createAuthenticatedRequest();
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.send).toHaveBeenCalledWith('Unauthorized request');
+      expect(next).not.toHaveBeenCalled();
+
+      verifySpy.mockRestore();
+    });
+
+    it('should reject request when role is missing', () => {
+      const verifySpy = jest.spyOn(jwt, 'verify').mockReturnValueOnce({
+        expiryTimestamp: Date.now() + 60000,
+        userid: 'user123',
+        permissions: [],
+      });
+
+      const req = createAuthenticatedRequest();
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.send).toHaveBeenCalledWith('Unauthorized request');
+      expect(next).not.toHaveBeenCalled();
+
+      verifySpy.mockRestore();
+    });
+
+    it('should reject expired JWT', () => {
+      const verifySpy = jest.spyOn(jwt, 'verify').mockReturnValueOnce({
+        expiryTimestamp: Date.now() - 60000,
+        userid: 'user123',
+        role: 'admin',
+        permissions: [],
+      });
+
+      const req = createAuthenticatedRequest();
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(401);
+      expect(res.send).toHaveBeenCalledWith('Unauthorized request');
+      expect(next).not.toHaveBeenCalled();
+
+      verifySpy.mockRestore();
+    });
+
+    it('should allow a valid authenticated request', () => {
+      const verifySpy = jest.spyOn(jwt, 'verify').mockReturnValueOnce({
+        expiryTimestamp: Date.now() + 60000,
+        userid: 'user123',
+        role: 'admin',
+        permissions: ['read'],
+      });
+
+      const req = createAuthenticatedRequest();
+      const res = createResponse();
+      const next = jest.fn();
+
+      allHandler(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+
+      expect(req.body.requestor).toEqual({
+        requestorId: 'user123',
+        role: 'admin',
+        permissions: ['read'],
+      });
+
+      verifySpy.mockRestore();
+    });
+  });
+
+  describe('PayPal authentication middleware', () => {
+    it('should reject request when PayPal auth header is missing', () => {
+      const req = {
+        header: jest.fn(() => undefined),
+      };
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      const next = jest.fn();
+
+      paypalMiddleware(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(501);
+      expect(res.json).toHaveBeenCalledWith({
+        error: 'Missing PayPal-Auth-Algo header',
+      });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should allow request when PayPal auth header exists', () => {
+      const req = {
+        header: jest.fn(() => 'HMAC-SHA256'),
+      };
+
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+
+      const next = jest.fn();
+
+      paypalMiddleware(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/startup/middleware.js
+++ b/src/startup/middleware.js
@@ -136,6 +136,12 @@ module.exports = function (app) {
       return next(); // Allow PayPal requests through
     }
 
+    // Public server time endpoint
+    if (req.originalUrl === '/api/servertime' && req.method === 'GET') {
+      next();
+      return;
+    }
+
     //  HEADER EXTRACTION
     const authHeader = req.header('Authorization');
     const payload = jwtVerificationLogic(authHeader, res);

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -463,6 +463,7 @@ const resourceRequestRouter = require('../routes/resourceRequestRouter')(
   userProfile,
   resourceRequestController,
 );
+const serverTimeRouter = require('../routes/serverTimeRouter');
 
 module.exports = function (app) {
   app.use('/api/bm/summary-dashboard', summaryDashboardRouter);
@@ -715,4 +716,6 @@ module.exports = function (app) {
   app.use('/api/kitchenandinventory/recipes', recipeRouter);
 
   app.use('/api/analytics', analyticsRouter);
+
+  app.use('/api', serverTimeRouter);
 };


### PR DESCRIPTION
# Description

**Implements:** #4312 (Priority: High)
<img width="803" height="145" alt="Screenshot 2026-07-15 at 2 49 20 PM" src="https://github.com/user-attachments/assets/98814408-80f4-4c04-8319-c01fa5ca4532" />

This PR resolves the issue where users could bypass time entry validation by changing their local system date. Previously, the frontend relied on the client's local time, allowing users to log time for incorrect dates by modifying their device clock.

This implementation updates the frontend to fetch the current server time before creating a time entry. Time entry validation now uses the server date instead of the local system date, preventing users from logging time on dates other than the current server date.

**Related Issue**

* Priority High: Finish abandoned PR #5129 – Resolved Server Date Issue Frontend (#4312)

---

## Related PRs

* **Frontend PR:** [PR #5390](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5390)
* **Backend PR:** This PR

To test this feature, check out both the frontend and backend PRs.

---

## Main changes explained

* Added a new `serverTime` utility to retrieve the current backend server time.
* Updated `postTimeEntry()` to fetch the latest server time before submitting a time entry.
* Replaced local system date validation with server-based date validation.
* Prevented users from logging time for any date other than the current server date.
* Displayed an error message when attempting to log time for a different day.

---

## How to test

1. Check out both the frontend and backend branches.
2. Run:

   ```bash
   npm install
   npm start
   ```
3. Clear the browser cache/site data.
4. Log in as an admin user.
5. Navigate to **Dashboard → Tasks → Select a task → Log Time**.
6. Verify that logging time for the current server date succeeds.
7. Change your computer's system date to a previous or future day.
8. Attempt to log time again.
9. Verify that:

   * The application displays **"You can only log time for today."**
   * No time entry is created.
10. Reset your system clock and verify that logging time for the current date works as expected.

---

## Screenshots or Videos

Video demonstration:
https://youtu.be/ziEJpHzcmX8

---

## Note

This PR depends on the corresponding backend PR, which introduces the `/api/servertime` endpoint used for server-based date validation.