### PR TITLE
Ken Fix Promotion Eligibility Questionnaire Filtering

### DIFF
--- a/src/controllers/promotionEligibilityController.js
+++ b/src/controllers/promotionEligibilityController.js
@@ -3,6 +3,7 @@ const mongoose = require('mongoose');
 const { hasPermission } = require('../utilities/permissions');
 const logger = require('../startup/logger');
 const { ValidationError } = require('../utilities/errorHandling/customError');
+const FormResponse = require('../models/hgnFormResponse');
 
 const promotionEligibilityController = function (
   UserProfile,
@@ -33,8 +34,15 @@ const promotionEligibilityController = function (
     }
 
     try {
+      // Only include users who have completed the questionnaire
+      const questionnaireResponses = await FormResponse.find({}, 'user_id').lean();
+      const questionnaireUserIds = questionnaireResponses
+        .map((response) => response.user_id)
+        .filter(Boolean);
+
       const users = await UserProfile.find(
         {
+          _id: { $in: questionnaireUserIds },
           isActive: true,
           role: { $nin: ['Owner', 'Administrator', 'Promoted Reviewer'] },
         },


### PR DESCRIPTION
# Description
The Promotion Eligibility table currently includes active users who have not completed the HGN questionnaire. This causes users who have not submitted the required questionnaire to appear in the table. This PR updates the eligibility query to only include users who submitted the HGN questionnaire.

<img width="900" height="483" alt="image" src="https://github.com/user-attachments/assets/3092dd48-1897-419a-81a3-f7274d4bd57e" />


## Related PRS (if any):
- PR [3851](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/3851)(Already merged)

## Main changes explained:
- Update `src/controllers/promotionEligibilityController.js` to only include active users who have submitted the HGN questionnaire in the promotion eligibility table.
- Use questionnaire response `user_id` values to filter the eligible users returned by the promotion eligibility endpoint.

## How to test:
1. check into current branch
2. do `npm install` and `npm run build` and `npm start` to run this PR locally
3. Clear site data/cache
4. log as admin user
5. Create a user(That isn't one of Owner, Promoted Reviewer, or Admin) by clicking on "Other Links" => "User Management" => "Create User"
6. Go to `/promotiontable` and verify the newly created user is not present in the table
7. Logout and login as the newly created User
8. Fill out the questionnaire form at `/hgnform` 
9. Log back in as Admin user and verify that the User is now in the table

## Screenshots or videos of changes:
- Before the filtering changes, the table had a long list of users who appeared despite not filling out the questionnaire.
  <img width="1908" height="1031" alt="image" src="https://github.com/user-attachments/assets/fd2a694e-129e-42fe-9315-3c118181ac64" />

- After implementation:
  - Before User Filled out the form
    <img width="1351" height="533" alt="image" src="https://github.com/user-attachments/assets/bde7cd53-8c3b-4ad3-9361-9ffc667c3b05" />
  - After User Filled out the Form
    <img width="1908" height="1035" alt="image" src="https://github.com/user-attachments/assets/831eb406-58f4-4b9a-a3b1-b20818ee160e" />

    <img width="1353" height="519" alt="image" src="https://github.com/user-attachments/assets/78837864-5e18-427c-96fb-587daf6e5f38" />



## Note:
- The staged test (npm run test:staged) was unable to complete because the existing reasonSchedulingController integration tests failed with dbConnect timed out after 30s.
- Manual testing of the promotion eligibility flow passed: users without a completed questionnaire were excluded, users appeared after completing the questionnaire, and duplicate questionnaire submissions did not create duplicate entries.