### PR TITLE
Amaresh - Fix: Add Lost Time for project/team returns 404 due to missing personId lookup

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -563,25 +563,28 @@ const timeEntrycontroller = function (TimeEntry) {
       timeEntry.lastModifiedDateTime = now;
       timeEntry.entryType = req.body.entryType;
 
-      const userprofile = await UserProfile.findById(timeEntry.personId);
+      // Project and team lost-time entries have no associated personId, so there is
+      // no user profile to look up or update for them.
+      const entryHasPerson = timeEntry.entryType !== 'project' && timeEntry.entryType !== 'team';
+      const userprofile = entryHasPerson ? await UserProfile.findById(timeEntry.personId) : null;
 
-      if (!userprofile) {
+      if (entryHasPerson && !userprofile) {
         await session.abortTransaction();
         return res.status(404).send({ error: 'User not found' });
       }
 
-      if (!userprofile.isActive && userprofile.deactivatedAt) {
-        const cutoff = moment(userprofile.deactivatedAt).tz(COMPANY_TZ).endOf('day');
-
-        if (moment().isAfter(cutoff)) {
-          await session.abortTransaction();
-          return res.status(403).send({
-            error: 'User is deactivated and can no longer log time',
-          });
-        }
-      }
-
       if (userprofile) {
+        if (!userprofile.isActive && userprofile.deactivatedAt) {
+          const cutoff = moment(userprofile.deactivatedAt).tz(COMPANY_TZ).endOf('day');
+
+          if (moment().isAfter(cutoff)) {
+            await session.abortTransaction();
+            return res.status(403).send({
+              error: 'User is deactivated and can no longer log time',
+            });
+          }
+        }
+
         // if the time entry is tangible, update the tangible hours in the user profile
         if (timeEntry.isTangible) {
           // update the total tangible hours in the user profile and the hours by category
@@ -609,16 +612,16 @@ const timeEntrycontroller = function (TimeEntry) {
           // if the time entry is intangible, just update the intangible hours in the userprofile
           updateUserprofileTangibleIntangibleHrs(0, timeEntry.totalSeconds, userprofile);
         }
-      }
 
-      // Replace the isFirstTimelog checking logic from the frontend to the backend
-      // Update the user start date to current date if this is the first time entry (Weekly blue square assignment related)
-      const isFirstTimeEntry = await checkIsUserFirstTimeEntry(timeEntry.personId);
-      if (isFirstTimeEntry) {
-        userprofile.isFirstTimelog = false;
-        userprofile.startDate = now;
+        // Replace the isFirstTimelog checking logic from the frontend to the backend
+        // Update the user start date to current date if this is the first time entry (Weekly blue square assignment related)
+        const isFirstTimeEntry = await checkIsUserFirstTimeEntry(timeEntry.personId);
+        if (isFirstTimeEntry) {
+          userprofile.isFirstTimelog = false;
+          userprofile.startDate = now;
+        }
+        userprofile.lastActivityAt = new Date();
       }
-      userprofile.lastActivityAt = new Date();
 
       await timeEntry.save({ session });
       if (userprofile) {

--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -645,6 +645,11 @@ const timeEntrycontroller = function (TimeEntry) {
         }
       }
 
+      if (timeEntry.entryType === 'team') {
+        const lostteamentryCache = cacheClosure();
+        lostteamentryCache.clearByPrefix('LostTeamEntry_');
+      }
+
       await session.commitTransaction();
       pendingEmailCollection.forEach((emailHandler) => emailHandler());
       return res.status(200).send({


### PR DESCRIPTION
# Description
`POST /api/TimeEntry` was returning a 404 ("User not found") for any lost-time entry of type `project` or `team`, so those entries silently failed to save even after the frontend fix in PR #4738 stopped the UI from erroring visibly. Root cause: `postTimeEntryController` unconditionally did `UserProfile.findById(timeEntry.personId)` and 404'd if no user was found, but `project` and `team` type lost-time entries never have a `personId` (only a `projectId` or `teamId`), so the lookup always failed for those two types.

## Related PRS (if any):
This backend PR is related to the [#4738](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4738) frontend PR.
To test this backend PR you need to checkout the [#4738](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4738) frontend PR (branch `shravya/bugfix/3824`).

## Main changes explained:
- Update `src/controllers/timeEntryController.js` for making the `UserProfile` lookup/update in `postTimeEntry` conditional on `entryType` being `person` or `default` (the only types that carry a `personId`). For `project`/`team` entries, the user-profile lookup, the 404 guard, the deactivation check, the tangible/intangible hour updates, and the `isFirstTimelog` update are all skipped, and the time entry is saved directly. No behavior change for `person`/`default` entries.
- Update `src/controllers/timeEntryController.js` for clearing the `LostTeamEntry_*` cache in `postTimeEntry` when a new team entry is added. ' editTimeEntry` and `deleteTimeEntry` already did this, but `postTimeEntry` (create) didn't, so newly-added team lost time sat behind a stale cached response for up to 5 minutes (the cache's `stdTTL`) before showing up under "Show Team Lost Time".

## How to test:
1. Check out this branch (`amaresh/fix-lost-time-post-entry-404`) and run `npm install` and `npm run dev` to run this PR locally
2. Check out frontend PR #4738 (branch `shravya/bugfix/3824`) and run it locally, pointed at this backend
3. Clear site data/cache
4. Log in as a user with the **Owner** role
5. Go to Reports page → scroll to the Lost Time section → click **Add Lost Time**
6. Select **Type: Project** (or **Team**), fill in a project/team name, date, and time, then Submit
7. Verify function "Add Lost Time" works: you get a success response (no 404) and the entry appears under **Show Project Lost Time** (or **Show Team Lost Time**)
8. For **Team** specifically: click **Show Team Lost Time** first (to warm the cache), then submit a new Team entry, then click **Show Team Lost Time** again, verify the new entry appears **immediately**, not after a ~5 minute delay
9. As a regression check, also submit a **Person** type entry and confirm it still works exactly as before

## Screenshots or videos of changes:
<img width="1470" height="880" alt="Screenshot 2026-07-18 at 3 07 36 PM" src="https://github.com/user-attachments/assets/a5621976-6cbb-48cf-935d-044108759b9e" />
<img width="1470" height="881" alt="Screenshot 2026-07-18 at 3 08 16 PM" src="https://github.com/user-attachments/assets/9f43e5a7-498c-46a0-a62e-71e4ddbc789c" />
<img width="1470" height="881" alt="Screenshot 2026-07-18 at 3 11 33 PM" src="https://github.com/user-attachments/assets/dd97b41c-0307-4a2a-b702-86625f0d580e" />
<img width="1470" height="882" alt="Screenshot 2026-07-18 at 3 20 49 PM" src="https://github.com/user-attachments/assets/a2ed8789-36cf-49b8-aa09-4833d217b8b4" />

## Note: