### PR TITLE
Abhishek 🔥: correct issueName fallback, flatten response shape, and sort by duration in Longest Open Issues

### DIFF
--- a/src/controllers/bmdashboard/__tests__/bmIssueController.test.js
+++ b/src/controllers/bmdashboard/__tests__/bmIssueController.test.js
@@ -793,8 +793,7 @@ describe('Building Issue Controller', () => {
       const result = res.json.mock.calls[0][0];
       expect(result).toHaveLength(1);
       expect(result[0].issueName).toBe('Old Issue');
-      expect(result[0].projects).toHaveLength(1);
-      expect(result[0].projects[0].durationOpen).toBeGreaterThan(0);
+      expect(result[0].durationOpen).toBeGreaterThan(0);
     });
 
     it('should filter by projects when provided', async () => {
@@ -849,12 +848,15 @@ describe('Building Issue Controller', () => {
 
       const result = res.json.mock.calls[0][0];
       expect(result).toHaveLength(7);
-      // Response is capped at 7 items; each item has issueName and projects with durationOpen
+      // Response is capped at 7 items; each item is a flat object with issueName and durationOpen
       result.forEach((item) => {
         expect(item.issueName).toBeDefined();
-        expect(item.projects).toHaveLength(1);
-        expect(typeof item.projects[0].durationOpen).toBe('number');
+        expect(typeof item.durationOpen).toBe('number');
       });
+      // Confirm results are actually sorted longest-to-shortest
+      for (let i = 1; i < result.length; i += 1) {
+        expect(result[i - 1].durationOpen).toBeGreaterThanOrEqual(result[i].durationOpen);
+      }
     });
 
     it('should format duration correctly for months', async () => {
@@ -874,7 +876,7 @@ describe('Building Issue Controller', () => {
       await controller.getLongestOpenIssues(req, res);
 
       const result = res.json.mock.calls[0][0];
-      expect(result[0].projects[0].durationOpen).toBeGreaterThanOrEqual(2);
+      expect(result[0].durationOpen).toBeGreaterThanOrEqual(2);
     });
 
     it('should return 500 error when database error occurs', async () => {

--- a/src/controllers/bmdashboard/bmIssueController.js
+++ b/src/controllers/bmdashboard/bmIssueController.js
@@ -65,13 +65,10 @@ const getDurationOpenMonths = (issueDate) =>
 
 const buildGroupedIssues = (issues) => {
   const grouped = {};
-
   issues.forEach((issue) => {
     if (!issue.issueDate || !issue.projectId) return;
-
-    const issueName = Array.isArray(issue.issueTitle)
-      ? issue.issueTitle[0]
-      : issue.issueTitle || 'Unknown Issue';
+    const rawTitle = Array.isArray(issue.issueTitle) ? issue.issueTitle[0] : issue.issueTitle;
+    const issueName = rawTitle || 'Unknown Issue';
 
     const projectId = issue.projectId._id.toString();
     const projectName = issue.projectId.projectName || issue.projectId.name || 'Unknown Project';
@@ -93,10 +90,15 @@ const buildGroupedIssues = (issues) => {
 
 const buildLongestOpenResponse = (grouped) =>
   Object.entries(grouped)
-    .map(([issueName, projectsById]) => ({
-      issueName,
-      projects: Object.values(projectsById),
-    }))
+    .flatMap(([issueName, projectsById]) =>
+      Object.values(projectsById).map((project) => ({
+        issueName,
+        projectId: project.projectId,
+        projectName: project.projectName,
+        durationOpen: project.durationOpen,
+      })),
+    )
+    .sort((a, b) => b.durationOpen - a.durationOpen)
     .slice(0, MAX_LONGEST_OPEN_ISSUES);
 
 const omitUndefined = (obj) =>


### PR DESCRIPTION
## What's Working Well

Fixes three data bugs in the "Longest Open Issues" chart (BM Dashboard → Issue Tracking):

1. **Literal "undefined" row appearing in the chart.** In `buildGroupedIssues`, the `'Unknown Issue'` fallback only applied when `issue.issueTitle` was a non-array falsy value. When `issueTitle` was an array with no usable first element, `issueName` evaluated to JS `undefined`, which became the literal string `"undefined"` once used as an object key — showing up as a real row label in the chart.

2. **Every bar showing "0 months" regardless of actual issue age.** `buildLongestOpenResponse` returned a nested shape (`{ issueName, projects: [{ projectId, projectName, durationOpen }] }`), but the frontend expects a flat shape (`durationOpen`, `projectId`, `projectName` directly on each item). Since the frontend read `item.durationOpen ?? 0` and that field never existed at the top level, every bar silently defaulted to 0.

3. **Results weren't actually sorted by duration.** The response was sliced to the top `MAX_LONGEST_OPEN_ISSUES` (7) without any prior sort, so "Longest Open Issues" could show arbitrary issues rather than the actual longest-open ones.

## Changes

`bmIssueController.js`:

- `buildGroupedIssues`: extracted `rawTitle` separately from both the array and non-array branches, so the `'Unknown Issue'` fallback now applies consistently regardless of how `issueTitle` is stored.
- `buildLongestOpenResponse`: flattened the response to one object per issue-project pair with `issueName`, `projectId`, `projectName`, `durationOpen` all top-level; added `.sort((a, b) => b.durationOpen - a.durationOpen)` before slicing to the top N.

## Testing

### Via the UI

Verified via the frontend (Use this branch for frontend and backend: `Abhishek_FixLongestOpenIssuesDataAndTheming`): Reports → Total Construction Summary → Issue Tracking → Longest Open Issues
- No more "Unknown Issue" mislabeled as "undefined"
- All bars show correct, non-zero durations matching real issue ages
- Results correctly sorted longest-to-shortest (20 → 20 → 17 → 10 → 9 → 6 → 6 months in test data)

### Via direct API call

Backend runs on port `4500` by default. Endpoint:

```
GET /api/bm/issues/longest-open
```

Optional query params: `dates` (comma-separated start,end) and `projects` (comma-separated project IDs).

```bash
curl "http://localhost:4500/api/bm/issues/longest-open" \
  -H "Authorization: Bearer YOUR_TOKEN_HERE" | python -m json.tool
```

Filtered example:

```bash
curl "http://localhost:4500/api/bm/issues/longest-open?dates=2025-01-01,2026-07-20" \
  -H "Authorization: Bearer YOUR_TOKEN_HERE" | python -m json.tool
```

Expected response shape — flat array, sorted by `durationOpen` descending, no nested `projects`, `"Unknown Issue"` instead of `"undefined"`:

Related PR: https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5396