### PR TITLE
Abhishek 🔥: resolve role distribution stats crash on comparison filter

### DIFF
--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -1011,38 +1011,12 @@ const overviewReportHelper = function () {
    * NOTE: This shows ALL active users regardless of createdDate to provide
    * a complete picture of current role distribution in the organization
    */
-  async function getRoleDistributionStats(
-    startDate,
-    endDate,
-    comparisonStartDate,
-    comparisonEndDate,
-  ) {
+  async function getRoleDistributionStats() {
     // Always match only active users, ignore date filters for role distribution
-    // This ensures all current roles are displayed, not just recently created users
-    const buildMatch = () => ({ isActive: true });
-
-    // If comparison dates provided, return both current and comparison facets
-    if (comparisonStartDate && comparisonEndDate) {
-      const roleStats = await UserProfile.aggregate([
-        {
-          $facet: {
-            current: [{ $match: buildMatch() }, { $group: { _id: '$role', count: { $sum: 1 } } }],
-            comparison: [
-              { $match: buildMatch() },
-              { $group: { _id: '$role', count: { $sum: 1 } } },
-            ],
-          },
-        },
-      ]);
-
-      return {
-        current: roleStats[0]?.current || [],
-        comparison: roleStats[0]?.comparison || [],
-      };
-    }
-
-    // No comparison: return same shape as before (array of {_id: role, count})
-    const matchStage = buildMatch();
+    // This ensures all current roles are displayed, not just recently created users.
+    // Role distribution is a live snapshot, not a time-series metric, so comparison
+    // periods do not apply here — always return a flat array of {_id: role, count}.
+    const matchStage = { isActive: true };
     const result = await UserProfile.aggregate([
       { $match: matchStage },
       { $group: { _id: '$role', count: { $sum: 1 } } },


### PR DESCRIPTION
## What's Working Well
- Fixes a frontend crash ("Something went wrong" / `TypeError: roleDistributionStats is not iterable`) that occurred whenever a comparison filter (Previous Week, Week Over Week, Month Over Month, Year Over Year) was selected on the Total Org Summary page.

## Root Cause
`getRoleDistributionStats` in `overviewReportHelper.js` branched on whether comparison dates were provided:
- **No comparison:** returned a flat array of `{_id: role, count}` — the shape the frontend (`RoleDistributionPieChart.jsx`) has always expected.
- **With comparison:** ran a MongoDB `$facet` aggregation and returned an object `{ current: [...], comparison: [...] }` instead — a completely different shape, which crashed the frontend when it tried to spread/iterate the response as an array.

Notably, role distribution is explicitly documented in the code as a **live snapshot** (`isActive: true`, no date filtering) — it isn't a time-series metric. The comparison branch's `current` and `comparison` facets both used the exact same match stage with no date filter, so they always returned identical data anyway. The branching added complexity and a shape mismatch without providing any real comparison value.

## Changes
- `overviewReportHelper.js`: removed the comparison branching in `getRoleDistributionStats`. The function now always returns a flat array, matching the frontend's expectation and eliminating the now-unnecessary duplicate aggregation. Unused `startDate`, `endDate`, `comparisonStartDate`, `comparisonEndDate` parameters were dropped from the function signature (the call site still passes them positionally, which is harmless since JS ignores unused arguments).

## Testing

### Via the UI
1. Start both HGNRest (backend) on the branch `Abhishek_FixRoleDistributionStatsComparisonCrash` and HighestGoodNetworkApp (frontend) on `development`
2. Navigate to **Total Org Summary**.
3. Toggle through each comparison option (Previous Week, Week Over Week, Month Over Month, Year Over Year) and confirm:
   - No crash / error screen
   - The **Role Distribution** pie chart (Volunteer Roles & Team Dynamics section) renders correctly
   - Switching back to "No Comparison" still works

### Via direct API call
The backend runs on port `4500` by default, and this endpoint requires an authenticated Bearer token (obtainable via `/api/login` or from the frontend's local storage after logging in).

```bash
curl "http://localhost:4500/api/reports/volunteerstats?startDate=2026-07-05&endDate=2026-07-11&comparisonStartDate=2026-06-05&comparisonEndDate=2026-06-11" \
  -H "Authorization: Bearer YOUR_TOKEN_HERE"
```

Verified locally: this request, which previously would have returned `roleDistributionStats` as an object (`{ current: [...], comparison: [...] }`) and crashed the frontend, now returns **200 OK** with `roleDistributionStats` as a flat array, e.g.:
```json
"roleDistributionStats": [
  { "_id": "Volunteer", "count": 2400 },
  { "_id": "Manager", "count": 45 },
  ...
]
```
<img width="2880" height="1368" alt="Screenshot 2026-07-17 162514" src="https://github.com/user-attachments/assets/bbd84a57-2a8e-4ae9-ad95-a662c4e0de61" />
<img width="2880" height="1096" alt="Screenshot 2026-07-17 162447" src="https://github.com/user-attachments/assets/dd5a0294-db45-47a1-bdfb-012781786e48" />
