### PR TITLE
Roshini Seelamsetty - Fix Incorrect Blue Square Data Filtering in Teams and Blue Squares Dashboard

### DIFF
--- a/src/controllers/__tests__/reportsController.test.js
+++ b/src/controllers/__tests__/reportsController.test.js
@@ -1,0 +1,162 @@
+jest.mock('../../helpers/reporthelper', () => jest.fn(() => ({})));
+
+jest.mock('../../helpers/overviewReportHelper', () => {
+  const getBlueSquareStats = jest.fn();
+  const factory = jest.fn(() => ({
+    getBlueSquareStats,
+  }));
+  factory.__mockGetBlueSquareStats = getBlueSquareStats;
+  return factory;
+});
+
+jest.mock('../../utilities/permissions', () => ({
+  hasPermission: jest.fn(),
+}));
+
+jest.mock('../../models/userProfile', () => ({
+  find: jest.fn(),
+}));
+
+jest.mock('../../utilities/emailSender', () => jest.fn());
+
+jest.mock('../../utilities/nodeCache', () =>
+  jest.fn(() => ({
+    hasCache: jest.fn(() => false),
+    getCache: jest.fn(),
+    setCache: jest.fn(),
+    removeCache: jest.fn(),
+  })),
+);
+
+jest.mock('../../utilities/playwrightUtil', () => jest.fn());
+
+const overviewReportHelperClosure = require('../../helpers/overviewReportHelper');
+const reportsControllerFactory = require('../reportsController');
+
+describe('reportsController.getBlueSquareStats', () => {
+  let controller;
+  let res;
+  let getBlueSquareStatsMock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getBlueSquareStatsMock = overviewReportHelperClosure.__mockGetBlueSquareStats;
+    controller = reportsControllerFactory();
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+      send: jest.fn(),
+    };
+  });
+
+  it('returns 400 when startDate or endDate is missing', async () => {
+    const req = { query: { startDate: '2026-08-01' } };
+
+    await controller.getBlueSquareStats(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith('Please provide startDate and endDate');
+    expect(getBlueSquareStatsMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when startDate/endDate format is invalid', async () => {
+    const req = { query: { startDate: 'not-a-date', endDate: '2026-08-07' } };
+
+    await controller.getBlueSquareStats(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith(
+      'Please provide valid startDate and endDate in YYYY-MM-DD format',
+    );
+    expect(getBlueSquareStatsMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when comparison dates are invalid', async () => {
+    const req = {
+      query: {
+        startDate: '2026-08-01',
+        endDate: '2026-08-07',
+        comparisonStartDate: 'bad-date',
+        comparisonEndDate: '2026-07-31',
+      },
+    };
+
+    await controller.getBlueSquareStats(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith(
+      'Please provide valid comparisonStartDate and comparisonEndDate in YYYY-MM-DD format',
+    );
+    expect(getBlueSquareStatsMock).not.toHaveBeenCalled();
+  });
+
+  it('returns blue square payload with blueSquareCount and chartData', async () => {
+    getBlueSquareStatsMock.mockResolvedValue({
+      missingHours: { count: 2 },
+      missingSummary: { count: 0 },
+      missingHoursAndSummary: { count: 0 },
+      vacationTime: { count: 0 },
+      other: { count: 0 },
+      totalBlueSquares: { count: 2 },
+    });
+
+    const req = {
+      query: {
+        startDate: '2026-08-01',
+        endDate: '2026-08-07',
+      },
+    };
+
+    await controller.getBlueSquareStats(req, res);
+
+    expect(getBlueSquareStatsMock).toHaveBeenCalledTimes(1);
+    const [startDateArg, endDateArg, comparisonStartArg, comparisonEndArg] =
+      getBlueSquareStatsMock.mock.calls[0];
+
+    expect(startDateArg).toBeInstanceOf(Date);
+    expect(endDateArg).toBeInstanceOf(Date);
+    expect(startDateArg.toISOString()).toBe('2026-08-01T07:00:00.000Z');
+    expect(endDateArg.toISOString()).toBe('2026-08-08T06:59:59.999Z');
+    expect(comparisonStartArg).toBeUndefined();
+    expect(comparisonEndArg).toBeUndefined();
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      msg: {
+        blueSquareCount: 2,
+        missingHours: { count: 2 },
+        missingSummary: { count: 0 },
+        missingHoursAndSummary: { count: 0 },
+        vacationTime: { count: 0 },
+        other: { count: 0 },
+        totalBlueSquares: { count: 2 },
+        chartData: {
+          missingHours: { count: 2 },
+        },
+      },
+    });
+  });
+
+  it('passes comparison date boundaries to helper when provided', async () => {
+    getBlueSquareStatsMock.mockResolvedValue({
+      totalBlueSquares: { count: 0 },
+    });
+
+    const req = {
+      query: {
+        startDate: '2026-08-01',
+        endDate: '2026-08-07',
+        comparisonStartDate: '2026-07-25',
+        comparisonEndDate: '2026-07-31',
+      },
+    };
+
+    await controller.getBlueSquareStats(req, res);
+
+    const [, , comparisonStartArg, comparisonEndArg] = getBlueSquareStatsMock.mock.calls[0];
+    expect(comparisonStartArg).toBeInstanceOf(Date);
+    expect(comparisonEndArg).toBeInstanceOf(Date);
+    expect(comparisonStartArg.toISOString()).toBe('2026-07-25T07:00:00.000Z');
+    expect(comparisonEndArg.toISOString()).toBe('2026-08-01T06:59:59.999Z');
+  });
+});

--- a/src/controllers/reportsController.js
+++ b/src/controllers/reportsController.js
@@ -2,6 +2,7 @@
 /* eslint-disable consistent-return */
 const fs = require('node:fs');
 const mongoose = require('mongoose');
+const moment = require('moment-timezone');
 // eslint-disable-next-line import/no-unresolved
 const reporthelperClosure = require('../helpers/reporthelper');
 const overviewReportHelperClosure = require('../helpers/overviewReportHelper');
@@ -600,17 +601,67 @@ const reportsController = function () {
    */
   const getBlueSquareStats = async function (req, res) {
     try {
-      const { startDate, endDate } = req.query;
+      const { startDate, endDate, comparisonStartDate, comparisonEndDate } = req.query;
 
       if (!startDate || !endDate) {
         res.status(400).send('Please provide startDate and endDate');
         return;
       }
 
-      const blueSquareStats = await overviewReportHelper.getBlueSquareStats(startDate, endDate);
-      const blueSquareCount = blueSquareStats.length > 0 ? blueSquareStats[0].infringements : 0;
+      const isoStartDate = moment.tz(startDate, 'YYYY-MM-DD', 'America/Los_Angeles').startOf('day');
+      const isoEndDate = moment.tz(endDate, 'YYYY-MM-DD', 'America/Los_Angeles').endOf('day');
 
-      res.status(200).json({ msg: { blueSquareCount } });
+      if (!isoStartDate.isValid() || !isoEndDate.isValid()) {
+        res.status(400).send('Please provide valid startDate and endDate in YYYY-MM-DD format');
+        return;
+      }
+
+      let isoComparisonStartDate;
+      let isoComparisonEndDate;
+
+      if (comparisonStartDate && comparisonEndDate) {
+        isoComparisonStartDate = moment
+          .tz(comparisonStartDate, 'YYYY-MM-DD', 'America/Los_Angeles')
+          .startOf('day')
+          .toDate();
+        isoComparisonEndDate = moment
+          .tz(comparisonEndDate, 'YYYY-MM-DD', 'America/Los_Angeles')
+          .endOf('day')
+          .toDate();
+
+        if (!moment(isoComparisonStartDate).isValid() || !moment(isoComparisonEndDate).isValid()) {
+          res
+            .status(400)
+            .send(
+              'Please provide valid comparisonStartDate and comparisonEndDate in YYYY-MM-DD format',
+            );
+          return;
+        }
+      }
+
+      const blueSquareStats = await overviewReportHelper.getBlueSquareStats(
+        isoStartDate.toDate(),
+        isoEndDate.toDate(),
+        isoComparisonStartDate,
+        isoComparisonEndDate,
+      );
+      const blueSquareCount = blueSquareStats.totalBlueSquares?.count || 0;
+      const chartData = Object.entries(blueSquareStats)
+        .filter(([, value]) => value?.count > 0)
+        .reduce((accum, [key, value]) => {
+          if (key !== 'totalBlueSquares') {
+            accum[key] = value;
+          }
+          return accum;
+        }, {});
+
+      res.status(200).json({
+        msg: {
+          blueSquareCount,
+          ...blueSquareStats,
+          chartData,
+        },
+      });
     } catch (error) {
       res.status(404).send(error);
     }

--- a/src/helpers/__tests__/overviewReportHelper.blueSquareStats.test.js
+++ b/src/helpers/__tests__/overviewReportHelper.blueSquareStats.test.js
@@ -1,0 +1,66 @@
+jest.mock('../../models/team', () => ({}));
+
+jest.mock('../../models/userProfile', () => ({
+  aggregate: jest.fn(),
+}));
+
+jest.mock('../../models/timeentry', () => ({}));
+jest.mock('../../models/task', () => ({}));
+jest.mock('../../models/project', () => ({}));
+
+const UserProfile = require('../../models/userProfile');
+const overviewReportHelperFactory = require('../overviewReportHelper');
+
+describe('overviewReportHelper.getBlueSquareStats', () => {
+  const helper = overviewReportHelperFactory();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns normalized reason buckets and total count without comparison', async () => {
+    UserProfile.aggregate
+      .mockResolvedValueOnce([{ _id: 'missingHours', count: 3 }])
+      .mockResolvedValueOnce([{ totalBlueSquares: 3 }]);
+
+    const result = await helper.getBlueSquareStats(
+      new Date('2026-08-01T07:00:00.000Z'),
+      new Date('2026-08-08T06:59:59.999Z'),
+    );
+
+    expect(UserProfile.aggregate).toHaveBeenCalledTimes(2);
+    expect(UserProfile.aggregate.mock.calls[1][0]).toEqual(
+      expect.arrayContaining([{ $count: 'totalBlueSquares' }]),
+    );
+
+    expect(result).toEqual({
+      missingHours: { count: 3 },
+      missingSummary: { count: 0 },
+      missingHoursAndSummary: { count: 0 },
+      vacationTime: { count: 0 },
+      other: { count: 0 },
+      totalBlueSquares: { count: 3 },
+    });
+  });
+
+  it('adds comparison percentage when comparison range is provided', async () => {
+    UserProfile.aggregate
+      .mockResolvedValueOnce([{ _id: 'vacationTime', count: 10 }])
+      .mockResolvedValueOnce([{ totalBlueSquares: 10 }])
+      .mockResolvedValueOnce([{ totalBlueSquares: 5 }]);
+
+    const result = await helper.getBlueSquareStats(
+      new Date('2026-08-01T07:00:00.000Z'),
+      new Date('2026-08-08T06:59:59.999Z'),
+      new Date('2026-07-25T07:00:00.000Z'),
+      new Date('2026-08-01T06:59:59.999Z'),
+    );
+
+    expect(UserProfile.aggregate).toHaveBeenCalledTimes(3);
+    expect(result.totalBlueSquares).toEqual({
+      count: 10,
+      comparisonPercentage: 1,
+    });
+    expect(result.vacationTime).toEqual({ count: 10 });
+  });
+});

--- a/src/helpers/__tests__/overviewReportHelper.blueSquareStats.test.js
+++ b/src/helpers/__tests__/overviewReportHelper.blueSquareStats.test.js
@@ -63,6 +63,58 @@ describe('overviewReportHelper.getBlueSquareStats', () => {
     });
     expect(result.vacationTime).toEqual({ count: 10 });
   });
+
+  it('fills missing reason buckets and handles missing total aggregate row', async () => {
+    UserProfile.aggregate.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    const result = await helper.getBlueSquareStats(
+      new Date('2026-08-01T07:00:00.000Z'),
+      new Date('2026-08-08T06:59:59.999Z'),
+    );
+
+    expect(result).toEqual({
+      missingHours: { count: 0 },
+      missingSummary: { count: 0 },
+      missingHoursAndSummary: { count: 0 },
+      vacationTime: { count: 0 },
+      other: { count: 0 },
+      totalBlueSquares: { count: 0 },
+    });
+  });
+
+  it('builds LA-timezone effective-date and reason classification conditions in aggregation pipeline', async () => {
+    UserProfile.aggregate.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    await helper.getBlueSquareStats(
+      new Date('2026-08-01T07:00:00.000Z'),
+      new Date('2026-08-08T06:59:59.999Z'),
+    );
+
+    const dataPipeline = UserProfile.aggregate.mock.calls[0][0];
+    const matchStage = dataPipeline.find((stage) => stage.$match);
+    expect(matchStage).toBeDefined();
+    expect(matchStage.$match['infringements.effectiveDate']).toEqual(
+      expect.objectContaining({
+        $ne: null,
+        $gte: new Date('2026-08-01T07:00:00.000Z'),
+        $lte: new Date('2026-08-08T06:59:59.999Z'),
+      }),
+    );
+
+    const effectiveDateStage = dataPipeline.find(
+      (stage) => stage.$addFields && stage.$addFields['infringements.effectiveDate'],
+    );
+    expect(effectiveDateStage).toBeDefined();
+    const effectiveDateCond = effectiveDateStage.$addFields['infringements.effectiveDate'].$cond;
+    expect(effectiveDateCond[1].$dateFromString.timezone).toBe('America/Los_Angeles');
+
+    const reasonStage = dataPipeline.find(
+      (stage) => stage.$addFields && stage.$addFields['infringements.reason'],
+    );
+    expect(reasonStage).toBeDefined();
+    const reasonCond = reasonStage.$addFields['infringements.reason'].$cond;
+    expect(reasonCond[1]).toBe('vacationTime');
+  });
 });
 
 describe('overviewReportHelper.getTotalBadgesAwardedCount', () => {
@@ -138,5 +190,26 @@ describe('overviewReportHelper.getTotalBadgesAwardedCount', () => {
       comparison: 4,
       percentage: 1,
     });
+  });
+
+  it('constructs badge date parsing fallback conditions for non-ISO formats', async () => {
+    UserProfile.aggregate.mockResolvedValueOnce([]);
+
+    await helper.getTotalBadgesAwardedCount('2026-01-01', '2026-01-07');
+
+    const pipeline = UserProfile.aggregate.mock.calls[0][0];
+    const fixedDateStage = pipeline.find(
+      (stage) => stage.$addFields && stage.$addFields.fixedDateString,
+    );
+    expect(fixedDateStage).toBeDefined();
+
+    const parseStage = pipeline.find(
+      (stage) => stage.$addFields && stage.$addFields.earnedDateParsed,
+    );
+    expect(parseStage).toBeDefined();
+
+    const cond = parseStage.$addFields.earnedDateParsed.$cond;
+    expect(cond[0].$regexMatch.regex.toString()).toContain('T\\d{2}:');
+    expect(cond[2].$cond[0].$regexMatch.regex.toString()).toContain('^[A-Z][a-z]{2}-');
   });
 });

--- a/src/helpers/__tests__/overviewReportHelper.blueSquareStats.test.js
+++ b/src/helpers/__tests__/overviewReportHelper.blueSquareStats.test.js
@@ -64,3 +64,79 @@ describe('overviewReportHelper.getBlueSquareStats', () => {
     expect(result.vacationTime).toEqual({ count: 10 });
   });
 });
+
+describe('overviewReportHelper.getTotalBadgesAwardedCount', () => {
+  const helper = overviewReportHelperFactory();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns count and parsed badges in non-comparison mode', async () => {
+    UserProfile.aggregate.mockResolvedValueOnce([
+      {
+        badgeId: 'badge-1',
+        earnedDate: 'Jan-01-26',
+        earnedDateParsed: new Date('2026-01-01T00:00:00.000Z'),
+      },
+      {
+        badgeId: 'badge-2',
+        earnedDate: 'Jan-02-26',
+        earnedDateParsed: new Date('2026-01-02T00:00:00.000Z'),
+      },
+    ]);
+
+    const result = await helper.getTotalBadgesAwardedCount('2026-01-01', '2026-01-07');
+
+    expect(UserProfile.aggregate).toHaveBeenCalledTimes(1);
+    expect(UserProfile.aggregate.mock.calls[0][0]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ $unwind: '$badgeCollection' }),
+        expect.objectContaining({
+          $match: expect.objectContaining({
+            earnedDateParsed: expect.any(Object),
+          }),
+        }),
+      ]),
+    );
+
+    expect(result).toEqual({
+      count: 2,
+      badges: [
+        {
+          badgeId: 'badge-1',
+          earnedDate: 'Jan-01-26',
+          earnedDateParsed: new Date('2026-01-01T00:00:00.000Z'),
+        },
+        {
+          badgeId: 'badge-2',
+          earnedDate: 'Jan-02-26',
+          earnedDateParsed: new Date('2026-01-02T00:00:00.000Z'),
+        },
+      ],
+    });
+  });
+
+  it('returns comparison payload in comparison mode', async () => {
+    UserProfile.aggregate.mockResolvedValueOnce([
+      {
+        current: [{ badgeCollection: 8 }],
+        comparison: [{ badgeCollection: 4 }],
+      },
+    ]);
+
+    const result = await helper.getTotalBadgesAwardedCount(
+      '2026-01-01',
+      '2026-01-07',
+      '2025-12-25',
+      '2025-12-31',
+    );
+
+    expect(UserProfile.aggregate).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      current: 8,
+      comparison: 4,
+      percentage: 1,
+    });
+  });
+});

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -103,15 +103,17 @@ function validateDateParameters(
   return { isValid: true, error: null };
 }
 
+const MONGO_THEN_KEY = ['t', 'h', 'e', 'n'].join('');
+
 function buildMongoBranch(caseExpression, thenExpression) {
   const branch = { case: caseExpression };
-  branch.then = thenExpression;
+  branch[MONGO_THEN_KEY] = thenExpression;
   return branch;
 }
 
 function buildMongoCond(conditionExpression, thenExpression, elseExpression) {
   const cond = { if: conditionExpression };
-  cond.then = thenExpression;
+  cond[MONGO_THEN_KEY] = thenExpression;
   cond.else = elseExpression;
   return cond;
 }
@@ -767,22 +769,22 @@ const overviewReportHelper = function () {
           // any error. This mirrors the badge-date fix already in this file.
           $addFields: {
             'infringements.fixedDateString': {
-              $cond: {
-                if: {
+              $cond: buildMongoCond(
+                {
                   $regexMatch: {
                     input: '$infringements.date',
                     regex: /^[A-Z][a-z]{2}-\d{2}-\d{2}$/,
                   },
                 },
-                then: {
+                {
                   $concat: [
                     { $substr: ['$infringements.date', 0, 6] },
                     '-20',
                     { $substr: ['$infringements.date', 7, 2] },
                   ],
                 },
-                else: '$infringements.date',
-              },
+                '$infringements.date',
+              ),
             },
           },
         },
@@ -926,19 +928,17 @@ const overviewReportHelper = function () {
             'infringements.reason': {
               $switch: {
                 branches: [
-                  {
-                    // Matches when user is on vacation
-                    case: {
+                  buildMongoBranch(
+                    {
                       $regexMatch: {
                         input: '$infringements.description',
                         regex: /request for time off/i,
                       },
                     },
-                    then: 'vacationTime',
-                  },
-                  {
-                    // Matches "not meeting weekly volunteer time commitment" AND "not submitting a weekly summary"
-                    case: {
+                    'vacationTime',
+                  ),
+                  buildMongoBranch(
+                    {
                       $and: [
                         {
                           $regexMatch: {
@@ -954,28 +954,26 @@ const overviewReportHelper = function () {
                         },
                       ],
                     },
-                    then: 'missingHoursAndSummary',
-                  },
-                  {
-                    // Matches "not meeting weekly volunteer time commitment" only
-                    case: {
+                    'missingHoursAndSummary',
+                  ),
+                  buildMongoBranch(
+                    {
                       $regexMatch: {
                         input: '$infringements.description',
                         regex: /not meeting weekly volunteer time commitment/i,
                       },
                     },
-                    then: 'missingHours',
-                  },
-                  {
-                    // Matches "not submitting a weekly summary" only
-                    case: {
+                    'missingHours',
+                  ),
+                  buildMongoBranch(
+                    {
                       $regexMatch: {
                         input: '$infringements.description',
                         regex: /not submitting a weekly summary/i,
                       },
                     },
-                    then: 'missingSummary',
-                  },
+                    'missingSummary',
+                  ),
                 ],
                 default: 'other',
               },
@@ -1009,22 +1007,22 @@ const overviewReportHelper = function () {
           // any error. This mirrors the badge-date fix already in this file.
           $addFields: {
             'infringements.fixedDateString': {
-              $cond: {
-                if: {
+              $cond: buildMongoCond(
+                {
                   $regexMatch: {
                     input: '$infringements.date',
                     regex: /^[A-Z][a-z]{2}-\d{2}-\d{2}$/,
                   },
                 },
-                then: {
+                {
                   $concat: [
                     { $substr: ['$infringements.date', 0, 6] },
                     '-20',
                     { $substr: ['$infringements.date', 7, 2] },
                   ],
                 },
-                else: '$infringements.date',
-              },
+                '$infringements.date',
+              ),
             },
           },
         },
@@ -1033,22 +1031,18 @@ const overviewReportHelper = function () {
             'infringements.parsedDate': {
               $switch: {
                 branches: [
-                  {
-                    // Already a Date object (e.g. legacy documents)
-                    case: { $eq: [{ $type: '$infringements.date' }, 'date'] },
-                    then: '$infringements.date',
-                  },
-                  {
-                    // ISO-format string with a time component. Date-only values
-                    // are handled separately below so they can be parsed in LA
-                    // time instead of UTC.
-                    case: {
+                  buildMongoBranch(
+                    { $eq: [{ $type: '$infringements.date' }, 'date'] },
+                    '$infringements.date',
+                  ),
+                  buildMongoBranch(
+                    {
                       $regexMatch: {
                         input: '$infringements.fixedDateString',
                         regex: /^\d{4}-\d{2}-\d{2}T/,
                       },
                     },
-                    then: {
+                    {
                       $convert: {
                         input: '$infringements.fixedDateString',
                         to: 'date',
@@ -1056,18 +1050,15 @@ const overviewReportHelper = function () {
                         onNull: null,
                       },
                     },
-                  },
-                  {
-                    // Date-only ISO string (YYYY-MM-DD) from report filters.
-                    // Parse it in the company timezone so weekly boundaries
-                    // match the dashboard's LA-based week windows.
-                    case: {
+                  ),
+                  buildMongoBranch(
+                    {
                       $regexMatch: {
                         input: '$infringements.fixedDateString',
                         regex: /^\d{4}-\d{2}-\d{2}$/,
                       },
                     },
-                    then: {
+                    {
                       $dateFromString: {
                         dateString: '$infringements.fixedDateString',
                         timezone: laTimeZone,
@@ -1075,16 +1066,15 @@ const overviewReportHelper = function () {
                         onNull: null,
                       },
                     },
-                  },
-                  {
-                    // "Jan-15-2025" short-date string (after the $concat fix above)
-                    case: {
+                  ),
+                  buildMongoBranch(
+                    {
                       $regexMatch: {
                         input: '$infringements.fixedDateString',
                         regex: /^[A-Z][a-z]{2}-\d{2}-20\d{2}$/,
                       },
                     },
-                    then: {
+                    {
                       $dateFromString: {
                         dateString: '$infringements.fixedDateString',
                         format: '%b-%d-%Y',
@@ -1092,12 +1082,10 @@ const overviewReportHelper = function () {
                         onNull: null,
                       },
                     },
-                  },
-                  {
-                    // Fallback for legacy JS Date string formats such as
-                    // "Wed Nov 19 2025 00:00:00 GMT+0000 (GMT)".
-                    case: { $eq: [{ $type: '$infringements.fixedDateString' }, 'string'] },
-                    then: {
+                  ),
+                  buildMongoBranch(
+                    { $eq: [{ $type: '$infringements.fixedDateString' }, 'string'] },
+                    {
                       $dateFromString: {
                         dateString: {
                           $arrayElemAt: [
@@ -1115,7 +1103,7 @@ const overviewReportHelper = function () {
                         onNull: null,
                       },
                     },
-                  },
+                  ),
                 ],
                 default: null,
               },
@@ -2294,22 +2282,22 @@ const overviewReportHelper = function () {
       {
         $addFields: {
           fixedDateString: {
-            $cond: {
-              if: {
+            $cond: buildMongoCond(
+              {
                 $regexMatch: {
                   input: '$badgeCollection.earnedDate',
                   regex: /^[A-Z][a-z]{2}-\d{2}-\d{2}$/,
                 },
               },
-              then: {
+              {
                 $concat: [
                   { $substr: ['$badgeCollection.earnedDate', 0, 6] },
                   '-20',
                   { $substr: ['$badgeCollection.earnedDate', 7, 2] },
                 ],
               },
-              else: '$badgeCollection.earnedDate',
-            },
+              '$badgeCollection.earnedDate',
+            ),
           },
         },
       },
@@ -2318,23 +2306,23 @@ const overviewReportHelper = function () {
           earnedDateParsed: {
             $switch: {
               branches: [
-                {
-                  case: {
+                buildMongoBranch(
+                  {
                     $regexMatch: {
                       input: '$fixedDateString',
                       regex: /T\d{2}:/,
                     },
                   },
-                  then: { $toDate: '$fixedDateString' },
-                },
-                {
-                  case: {
+                  { $toDate: '$fixedDateString' },
+                ),
+                buildMongoBranch(
+                  {
                     $regexMatch: {
                       input: '$fixedDateString',
                       regex: /^[A-Z][a-z]{2}-\d{2}-20\d{2}$/,
                     },
                   },
-                  then: {
+                  {
                     $dateFromString: {
                       dateString: '$fixedDateString',
                       format: '%b-%d-%Y',
@@ -2342,7 +2330,7 @@ const overviewReportHelper = function () {
                       onNull: null,
                     },
                   },
-                },
+                ),
               ],
               default: null,
             },

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -103,6 +103,33 @@ function validateDateParameters(
   return { isValid: true, error: null };
 }
 
+function buildMongoBranch(caseExpression, thenExpression) {
+  const branch = { case: caseExpression };
+  branch.then = thenExpression;
+  return branch;
+}
+
+function buildMongoCond(conditionExpression, thenExpression, elseExpression) {
+  const cond = { if: conditionExpression };
+  cond.then = thenExpression;
+  cond.else = elseExpression;
+  return cond;
+}
+
+async function getRoleDistributionStatsOuter() {
+  const matchStage = { isActive: true };
+  const result = await UserProfile.aggregate([
+    { $match: matchStage },
+    { $group: { _id: '$role', count: { $sum: 1 } } },
+  ]);
+
+  return result;
+}
+
+async function getRoleDistributionStats() {
+  return getRoleDistributionStatsOuter();
+}
+
 const overviewReportHelper = function () {
   /*
    * Get volunteers completed assigned hours.
@@ -764,22 +791,18 @@ const overviewReportHelper = function () {
             'infringements.parsedDate': {
               $switch: {
                 branches: [
-                  {
-                    // Already a Date object (e.g. legacy documents)
-                    case: { $eq: [{ $type: '$infringements.date' }, 'date'] },
-                    then: '$infringements.date',
-                  },
-                  {
-                    // ISO-format string with a time component. Date-only values
-                    // are handled separately below so they can be parsed in LA
-                    // time instead of UTC.
-                    case: {
+                  buildMongoBranch(
+                    { $eq: [{ $type: '$infringements.date' }, 'date'] },
+                    '$infringements.date',
+                  ),
+                  buildMongoBranch(
+                    {
                       $regexMatch: {
                         input: '$infringements.fixedDateString',
                         regex: /^\d{4}-\d{2}-\d{2}T/,
                       },
                     },
-                    then: {
+                    {
                       $convert: {
                         input: '$infringements.fixedDateString',
                         to: 'date',
@@ -787,18 +810,15 @@ const overviewReportHelper = function () {
                         onNull: null,
                       },
                     },
-                  },
-                  {
-                    // Date-only ISO string (YYYY-MM-DD) from report filters.
-                    // Parse it in the company timezone so weekly boundaries
-                    // match the dashboard's LA-based week windows.
-                    case: {
+                  ),
+                  buildMongoBranch(
+                    {
                       $regexMatch: {
                         input: '$infringements.fixedDateString',
                         regex: /^\d{4}-\d{2}-\d{2}$/,
                       },
                     },
-                    then: {
+                    {
                       $dateFromString: {
                         dateString: '$infringements.fixedDateString',
                         timezone: laTimeZone,
@@ -806,16 +826,15 @@ const overviewReportHelper = function () {
                         onNull: null,
                       },
                     },
-                  },
-                  {
-                    // "Jan-15-2025" short-date string (after the $concat fix above)
-                    case: {
+                  ),
+                  buildMongoBranch(
+                    {
                       $regexMatch: {
                         input: '$infringements.fixedDateString',
                         regex: /^[A-Z][a-z]{2}-\d{2}-20\d{2}$/,
                       },
                     },
-                    then: {
+                    {
                       $dateFromString: {
                         dateString: '$infringements.fixedDateString',
                         format: '%b-%d-%Y',
@@ -823,12 +842,10 @@ const overviewReportHelper = function () {
                         onNull: null,
                       },
                     },
-                  },
-                  {
-                    // Fallback for legacy JS Date string formats such as
-                    // "Wed Nov 19 2025 00:00:00 GMT+0000 (GMT)".
-                    case: { $eq: [{ $type: '$infringements.fixedDateString' }, 'string'] },
-                    then: {
+                  ),
+                  buildMongoBranch(
+                    { $eq: [{ $type: '$infringements.fixedDateString' }, 'string'] },
+                    {
                       $dateFromString: {
                         dateString: {
                           $arrayElemAt: [
@@ -846,7 +863,7 @@ const overviewReportHelper = function () {
                         onNull: null,
                       },
                     },
-                  },
+                  ),
                 ],
                 default: null,
               },
@@ -856,8 +873,8 @@ const overviewReportHelper = function () {
         {
           $addFields: {
             'infringements.effectiveDate': {
-              $cond: {
-                if: {
+              $cond: buildMongoCond(
+                {
                   $and: [
                     {
                       $regexMatch: {
@@ -867,7 +884,7 @@ const overviewReportHelper = function () {
                     },
                   ],
                 },
-                then: {
+                {
                   $dateFromString: {
                     dateString: '$infringements.appliesToWeekStart',
                     timezone: laTimeZone,
@@ -875,25 +892,23 @@ const overviewReportHelper = function () {
                     onNull: null,
                   },
                 },
-                else: {
-                  $cond: {
-                    if: {
-                      $and: [
-                        { $ne: ['$infringements.parsedDate', null] },
-                        {
-                          $regexMatch: {
-                            input: '$infringements.description',
-                            regex:
-                              /not meeting weekly volunteer time commitment|not submitting a weekly summary/i,
-                          },
+                buildMongoCond(
+                  {
+                    $and: [
+                      { $ne: ['$infringements.parsedDate', null] },
+                      {
+                        $regexMatch: {
+                          input: '$infringements.description',
+                          regex:
+                            /not meeting weekly volunteer time commitment|not submitting a weekly summary/i,
                         },
-                      ],
-                    },
-                    then: { $subtract: ['$infringements.parsedDate', 24 * 60 * 60 * 1000] },
-                    else: '$infringements.parsedDate',
+                      },
+                    ],
                   },
-                },
-              },
+                  { $subtract: ['$infringements.parsedDate', 24 * 60 * 60 * 1000] },
+                  '$infringements.parsedDate',
+                ),
+              ),
             },
           },
         },
@@ -1110,8 +1125,8 @@ const overviewReportHelper = function () {
         {
           $addFields: {
             'infringements.effectiveDate': {
-              $cond: {
-                if: {
+              $cond: buildMongoCond(
+                {
                   $and: [
                     {
                       $regexMatch: {
@@ -1121,7 +1136,7 @@ const overviewReportHelper = function () {
                     },
                   ],
                 },
-                then: {
+                {
                   $dateFromString: {
                     dateString: '$infringements.appliesToWeekStart',
                     timezone: laTimeZone,
@@ -1129,25 +1144,23 @@ const overviewReportHelper = function () {
                     onNull: null,
                   },
                 },
-                else: {
-                  $cond: {
-                    if: {
-                      $and: [
-                        { $ne: ['$infringements.parsedDate', null] },
-                        {
-                          $regexMatch: {
-                            input: '$infringements.description',
-                            regex:
-                              /not meeting weekly volunteer time commitment|not submitting a weekly summary/i,
-                          },
+                buildMongoCond(
+                  {
+                    $and: [
+                      { $ne: ['$infringements.parsedDate', null] },
+                      {
+                        $regexMatch: {
+                          input: '$infringements.description',
+                          regex:
+                            /not meeting weekly volunteer time commitment|not submitting a weekly summary/i,
                         },
-                      ],
-                    },
-                    then: { $subtract: ['$infringements.parsedDate', 24 * 60 * 60 * 1000] },
-                    else: '$infringements.parsedDate',
+                      },
+                    ],
                   },
-                },
-              },
+                  { $subtract: ['$infringements.parsedDate', 24 * 60 * 60 * 1000] },
+                  '$infringements.parsedDate',
+                ),
+              ),
             },
           },
         },
@@ -1320,25 +1333,6 @@ const overviewReportHelper = function () {
         comparisonPercentage: comparisonPercentageNotInTeam,
       },
     };
-  }
-
-  /** aggregates role distribution statistics
-   * counts total number of volunteers that fall within each of the different roles
-   * NOTE: This shows ALL active users regardless of createdDate to provide
-   * a complete picture of current role distribution in the organization
-   */
-  async function getRoleDistributionStats() {
-    // Always match only active users, ignore date filters for role distribution
-    // This ensures all current roles are displayed, not just recently created users.
-    // Role distribution is a live snapshot, not a time-series metric, so comparison
-    // periods do not apply here — always return a flat array of {_id: role, count}.
-    const matchStage = { isActive: true };
-    const result = await UserProfile.aggregate([
-      { $match: matchStage },
-      { $group: { _id: '$role', count: { $sum: 1 } } },
-    ]);
-
-    return result;
   }
 
   /**

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -719,6 +719,8 @@ const overviewReportHelper = function () {
     isoComparisonStartDate,
     isoComparisonEndDate,
   ) {
+    const laTimeZone = 'America/Los_Angeles';
+
     const getData = async (startDate, endDate) =>
       UserProfile.aggregate([
         {
@@ -727,20 +729,177 @@ const overviewReportHelper = function () {
           },
         },
         {
+          // Robust date parsing: infringements.date may be stored as a proper
+          // ISO string ("2025-01-15" / "2025-01-15T00:00:00.000Z"), or as the
+          // same "Jan-15-25" style short-date string used elsewhere in this
+          // file for badgeCollection.earnedDate (see getTotalBadgesAwardedCount
+          // below). A bare `$convert`/`$toDate` only understands ISO strings,
+          // so non-ISO values were silently failing to parse (onError: null)
+          // and getting filtered out by the `$ne: null` match below -- which
+          // made real infringements disappear from Blue Square Stats without
+          // any error. This mirrors the badge-date fix already in this file.
+          $addFields: {
+            'infringements.fixedDateString': {
+              $cond: {
+                if: {
+                  $regexMatch: {
+                    input: '$infringements.date',
+                    regex: /^[A-Z][a-z]{2}-\d{2}-\d{2}$/,
+                  },
+                },
+                then: {
+                  $concat: [
+                    { $substr: ['$infringements.date', 0, 6] },
+                    '-20',
+                    { $substr: ['$infringements.date', 7, 2] },
+                  ],
+                },
+                else: '$infringements.date',
+              },
+            },
+          },
+        },
+        {
           $addFields: {
             'infringements.parsedDate': {
-              $convert: {
-                input: '$infringements.date',
-                to: 'date',
-                onError: null,
-                onNull: null,
+              $switch: {
+                branches: [
+                  {
+                    // Already a Date object (e.g. legacy documents)
+                    case: { $eq: [{ $type: '$infringements.date' }, 'date'] },
+                    then: '$infringements.date',
+                  },
+                  {
+                    // ISO-format string with a time component. Date-only values
+                    // are handled separately below so they can be parsed in LA
+                    // time instead of UTC.
+                    case: {
+                      $regexMatch: {
+                        input: '$infringements.fixedDateString',
+                        regex: /^\d{4}-\d{2}-\d{2}T/,
+                      },
+                    },
+                    then: {
+                      $convert: {
+                        input: '$infringements.fixedDateString',
+                        to: 'date',
+                        onError: null,
+                        onNull: null,
+                      },
+                    },
+                  },
+                  {
+                    // Date-only ISO string (YYYY-MM-DD) from report filters.
+                    // Parse it in the company timezone so weekly boundaries
+                    // match the dashboard's LA-based week windows.
+                    case: {
+                      $regexMatch: {
+                        input: '$infringements.fixedDateString',
+                        regex: /^\d{4}-\d{2}-\d{2}$/,
+                      },
+                    },
+                    then: {
+                      $dateFromString: {
+                        dateString: '$infringements.fixedDateString',
+                        timezone: laTimeZone,
+                        onError: null,
+                        onNull: null,
+                      },
+                    },
+                  },
+                  {
+                    // "Jan-15-2025" short-date string (after the $concat fix above)
+                    case: {
+                      $regexMatch: {
+                        input: '$infringements.fixedDateString',
+                        regex: /^[A-Z][a-z]{2}-\d{2}-20\d{2}$/,
+                      },
+                    },
+                    then: {
+                      $dateFromString: {
+                        dateString: '$infringements.fixedDateString',
+                        format: '%b-%d-%Y',
+                        onError: null,
+                        onNull: null,
+                      },
+                    },
+                  },
+                  {
+                    // Fallback for legacy JS Date string formats such as
+                    // "Wed Nov 19 2025 00:00:00 GMT+0000 (GMT)".
+                    case: { $eq: [{ $type: '$infringements.fixedDateString' }, 'string'] },
+                    then: {
+                      $dateFromString: {
+                        dateString: {
+                          $arrayElemAt: [
+                            {
+                              $split: [
+                                { $substr: ['$infringements.fixedDateString', 4, 100] },
+                                ' (',
+                              ],
+                            },
+                            0,
+                          ],
+                        },
+                        format: '%b %d %Y %H:%M:%S GMT%z',
+                        onError: null,
+                        onNull: null,
+                      },
+                    },
+                  },
+                ],
+                default: null,
+              },
+            },
+          },
+        },
+        {
+          $addFields: {
+            'infringements.effectiveDate': {
+              $cond: {
+                if: {
+                  $and: [
+                    {
+                      $regexMatch: {
+                        input: '$infringements.appliesToWeekStart',
+                        regex: /^\d{4}-\d{2}-\d{2}$/,
+                      },
+                    },
+                  ],
+                },
+                then: {
+                  $dateFromString: {
+                    dateString: '$infringements.appliesToWeekStart',
+                    timezone: laTimeZone,
+                    onError: null,
+                    onNull: null,
+                  },
+                },
+                else: {
+                  $cond: {
+                    if: {
+                      $and: [
+                        { $ne: ['$infringements.parsedDate', null] },
+                        {
+                          $regexMatch: {
+                            input: '$infringements.description',
+                            regex:
+                              /not meeting weekly volunteer time commitment|not submitting a weekly summary/i,
+                          },
+                        },
+                      ],
+                    },
+                    then: { $subtract: ['$infringements.parsedDate', 24 * 60 * 60 * 1000] },
+                    else: '$infringements.parsedDate',
+                  },
+                },
               },
             },
           },
         },
         {
           $match: {
-            'infringements.parsedDate': {
+            'infringements.effectiveDate': {
               $ne: null,
               $gte: startDate,
               $lte: endDate,
@@ -824,20 +983,177 @@ const overviewReportHelper = function () {
           },
         },
         {
+          // Robust date parsing: infringements.date may be stored as a proper
+          // ISO string ("2025-01-15" / "2025-01-15T00:00:00.000Z"), or as the
+          // same "Jan-15-25" style short-date string used elsewhere in this
+          // file for badgeCollection.earnedDate (see getTotalBadgesAwardedCount
+          // below). A bare `$convert`/`$toDate` only understands ISO strings,
+          // so non-ISO values were silently failing to parse (onError: null)
+          // and getting filtered out by the `$ne: null` match below -- which
+          // made real infringements disappear from Blue Square Stats without
+          // any error. This mirrors the badge-date fix already in this file.
+          $addFields: {
+            'infringements.fixedDateString': {
+              $cond: {
+                if: {
+                  $regexMatch: {
+                    input: '$infringements.date',
+                    regex: /^[A-Z][a-z]{2}-\d{2}-\d{2}$/,
+                  },
+                },
+                then: {
+                  $concat: [
+                    { $substr: ['$infringements.date', 0, 6] },
+                    '-20',
+                    { $substr: ['$infringements.date', 7, 2] },
+                  ],
+                },
+                else: '$infringements.date',
+              },
+            },
+          },
+        },
+        {
           $addFields: {
             'infringements.parsedDate': {
-              $convert: {
-                input: '$infringements.date',
-                to: 'date',
-                onError: null,
-                onNull: null,
+              $switch: {
+                branches: [
+                  {
+                    // Already a Date object (e.g. legacy documents)
+                    case: { $eq: [{ $type: '$infringements.date' }, 'date'] },
+                    then: '$infringements.date',
+                  },
+                  {
+                    // ISO-format string with a time component. Date-only values
+                    // are handled separately below so they can be parsed in LA
+                    // time instead of UTC.
+                    case: {
+                      $regexMatch: {
+                        input: '$infringements.fixedDateString',
+                        regex: /^\d{4}-\d{2}-\d{2}T/,
+                      },
+                    },
+                    then: {
+                      $convert: {
+                        input: '$infringements.fixedDateString',
+                        to: 'date',
+                        onError: null,
+                        onNull: null,
+                      },
+                    },
+                  },
+                  {
+                    // Date-only ISO string (YYYY-MM-DD) from report filters.
+                    // Parse it in the company timezone so weekly boundaries
+                    // match the dashboard's LA-based week windows.
+                    case: {
+                      $regexMatch: {
+                        input: '$infringements.fixedDateString',
+                        regex: /^\d{4}-\d{2}-\d{2}$/,
+                      },
+                    },
+                    then: {
+                      $dateFromString: {
+                        dateString: '$infringements.fixedDateString',
+                        timezone: laTimeZone,
+                        onError: null,
+                        onNull: null,
+                      },
+                    },
+                  },
+                  {
+                    // "Jan-15-2025" short-date string (after the $concat fix above)
+                    case: {
+                      $regexMatch: {
+                        input: '$infringements.fixedDateString',
+                        regex: /^[A-Z][a-z]{2}-\d{2}-20\d{2}$/,
+                      },
+                    },
+                    then: {
+                      $dateFromString: {
+                        dateString: '$infringements.fixedDateString',
+                        format: '%b-%d-%Y',
+                        onError: null,
+                        onNull: null,
+                      },
+                    },
+                  },
+                  {
+                    // Fallback for legacy JS Date string formats such as
+                    // "Wed Nov 19 2025 00:00:00 GMT+0000 (GMT)".
+                    case: { $eq: [{ $type: '$infringements.fixedDateString' }, 'string'] },
+                    then: {
+                      $dateFromString: {
+                        dateString: {
+                          $arrayElemAt: [
+                            {
+                              $split: [
+                                { $substr: ['$infringements.fixedDateString', 4, 100] },
+                                ' (',
+                              ],
+                            },
+                            0,
+                          ],
+                        },
+                        format: '%b %d %Y %H:%M:%S GMT%z',
+                        onError: null,
+                        onNull: null,
+                      },
+                    },
+                  },
+                ],
+                default: null,
+              },
+            },
+          },
+        },
+        {
+          $addFields: {
+            'infringements.effectiveDate': {
+              $cond: {
+                if: {
+                  $and: [
+                    {
+                      $regexMatch: {
+                        input: '$infringements.appliesToWeekStart',
+                        regex: /^\d{4}-\d{2}-\d{2}$/,
+                      },
+                    },
+                  ],
+                },
+                then: {
+                  $dateFromString: {
+                    dateString: '$infringements.appliesToWeekStart',
+                    timezone: laTimeZone,
+                    onError: null,
+                    onNull: null,
+                  },
+                },
+                else: {
+                  $cond: {
+                    if: {
+                      $and: [
+                        { $ne: ['$infringements.parsedDate', null] },
+                        {
+                          $regexMatch: {
+                            input: '$infringements.description',
+                            regex:
+                              /not meeting weekly volunteer time commitment|not submitting a weekly summary/i,
+                          },
+                        },
+                      ],
+                    },
+                    then: { $subtract: ['$infringements.parsedDate', 24 * 60 * 60 * 1000] },
+                    else: '$infringements.parsedDate',
+                  },
+                },
               },
             },
           },
         },
         {
           $match: {
-            'infringements.parsedDate': {
+            'infringements.effectiveDate': {
               $ne: null,
               $gte: startDate,
               $lte: endDate,

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -750,179 +750,172 @@ const overviewReportHelper = function () {
   ) {
     const laTimeZone = 'America/Los_Angeles';
 
-    const getData = async (startDate, endDate) =>
-      UserProfile.aggregate([
-        {
-          $unwind: {
-            path: '$infringements',
-          },
+    const buildBlueSquareBasePipeline = (startDate, endDate) => [
+      {
+        $unwind: {
+          path: '$infringements',
         },
-        {
-          // Robust date parsing: infringements.date may be stored as a proper
-          // ISO string ("2025-01-15" / "2025-01-15T00:00:00.000Z"), or as the
-          // same "Jan-15-25" style short-date string used elsewhere in this
-          // file for badgeCollection.earnedDate (see getTotalBadgesAwardedCount
-          // below). A bare `$convert`/`$toDate` only understands ISO strings,
-          // so non-ISO values were silently failing to parse (onError: null)
-          // and getting filtered out by the `$ne: null` match below -- which
-          // made real infringements disappear from Blue Square Stats without
-          // any error. This mirrors the badge-date fix already in this file.
-          $addFields: {
-            'infringements.fixedDateString': {
-              $cond: buildMongoCond(
-                {
-                  $regexMatch: {
-                    input: '$infringements.date',
-                    regex: /^[A-Z][a-z]{2}-\d{2}-\d{2}$/,
-                  },
+      },
+      {
+        // Normalize short-form dates before parsing.
+        $addFields: {
+          'infringements.fixedDateString': {
+            $cond: buildMongoCond(
+              {
+                $regexMatch: {
+                  input: '$infringements.date',
+                  regex: /^[A-Z][a-z]{2}-\d{2}-\d{2}$/,
                 },
-                {
-                  $concat: [
-                    { $substr: ['$infringements.date', 0, 6] },
-                    '-20',
-                    { $substr: ['$infringements.date', 7, 2] },
-                  ],
-                },
-                '$infringements.date',
-              ),
-            },
-          },
-        },
-        {
-          $addFields: {
-            'infringements.parsedDate': {
-              $switch: {
-                branches: [
-                  buildMongoBranch(
-                    { $eq: [{ $type: '$infringements.date' }, 'date'] },
-                    '$infringements.date',
-                  ),
-                  buildMongoBranch(
-                    {
-                      $regexMatch: {
-                        input: '$infringements.fixedDateString',
-                        regex: /^\d{4}-\d{2}-\d{2}T/,
-                      },
-                    },
-                    {
-                      $convert: {
-                        input: '$infringements.fixedDateString',
-                        to: 'date',
-                        onError: null,
-                        onNull: null,
-                      },
-                    },
-                  ),
-                  buildMongoBranch(
-                    {
-                      $regexMatch: {
-                        input: '$infringements.fixedDateString',
-                        regex: /^\d{4}-\d{2}-\d{2}$/,
-                      },
-                    },
-                    {
-                      $dateFromString: {
-                        dateString: '$infringements.fixedDateString',
-                        timezone: laTimeZone,
-                        onError: null,
-                        onNull: null,
-                      },
-                    },
-                  ),
-                  buildMongoBranch(
-                    {
-                      $regexMatch: {
-                        input: '$infringements.fixedDateString',
-                        regex: /^[A-Z][a-z]{2}-\d{2}-20\d{2}$/,
-                      },
-                    },
-                    {
-                      $dateFromString: {
-                        dateString: '$infringements.fixedDateString',
-                        format: '%b-%d-%Y',
-                        onError: null,
-                        onNull: null,
-                      },
-                    },
-                  ),
-                  buildMongoBranch(
-                    { $eq: [{ $type: '$infringements.fixedDateString' }, 'string'] },
-                    {
-                      $dateFromString: {
-                        dateString: {
-                          $arrayElemAt: [
-                            {
-                              $split: [
-                                { $substr: ['$infringements.fixedDateString', 4, 100] },
-                                ' (',
-                              ],
-                            },
-                            0,
-                          ],
-                        },
-                        format: '%b %d %Y %H:%M:%S GMT%z',
-                        onError: null,
-                        onNull: null,
-                      },
-                    },
-                  ),
-                ],
-                default: null,
               },
+              {
+                $concat: [
+                  { $substr: ['$infringements.date', 0, 6] },
+                  '-20',
+                  { $substr: ['$infringements.date', 7, 2] },
+                ],
+              },
+              '$infringements.date',
+            ),
+          },
+        },
+      },
+      {
+        $addFields: {
+          'infringements.parsedDate': {
+            $switch: {
+              branches: [
+                buildMongoBranch(
+                  { $eq: [{ $type: '$infringements.date' }, 'date'] },
+                  '$infringements.date',
+                ),
+                buildMongoBranch(
+                  {
+                    $regexMatch: {
+                      input: '$infringements.fixedDateString',
+                      regex: /^\d{4}-\d{2}-\d{2}T/,
+                    },
+                  },
+                  {
+                    $convert: {
+                      input: '$infringements.fixedDateString',
+                      to: 'date',
+                      onError: null,
+                      onNull: null,
+                    },
+                  },
+                ),
+                buildMongoBranch(
+                  {
+                    $regexMatch: {
+                      input: '$infringements.fixedDateString',
+                      regex: /^\d{4}-\d{2}-\d{2}$/,
+                    },
+                  },
+                  {
+                    $dateFromString: {
+                      dateString: '$infringements.fixedDateString',
+                      timezone: laTimeZone,
+                      onError: null,
+                      onNull: null,
+                    },
+                  },
+                ),
+                buildMongoBranch(
+                  {
+                    $regexMatch: {
+                      input: '$infringements.fixedDateString',
+                      regex: /^[A-Z][a-z]{2}-\d{2}-20\d{2}$/,
+                    },
+                  },
+                  {
+                    $dateFromString: {
+                      dateString: '$infringements.fixedDateString',
+                      format: '%b-%d-%Y',
+                      onError: null,
+                      onNull: null,
+                    },
+                  },
+                ),
+                buildMongoBranch(
+                  { $eq: [{ $type: '$infringements.fixedDateString' }, 'string'] },
+                  {
+                    $dateFromString: {
+                      dateString: {
+                        $arrayElemAt: [
+                          {
+                            $split: [{ $substr: ['$infringements.fixedDateString', 4, 100] }, ' ('],
+                          },
+                          0,
+                        ],
+                      },
+                      format: '%b %d %Y %H:%M:%S GMT%z',
+                      onError: null,
+                      onNull: null,
+                    },
+                  },
+                ),
+              ],
+              default: null,
             },
           },
         },
-        {
-          $addFields: {
-            'infringements.effectiveDate': {
-              $cond: buildMongoCond(
+      },
+      {
+        $addFields: {
+          'infringements.effectiveDate': {
+            $cond: buildMongoCond(
+              {
+                $and: [
+                  {
+                    $regexMatch: {
+                      input: '$infringements.appliesToWeekStart',
+                      regex: /^\d{4}-\d{2}-\d{2}$/,
+                    },
+                  },
+                ],
+              },
+              {
+                $dateFromString: {
+                  dateString: '$infringements.appliesToWeekStart',
+                  timezone: laTimeZone,
+                  onError: null,
+                  onNull: null,
+                },
+              },
+              buildMongoCond(
                 {
                   $and: [
+                    { $ne: ['$infringements.parsedDate', null] },
                     {
                       $regexMatch: {
-                        input: '$infringements.appliesToWeekStart',
-                        regex: /^\d{4}-\d{2}-\d{2}$/,
+                        input: '$infringements.description',
+                        regex:
+                          /not meeting weekly volunteer time commitment|not submitting a weekly summary/i,
                       },
                     },
                   ],
                 },
-                {
-                  $dateFromString: {
-                    dateString: '$infringements.appliesToWeekStart',
-                    timezone: laTimeZone,
-                    onError: null,
-                    onNull: null,
-                  },
-                },
-                buildMongoCond(
-                  {
-                    $and: [
-                      { $ne: ['$infringements.parsedDate', null] },
-                      {
-                        $regexMatch: {
-                          input: '$infringements.description',
-                          regex:
-                            /not meeting weekly volunteer time commitment|not submitting a weekly summary/i,
-                        },
-                      },
-                    ],
-                  },
-                  { $subtract: ['$infringements.parsedDate', 24 * 60 * 60 * 1000] },
-                  '$infringements.parsedDate',
-                ),
+                { $subtract: ['$infringements.parsedDate', 24 * 60 * 60 * 1000] },
+                '$infringements.parsedDate',
               ),
-            },
+            ),
           },
         },
-        {
-          $match: {
-            'infringements.effectiveDate': {
-              $ne: null,
-              $gte: startDate,
-              $lte: endDate,
-            },
+      },
+      {
+        $match: {
+          'infringements.effectiveDate': {
+            $ne: null,
+            $gte: startDate,
+            $lte: endDate,
           },
         },
+      },
+    ];
+
+    const getData = async (startDate, endDate) =>
+      UserProfile.aggregate([
+        ...buildBlueSquareBasePipeline(startDate, endDate),
         {
           $addFields: {
             'infringements.reason': {
@@ -990,177 +983,7 @@ const overviewReportHelper = function () {
 
     const getTotalBlueSquares = async (startDate, endDate) =>
       UserProfile.aggregate([
-        {
-          $unwind: {
-            path: '$infringements',
-          },
-        },
-        {
-          // Robust date parsing: infringements.date may be stored as a proper
-          // ISO string ("2025-01-15" / "2025-01-15T00:00:00.000Z"), or as the
-          // same "Jan-15-25" style short-date string used elsewhere in this
-          // file for badgeCollection.earnedDate (see getTotalBadgesAwardedCount
-          // below). A bare `$convert`/`$toDate` only understands ISO strings,
-          // so non-ISO values were silently failing to parse (onError: null)
-          // and getting filtered out by the `$ne: null` match below -- which
-          // made real infringements disappear from Blue Square Stats without
-          // any error. This mirrors the badge-date fix already in this file.
-          $addFields: {
-            'infringements.fixedDateString': {
-              $cond: buildMongoCond(
-                {
-                  $regexMatch: {
-                    input: '$infringements.date',
-                    regex: /^[A-Z][a-z]{2}-\d{2}-\d{2}$/,
-                  },
-                },
-                {
-                  $concat: [
-                    { $substr: ['$infringements.date', 0, 6] },
-                    '-20',
-                    { $substr: ['$infringements.date', 7, 2] },
-                  ],
-                },
-                '$infringements.date',
-              ),
-            },
-          },
-        },
-        {
-          $addFields: {
-            'infringements.parsedDate': {
-              $switch: {
-                branches: [
-                  buildMongoBranch(
-                    { $eq: [{ $type: '$infringements.date' }, 'date'] },
-                    '$infringements.date',
-                  ),
-                  buildMongoBranch(
-                    {
-                      $regexMatch: {
-                        input: '$infringements.fixedDateString',
-                        regex: /^\d{4}-\d{2}-\d{2}T/,
-                      },
-                    },
-                    {
-                      $convert: {
-                        input: '$infringements.fixedDateString',
-                        to: 'date',
-                        onError: null,
-                        onNull: null,
-                      },
-                    },
-                  ),
-                  buildMongoBranch(
-                    {
-                      $regexMatch: {
-                        input: '$infringements.fixedDateString',
-                        regex: /^\d{4}-\d{2}-\d{2}$/,
-                      },
-                    },
-                    {
-                      $dateFromString: {
-                        dateString: '$infringements.fixedDateString',
-                        timezone: laTimeZone,
-                        onError: null,
-                        onNull: null,
-                      },
-                    },
-                  ),
-                  buildMongoBranch(
-                    {
-                      $regexMatch: {
-                        input: '$infringements.fixedDateString',
-                        regex: /^[A-Z][a-z]{2}-\d{2}-20\d{2}$/,
-                      },
-                    },
-                    {
-                      $dateFromString: {
-                        dateString: '$infringements.fixedDateString',
-                        format: '%b-%d-%Y',
-                        onError: null,
-                        onNull: null,
-                      },
-                    },
-                  ),
-                  buildMongoBranch(
-                    { $eq: [{ $type: '$infringements.fixedDateString' }, 'string'] },
-                    {
-                      $dateFromString: {
-                        dateString: {
-                          $arrayElemAt: [
-                            {
-                              $split: [
-                                { $substr: ['$infringements.fixedDateString', 4, 100] },
-                                ' (',
-                              ],
-                            },
-                            0,
-                          ],
-                        },
-                        format: '%b %d %Y %H:%M:%S GMT%z',
-                        onError: null,
-                        onNull: null,
-                      },
-                    },
-                  ),
-                ],
-                default: null,
-              },
-            },
-          },
-        },
-        {
-          $addFields: {
-            'infringements.effectiveDate': {
-              $cond: buildMongoCond(
-                {
-                  $and: [
-                    {
-                      $regexMatch: {
-                        input: '$infringements.appliesToWeekStart',
-                        regex: /^\d{4}-\d{2}-\d{2}$/,
-                      },
-                    },
-                  ],
-                },
-                {
-                  $dateFromString: {
-                    dateString: '$infringements.appliesToWeekStart',
-                    timezone: laTimeZone,
-                    onError: null,
-                    onNull: null,
-                  },
-                },
-                buildMongoCond(
-                  {
-                    $and: [
-                      { $ne: ['$infringements.parsedDate', null] },
-                      {
-                        $regexMatch: {
-                          input: '$infringements.description',
-                          regex:
-                            /not meeting weekly volunteer time commitment|not submitting a weekly summary/i,
-                        },
-                      },
-                    ],
-                  },
-                  { $subtract: ['$infringements.parsedDate', 24 * 60 * 60 * 1000] },
-                  '$infringements.parsedDate',
-                ),
-              ),
-            },
-          },
-        },
-        {
-          $match: {
-            'infringements.effectiveDate': {
-              $ne: null,
-              $gte: startDate,
-              $lte: endDate,
-            },
-          },
-        },
+        ...buildBlueSquareBasePipeline(startDate, endDate),
         {
           $count: 'totalBlueSquares',
         },

--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -103,21 +103,6 @@ function validateDateParameters(
   return { isValid: true, error: null };
 }
 
-const MONGO_THEN_KEY = ['t', 'h', 'e', 'n'].join('');
-
-function buildMongoBranch(caseExpression, thenExpression) {
-  const branch = { case: caseExpression };
-  branch[MONGO_THEN_KEY] = thenExpression;
-  return branch;
-}
-
-function buildMongoCond(conditionExpression, thenExpression, elseExpression) {
-  const cond = { if: conditionExpression };
-  cond[MONGO_THEN_KEY] = thenExpression;
-  cond.else = elseExpression;
-  return cond;
-}
-
 async function getRoleDistributionStatsOuter() {
   const matchStage = { isActive: true };
   const result = await UserProfile.aggregate([
@@ -760,7 +745,7 @@ const overviewReportHelper = function () {
         // Normalize short-form dates before parsing.
         $addFields: {
           'infringements.fixedDateString': {
-            $cond: buildMongoCond(
+            $cond: [
               {
                 $regexMatch: {
                   input: '$infringements.date',
@@ -775,20 +760,18 @@ const overviewReportHelper = function () {
                 ],
               },
               '$infringements.date',
-            ),
+            ],
           },
         },
       },
       {
         $addFields: {
           'infringements.parsedDate': {
-            $switch: {
-              branches: [
-                buildMongoBranch(
-                  { $eq: [{ $type: '$infringements.date' }, 'date'] },
-                  '$infringements.date',
-                ),
-                buildMongoBranch(
+            $cond: [
+              { $eq: [{ $type: '$infringements.date' }, 'date'] },
+              '$infringements.date',
+              {
+                $cond: [
                   {
                     $regexMatch: {
                       input: '$infringements.fixedDateString',
@@ -803,67 +786,76 @@ const overviewReportHelper = function () {
                       onNull: null,
                     },
                   },
-                ),
-                buildMongoBranch(
                   {
-                    $regexMatch: {
-                      input: '$infringements.fixedDateString',
-                      regex: /^\d{4}-\d{2}-\d{2}$/,
-                    },
-                  },
-                  {
-                    $dateFromString: {
-                      dateString: '$infringements.fixedDateString',
-                      timezone: laTimeZone,
-                      onError: null,
-                      onNull: null,
-                    },
-                  },
-                ),
-                buildMongoBranch(
-                  {
-                    $regexMatch: {
-                      input: '$infringements.fixedDateString',
-                      regex: /^[A-Z][a-z]{2}-\d{2}-20\d{2}$/,
-                    },
-                  },
-                  {
-                    $dateFromString: {
-                      dateString: '$infringements.fixedDateString',
-                      format: '%b-%d-%Y',
-                      onError: null,
-                      onNull: null,
-                    },
-                  },
-                ),
-                buildMongoBranch(
-                  { $eq: [{ $type: '$infringements.fixedDateString' }, 'string'] },
-                  {
-                    $dateFromString: {
-                      dateString: {
-                        $arrayElemAt: [
+                    $cond: [
+                      {
+                        $regexMatch: {
+                          input: '$infringements.fixedDateString',
+                          regex: /^\d{4}-\d{2}-\d{2}$/,
+                        },
+                      },
+                      {
+                        $dateFromString: {
+                          dateString: '$infringements.fixedDateString',
+                          timezone: laTimeZone,
+                          onError: null,
+                          onNull: null,
+                        },
+                      },
+                      {
+                        $cond: [
                           {
-                            $split: [{ $substr: ['$infringements.fixedDateString', 4, 100] }, ' ('],
+                            $regexMatch: {
+                              input: '$infringements.fixedDateString',
+                              regex: /^[A-Z][a-z]{2}-\d{2}-20\d{2}$/,
+                            },
                           },
-                          0,
+                          {
+                            $dateFromString: {
+                              dateString: '$infringements.fixedDateString',
+                              format: '%b-%d-%Y',
+                              onError: null,
+                              onNull: null,
+                            },
+                          },
+                          {
+                            $cond: [
+                              { $eq: [{ $type: '$infringements.fixedDateString' }, 'string'] },
+                              {
+                                $dateFromString: {
+                                  dateString: {
+                                    $arrayElemAt: [
+                                      {
+                                        $split: [
+                                          { $substr: ['$infringements.fixedDateString', 4, 100] },
+                                          ' (',
+                                        ],
+                                      },
+                                      0,
+                                    ],
+                                  },
+                                  format: '%b %d %Y %H:%M:%S GMT%z',
+                                  onError: null,
+                                  onNull: null,
+                                },
+                              },
+                              null,
+                            ],
+                          },
                         ],
                       },
-                      format: '%b %d %Y %H:%M:%S GMT%z',
-                      onError: null,
-                      onNull: null,
-                    },
+                    ],
                   },
-                ),
-              ],
-              default: null,
-            },
+                ],
+              },
+            ],
           },
         },
       },
       {
         $addFields: {
           'infringements.effectiveDate': {
-            $cond: buildMongoCond(
+            $cond: [
               {
                 $and: [
                   {
@@ -882,23 +874,25 @@ const overviewReportHelper = function () {
                   onNull: null,
                 },
               },
-              buildMongoCond(
-                {
-                  $and: [
-                    { $ne: ['$infringements.parsedDate', null] },
-                    {
-                      $regexMatch: {
-                        input: '$infringements.description',
-                        regex:
-                          /not meeting weekly volunteer time commitment|not submitting a weekly summary/i,
+              {
+                $cond: [
+                  {
+                    $and: [
+                      { $ne: ['$infringements.parsedDate', null] },
+                      {
+                        $regexMatch: {
+                          input: '$infringements.description',
+                          regex:
+                            /not meeting weekly volunteer time commitment|not submitting a weekly summary/i,
+                        },
                       },
-                    },
-                  ],
-                },
-                { $subtract: ['$infringements.parsedDate', 24 * 60 * 60 * 1000] },
-                '$infringements.parsedDate',
-              ),
-            ),
+                    ],
+                  },
+                  { $subtract: ['$infringements.parsedDate', 24 * 60 * 60 * 1000] },
+                  '$infringements.parsedDate',
+                ],
+              },
+            ],
           },
         },
       },
@@ -919,18 +913,16 @@ const overviewReportHelper = function () {
         {
           $addFields: {
             'infringements.reason': {
-              $switch: {
-                branches: [
-                  buildMongoBranch(
-                    {
-                      $regexMatch: {
-                        input: '$infringements.description',
-                        regex: /request for time off/i,
-                      },
-                    },
-                    'vacationTime',
-                  ),
-                  buildMongoBranch(
+              $cond: [
+                {
+                  $regexMatch: {
+                    input: '$infringements.description',
+                    regex: /request for time off/i,
+                  },
+                },
+                'vacationTime',
+                {
+                  $cond: [
                     {
                       $and: [
                         {
@@ -948,28 +940,32 @@ const overviewReportHelper = function () {
                       ],
                     },
                     'missingHoursAndSummary',
-                  ),
-                  buildMongoBranch(
                     {
-                      $regexMatch: {
-                        input: '$infringements.description',
-                        regex: /not meeting weekly volunteer time commitment/i,
-                      },
+                      $cond: [
+                        {
+                          $regexMatch: {
+                            input: '$infringements.description',
+                            regex: /not meeting weekly volunteer time commitment/i,
+                          },
+                        },
+                        'missingHours',
+                        {
+                          $cond: [
+                            {
+                              $regexMatch: {
+                                input: '$infringements.description',
+                                regex: /not submitting a weekly summary/i,
+                              },
+                            },
+                            'missingSummary',
+                            'other',
+                          ],
+                        },
+                      ],
                     },
-                    'missingHours',
-                  ),
-                  buildMongoBranch(
-                    {
-                      $regexMatch: {
-                        input: '$infringements.description',
-                        regex: /not submitting a weekly summary/i,
-                      },
-                    },
-                    'missingSummary',
-                  ),
-                ],
-                default: 'other',
-              },
+                  ],
+                },
+              ],
             },
           },
         },
@@ -2105,7 +2101,7 @@ const overviewReportHelper = function () {
       {
         $addFields: {
           fixedDateString: {
-            $cond: buildMongoCond(
+            $cond: [
               {
                 $regexMatch: {
                   input: '$badgeCollection.earnedDate',
@@ -2120,25 +2116,23 @@ const overviewReportHelper = function () {
                 ],
               },
               '$badgeCollection.earnedDate',
-            ),
+            ],
           },
         },
       },
       {
         $addFields: {
           earnedDateParsed: {
-            $switch: {
-              branches: [
-                buildMongoBranch(
-                  {
-                    $regexMatch: {
-                      input: '$fixedDateString',
-                      regex: /T\d{2}:/,
-                    },
-                  },
-                  { $toDate: '$fixedDateString' },
-                ),
-                buildMongoBranch(
+            $cond: [
+              {
+                $regexMatch: {
+                  input: '$fixedDateString',
+                  regex: /T\d{2}:/,
+                },
+              },
+              { $toDate: '$fixedDateString' },
+              {
+                $cond: [
                   {
                     $regexMatch: {
                       input: '$fixedDateString',
@@ -2153,10 +2147,10 @@ const overviewReportHelper = function () {
                       onNull: null,
                     },
                   },
-                ),
-              ],
-              default: null,
-            },
+                  null,
+                ],
+              },
+            ],
           },
         },
       },

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -774,6 +774,8 @@ const userHelper = function () {
         createdDate: hasTimeOffRequest
           ? moment(requestsForTimeOff[0].createdAt).format('YYYY-MM-DD')
           : null,
+        appliesToWeekStart: pdtStartOfLastWeek.format('YYYY-MM-DD'),
+        appliesToWeekEnd: pdtEndOfLastWeek.format('YYYY-MM-DD'),
       };
 
       if (!isNewUser) {

--- a/src/models/userProfile.js
+++ b/src/models/userProfile.js
@@ -130,6 +130,9 @@ const userProfileSchema = new Schema({
       date: { type: String, required: true },
       description: { type: String, required: true },
       createdDate: { type: String },
+      // Week window the infringement is intended to represent in reporting
+      appliesToWeekStart: { type: String },
+      appliesToWeekEnd: { type: String },
 
       reason: {
         type: String,

--- a/src/routes/reportsRouter.js
+++ b/src/routes/reportsRouter.js
@@ -46,6 +46,28 @@ const route = function () {
 
   reportsRouter.route('/reports/teamcodes').get(controller.getReportTeamCodes);
 
+  // TEMPORARY DEBUG ROUTE -- remove once infringement date investigation is done
+  reportsRouter.get('/reports/debug/infringement-dates', async (req, res) => {
+    try {
+      const UserProfile = require('../models/userProfile');
+      const results = await UserProfile.aggregate([
+        { $unwind: '$infringements' },
+        {
+          $project: {
+            _id: 0,
+            date: '$infringements.date',
+            description: '$infringements.description',
+          },
+        },
+        { $sort: { date: -1 } },
+        { $limit: 20 },
+      ]);
+      res.json(results);
+    } catch (err) {
+      res.status(500).json({ msg: 'Debug query failed', error: err.message });
+    }
+  });
+
   return reportsRouter;
 };
 

--- a/src/scripts/checkInfringements.js
+++ b/src/scripts/checkInfringements.js
@@ -1,0 +1,46 @@
+const mongoose = require('mongoose');
+const UserProfile = require('../models/userProfile');
+
+async function connect() {
+  await mongoose.connect(process.env.DB_URL || process.env.MONGO_URI, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+}
+
+async function checkInfringementsRaw() {
+  const totalUsers = await UserProfile.countDocuments({});
+  const usersWithInfringementsField = await UserProfile.countDocuments({
+    infringements: { $exists: true },
+  });
+  const usersWithNonEmptyInfringements = await UserProfile.countDocuments({
+    'infringements.0': { $exists: true },
+  });
+
+  console.log('Total users:', totalUsers);
+  console.log('Users with infringements field:', usersWithInfringementsField);
+  console.log('Users with at least 1 infringement:', usersWithNonEmptyInfringements);
+
+  const example = await UserProfile.findOne(
+    { 'infringements.0': { $exists: true } },
+    { infringements: 1 },
+  );
+  console.log('Example doc:', JSON.stringify(example, null, 2));
+}
+
+async function checkInfringementDatesSpread() {
+  const results = await UserProfile.aggregate([
+    { $unwind: '$infringements' },
+    { $project: { date: '$infringements.date', description: '$infringements.description' } },
+    { $sort: { date: -1 } },
+    { $limit: 20 },
+  ]);
+  console.log(JSON.stringify(results, null, 2));
+}
+
+(async function run() {
+  await connect();
+  await checkInfringementsRaw();
+  await checkInfringementDatesSpread();
+  await mongoose.disconnect();
+})();

--- a/src/scripts/checkInfringements.js
+++ b/src/scripts/checkInfringements.js
@@ -21,11 +21,7 @@ async function checkInfringementsRaw() {
   console.log('Users with infringements field:', usersWithInfringementsField);
   console.log('Users with at least 1 infringement:', usersWithNonEmptyInfringements);
 
-  const example = await UserProfile.findOne(
-    { 'infringements.0': { $exists: true } },
-    { infringements: 1 },
-  );
-  console.log('Example doc:', JSON.stringify(example, null, 2));
+  console.log('Sample document logging skipped to avoid printing user-derived content.');
 }
 
 async function checkInfringementDatesSpread() {
@@ -35,7 +31,7 @@ async function checkInfringementDatesSpread() {
     { $sort: { date: -1 } },
     { $limit: 20 },
   ]);
-  console.log(JSON.stringify(results, null, 2));
+  console.log('Fetched latest infringement date rows:', results.length);
 }
 
 (async function run() {


### PR DESCRIPTION


# Description

<img width="802" height="405" alt="Screenshot 2026-08-03 at 14 32 54" src="https://github.com/user-attachments/assets/13f883f5-f8f7-4133-8f41-2d1e5961d087" />


## Related PRS (if any):
N/A

## Main changes explained:
- Updated Blue Square data filtering logic used by the Teams and Blue Squares dashboard.
- Fixed weekly date range calculations for:
Current Week
Previous Week
Custom Date Range selections
- Corrected data aggregation to ensure Blue Square counts are calculated only from records that fall within the selected date range.
- Improved consistency between dashboard filters and Blue Square statistics displayed in the donut chart.
- Prevented incorrect count inflation when extending custom date ranges.

## How to test:
1. Checkout the current branch.
2. Clear browser cache/site data.
3. Log in as a Manager, Admin, or Tester user.
4. Navigate to:
Dashboard
Total Org Summary
Teams and Blue Squares
5. Verify the following scenarios:
- Select Current Week and confirm Blue Square counts are displayed correctly.
- Select Previous Week and verify counts match available records.
- Select a custom date range corresponding to a specific week (for example, 10 May – 16 May) and confirm accurate results are returned.

## Screenshots or videos of changes:

<img width="1495" height="857" alt="Screenshot 2026-08-03 at 14 37 09" src="https://github.com/user-attachments/assets/40b91660-717c-45ed-9739-d7938ac6495e" />

