### PR TITLE
Mahathi - fix: return project names for supplier performance Backend

### DIFF
--- a/src/controllers/summaryDashboard/supplierPerformance.js
+++ b/src/controllers/summaryDashboard/supplierPerformance.js
@@ -1,4 +1,5 @@
 const mongoose = require('mongoose');
+const Project = require('../../models/project');
 const SupplierPerformance = require('../../models/summaryDashboard/supplierPerformance');
 const logger = require('../../startup/logger');
 
@@ -66,25 +67,15 @@ const supplierPerformanceController = function () {
    */
   const getProjectsWithSupplierData = async function (req, res) {
     try {
-      console.log('Fetching projects with supplier performance data');
+      const projectIds = await SupplierPerformance.distinct('projectId');
 
-      // Get distinct project IDs from supplier performance records only
-      const projectsWithData = await SupplierPerformance.aggregate([
-        {
-          $group: {
-            _id: '$projectId',
-          },
-        },
-        {
-          $project: {
-            _id: 1,
-            projectId: '$_id',
-          },
-        },
-        { $sort: { _id: 1 } },
-      ]);
+      const projectsWithData = await Project.find({
+        _id: { $in: projectIds },
+      })
+        .select('_id projectName')
+        .sort({ projectName: 1 })
+        .lean();
 
-      console.log(`Found ${projectsWithData.length} projects with supplier data`);
       res.status(200).send(projectsWithData);
     } catch (error) {
       logger.logException(error);


### PR DESCRIPTION
# Description
<img width="532" height="433" alt="Screenshot 2026-08-15 at 3 34 43 PM" src="https://github.com/user-attachments/assets/c665d799-1b02-4f6f-896b-4cf9af834a4b" />

## Related PRS (if any):
To test this backend PR you need to checkout the [https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5448](url) frontend PR

## Main changes explained:
1. Updated the Supplier Performance projects endpoint to retrieve the distinct projectId values referenced by Supplier Performance records.
2. Added a lookup against the real Project collection so the endpoint returns project names instead of only project IDs.
3. Kept the existing Supplier Performance date-range filtering logic unchanged after confirming it was functioning correctly.
4. Verified the previous empty recent-date results were caused by stale 2024 development data rather than incorrect backend filtering.

## How to test:
1. check into current branch
2. do npm install and ... to run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to /bmdashboard/totalconstructionsummary
6. Open the tools and equipment tracking section
7. verify that you can see the supplier performance graph working correctly

## Note:
Note that the local pre-commit related-test command may still fail because the unrelated reasonSchedulingController integration tests cannot connect to the local test database; the backend build itself succeeds.
