### PR TITLE
Yuxuan - Fix Volunteer Hours Distribution date boundaries

### DIFF
--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -186,12 +186,12 @@ const reportsController = function () {
           isoComparisonEndDate,
         ),
         overviewReportHelper.getHoursStats(
-          isoStartDate,
-          isoEndDate,
-          isoComparisonStartDate,
-          isoComparisonEndDate,
+          startDate,
+          endDate,
+          comparisonStartDate,
+          comparisonEndDate,
         ),
-        overviewReportHelper.getTotalHoursWorked(isoStartDate, isoEndDate),
+        overviewReportHelper.getTotalHoursWorked(startDate, endDate),
         overviewReportHelper.getTasksStats(
           isoStartDate,
           isoEndDate,

--- a/src/controllers/reportsController.volunteerHoursDates.spec.js
+++ b/src/controllers/reportsController.volunteerHoursDates.spec.js
@@ -1,0 +1,62 @@
+const mockGetHoursStats = jest.fn();
+const mockGetTotalHoursWorked = jest.fn();
+
+jest.mock(
+  '../helpers/overviewReportHelper',
+  () => () =>
+    new Proxy(
+      {
+        getHoursStats: mockGetHoursStats,
+        getTotalHoursWorked: mockGetTotalHoursWorked,
+      },
+      {
+        get(target, property) {
+          return target[property] || jest.fn().mockResolvedValue({});
+        },
+      },
+    ),
+);
+
+jest.mock('../utilities/nodeCache', () => () => ({
+  hasCache: jest.fn().mockReturnValue(false),
+  getCache: jest.fn(),
+  setCache: jest.fn(),
+  setKeyTimeToLive: jest.fn(),
+  removeCache: jest.fn(),
+}));
+
+const reportsController = require('./reportsController');
+
+describe('getVolunteerStatsData volunteer-hours date flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetHoursStats.mockResolvedValue([]);
+    mockGetTotalHoursWorked.mockResolvedValue({ current: 0 });
+  });
+
+  test.each([
+    ['Current Week', '2026-07-26', '2026-07-31'],
+    ['Previous Week', '2026-07-19', '2026-07-25'],
+    ['custom range', '2026-07-05', '2026-07-11'],
+  ])('passes canonical strings for %s', async (label, startDate, endDate) => {
+    const req = {
+      query: {
+        startDate,
+        endDate,
+        comparisonStartDate: '2026-06-21',
+        comparisonEndDate: '2026-06-27',
+      },
+    };
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+
+    await reportsController().getVolunteerStatsData(req, res);
+
+    expect(mockGetHoursStats).toHaveBeenCalledWith(startDate, endDate, '2026-06-21', '2026-06-27');
+    expect(mockGetTotalHoursWorked).toHaveBeenCalledWith(startDate, endDate);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -1386,10 +1386,10 @@ const overviewReportHelper = function () {
               cond: {
                 $and: [
                   {
-                    $gte: ['$$entry.dateOfWork', moment(startDate).format('YYYY-MM-DD')],
+                    $gte: ['$$entry.dateOfWork', startDate],
                   },
                   {
-                    $lte: ['$$entry.dateOfWork', moment(endDate).format('YYYY-MM-DD')],
+                    $lte: ['$$entry.dateOfWork', endDate],
                   },
                 ],
               },
@@ -1470,19 +1470,16 @@ const overviewReportHelper = function () {
   }
 
   /**
-   * Aggregates total hours worked this week across all active volunteers,
+   * Aggregates total hours worked in the selected date range across all active volunteers,
    * matching the dashboard's getOrgData logic exactly:
-   * - Current week (America/Los_Angeles) date range, ignoring any passed-in date filters
+   * - Uses inclusive YYYY-MM-DD boundaries matching timeEntries.dateOfWork
    * - Only active users with weeklycommittedHours >= 1 and role != Mentor
    * - Excludes entryType of 'person', 'team', or 'project'
    */
   async function getTotalHoursWorked(startDate, endDate) {
-    const pdtstart = startDate
-      ? moment(startDate).format('YYYY-MM-DD')
-      : moment().tz('America/Los_Angeles').startOf('week').format('YYYY-MM-DD');
-    const pdtend = endDate
-      ? moment(endDate).format('YYYY-MM-DD')
-      : moment().tz('America/Los_Angeles').endOf('week').format('YYYY-MM-DD');
+    const pdtstart =
+      startDate || moment().tz('America/Los_Angeles').startOf('week').format('YYYY-MM-DD');
+    const pdtend = endDate || moment().tz('America/Los_Angeles').endOf('week').format('YYYY-MM-DD');
 
     const data = await UserProfile.aggregate([
       {

--- a/src/helpers/overviewReportHelper.spec.js
+++ b/src/helpers/overviewReportHelper.spec.js
@@ -1,6 +1,5 @@
-/* eslint-disable no-unused-vars */
+const UserProfile = require('../models/userProfile');
 const overviewReportHelper = require('./overviewReportHelper');
-// const UserProfile = require('../models/userProfile');
 
 // const makeSut = () => {
 //   const { getVolunteerNumberStats } = overviewReportHelper();
@@ -9,7 +8,114 @@ const overviewReportHelper = require('./overviewReportHelper');
 // };
 
 describe('overviewReportHelper tests', () => {
-  it('Fix this test suite', () => {});
+  describe('getHoursStats date boundaries', () => {
+    const originalTimezone = process.env.TZ;
+
+    afterEach(() => {
+      process.env.TZ = originalTimezone;
+      jest.restoreAllMocks();
+    });
+
+    test.each(['UTC', 'America/New_York', 'Asia/Tokyo'])(
+      'uses the same current, previous, and custom date boundaries in %s',
+      async (timezone) => {
+        process.env.TZ = timezone;
+
+        const entries = [
+          { dateOfWork: '2026-07-04', totalSeconds: 50 * 3600 },
+          { dateOfWork: '2026-07-05', totalSeconds: 5 * 3600 },
+          { dateOfWork: '2026-07-11', totalSeconds: 6 * 3600 },
+          { dateOfWork: '2026-07-12', totalSeconds: 50 * 3600 },
+          { dateOfWork: '2026-07-18', totalSeconds: 50 * 3600 },
+          { dateOfWork: '2026-07-19', totalSeconds: 5 * 3600 },
+          { dateOfWork: '2026-07-25', totalSeconds: 6 * 3600 },
+          { dateOfWork: '2026-07-26', totalSeconds: 5 * 3600 },
+          { dateOfWork: '2026-07-31', totalSeconds: 6 * 3600 },
+          { dateOfWork: '2026-08-01', totalSeconds: 50 * 3600 },
+        ];
+
+        jest.spyOn(UserProfile, 'aggregate').mockImplementation(async (pipeline) => {
+          const conditions = pipeline[3].$project.timeEntries.$filter.cond.$and;
+          const startDate = conditions[0].$gte[1];
+          const endDate = conditions[1].$lte[1];
+          return [
+            {
+              _id: 'volunteer-id',
+              timeEntries: entries.filter(
+                (entry) => entry.dateOfWork >= startDate && entry.dateOfWork <= endDate,
+              ),
+            },
+          ];
+        });
+
+        const { getHoursStats } = overviewReportHelper();
+        const ranges = [
+          ['2026-07-26', '2026-07-31'], // Current week
+          ['2026-07-19', '2026-07-25'], // Previous week
+          ['2026-07-05', '2026-07-11'], // Custom range
+        ];
+
+        const results = await Promise.all(
+          ranges.map(([startDate, endDate]) => getHoursStats(startDate, endDate)),
+        );
+
+        results.forEach((result) => {
+          expect(result).toEqual([
+            { _id: '10', count: 0 },
+            { _id: '20', count: 1 },
+            { _id: '30', count: 0 },
+            { _id: '40', count: 0 },
+            { _id: '50', count: 0 },
+            { _id: '50+', count: 0 },
+          ]);
+        });
+      },
+    );
+  });
+
+  describe('getTotalHoursWorked date boundaries', () => {
+    const originalTimezone = process.env.TZ;
+
+    afterEach(() => {
+      process.env.TZ = originalTimezone;
+      jest.restoreAllMocks();
+    });
+
+    test.each(['UTC', 'America/New_York', 'America/Los_Angeles', 'Asia/Tokyo'])(
+      'uses the exact inclusive date strings in %s',
+      async (timezone) => {
+        process.env.TZ = timezone;
+        let appliedStartDate;
+        let appliedEndDate;
+        const entries = [
+          { dateOfWork: '2026-07-18', totalSeconds: 50 * 3600 },
+          { dateOfWork: '2026-07-19', totalSeconds: 5 * 3600 },
+          { dateOfWork: '2026-07-25', totalSeconds: 6 * 3600 },
+          { dateOfWork: '2026-07-26', totalSeconds: 50 * 3600 },
+        ];
+
+        jest.spyOn(UserProfile, 'aggregate').mockImplementation(async (pipeline) => {
+          const conditions = pipeline[2].$project.timeEntryData.$filter.cond.$and;
+          const [startCondition, endCondition] = conditions;
+          [, appliedStartDate] = startCondition.$gte;
+          [, appliedEndDate] = endCondition.$lte;
+          const totalSeconds = entries
+            .filter(
+              (entry) => entry.dateOfWork >= appliedStartDate && entry.dateOfWork <= appliedEndDate,
+            )
+            .reduce((total, entry) => total + entry.totalSeconds, 0);
+          return [{ totaltime_hrs: totalSeconds / 3600 }];
+        });
+
+        const { getTotalHoursWorked } = overviewReportHelper();
+        const result = await getTotalHoursWorked('2026-07-19', '2026-07-25');
+
+        expect(appliedStartDate).toBe('2026-07-19');
+        expect(appliedEndDate).toBe('2026-07-25');
+        expect(result).toEqual({ current: 11 });
+      },
+    );
+  });
 });
 
 // describe('overviewReportHelper method tests', () => {


### PR DESCRIPTION
# Description
This PR fixes a timezone-dependent date boundary issue in the Volunteer Hours Distribution report. Previously, `volunteerHoursStats` and `totalHoursWorked` could use different effective date ranges because `totalHoursWorked` converted date-only boundaries through timezone-dependent `Date`/`moment` formatting. This caused inconsistent report results across different server timezones.

The report now preserves canonical `YYYY-MM-DD` boundaries throughout the calculation so both aggregations use the exact same inclusive date range regardless of server timezone.

## Related PRS (if any):

This backend PR is related to the frontend PR #[5423](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5423).

To test this backend PR, please also check out frontend PR #[5423](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5423).

Redo of this PR: https://github.com/OneCommunityGlobal/HGNRest/pull/2238

## Main changes explained:

- Updated `reportsController.js` to pass the validated `YYYY-MM-DD` request boundaries directly to both `getHoursStats()` and `getTotalHoursWorked()`.
- Updated `overviewReportHelper.js` so `getTotalHoursWorked()` compares canonical date strings directly against `timeEntries.dateOfWork` instead of converting dates through timezone-dependent formatting.
- Added regression tests covering multiple server timezones and inclusive start/end date boundaries.
- Updated helper documentation to reflect the new date-boundary behavior.

## How to test:

1. Check out this backend branch together with the related frontend PR.
2. Run `npm install`, then start the backend with `npm start`.
3. Start the frontend using `npm run start:local`.
4. Clear browser cache/site data.
5. Log in as an Admin user.
6. Go to **Dashboard → Reports → Total Org Summary**.
7. Test **Current Week**, **Previous Week**, and several custom date ranges.
8. Verify that the `/reports/volunteerstats` request uses the expected `startDate` and `endDate`.
9. Verify that `volunteerHoursStats` and `totalHoursWorked` are calculated using the same inclusive date boundaries regardless of server timezone.

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/81662895-5dbe-48d7-97fb-dc3b72993283


## Note:

- This PR does not change report business logic, bucket definitions, `shouldCountWeek()`, comparison behavior, or API response structure.
- The related frontend PR updates the week preset calculations so the requested date ranges are correct.
