### PR TITLE
Abhishek 🔥: stale "NEW" badge on Weekly Summary AI Prompt button

### DIFF
--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -76,7 +76,7 @@ const userProfileSchema = new Schema({
     unique: true,
     validate: [validate({ validator: 'isEmail', message: 'Email address is invalid' })],
   },
-  copiedAiPrompt: { type: Date, default: Date.now() },
+  copiedAiPrompt: { type: Date, default: Date.now },
   emailSubscriptions: {
     type: Boolean,
     default: false,

--- a/src/models/weeklySummaryAIPrompt.js
+++ b/src/models/weeklySummaryAIPrompt.js
@@ -5,7 +5,7 @@ const { Schema } = mongoose;
 const WeeklySummaryAIPrompt = new Schema({
   _id: { type: mongoose.Schema.Types.String },
   aIPromptText: { type: String },
-  modifiedDatetime: { type: Date, default: Date.now() }, // The modifiedDateTime will be updated, each time there is change/ update in the AI prompt.
+  modifiedDatetime: { type: Date, default: Date.now }, // The modifiedDateTime will be updated, each time there is change/ update in the AI prompt.
 });
 
 module.exports = mongoose.model(


### PR DESCRIPTION
## Problem

The "View and Copy AI Prompt" button on the Weekly Summary page shows a **NEW** badge to indicate the AI prompt has been updated since the user last copied it. This is driven by comparing two timestamps:

- `modifiedDatetime` on the `weeklySummaryAIPrompt` document (backend: `HGNRest`)
- `copiedAiPrompt` on the user's profile (backend: `HGNRest`)

Both schemas defined their default value as:

```js
default: Date.now()
```

Because `Date.now()` (with parentheses) is invoked **immediately when the schema is compiled** (i.e. once, at server startup), any document that falls back to this default — rather than having an explicit value written to it — receives a **frozen timestamp equal to the moment the server process booted**, not the actual time the document was created.

This meant the "NEW" badge comparison could be influenced by stale, coincidental startup-time values rather than genuine edit/copy activity, depending on when the server was last restarted relative to real prompt edits and user copies.

## Fix

Changed both schema defaults from `Date.now()` to `Date.now` (function reference) so Mongoose evaluates them fresh, per-document, at creation time:

- `src/models/weeklySummaryAIPrompt.js` → `modifiedDatetime: { type: Date, default: Date.now }`
- `src/models/userProfile.js` → `copiedAiPrompt: { type: Date, default: Date.now }`

## Testing done

- Inspected live network responses (`aiPrompt` and user profile `copiedAiPrompt`) via DevTools to confirm which values are being compared and how.
- Confirmed clicking **Copy Prompt** updates `copiedAiPrompt`, and the **NEW** badge correctly disappears after a page refresh.
- Verified the badge logic is otherwise consistent: badge shows only when `modifiedDatetime > copiedAiPrompt`.

Before:

<img width="1600" height="471" alt="image" src="https://github.com/user-attachments/assets/7ad06ef0-5505-40ec-a4a4-076e401a031b" />


After:

<img width="2420" height="1104" alt="Screenshot 2026-07-23 132627" src="https://github.com/user-attachments/assets/499114ec-1538-48af-a239-b28ebf9b3f64" />