### PR TITLE
Mahitha - feat(garden-management): add garden management backend APIs

### DIFF
--- a/src/controllers/gardenManagement/__tests__/gardenCalendarController.test.js
+++ b/src/controllers/gardenManagement/__tests__/gardenCalendarController.test.js
@@ -1,0 +1,1237 @@
+const mongoose = require('mongoose');
+
+jest.mock('../../../models/gardenManagement/gardenCalendar', () => ({
+  find: jest.fn(),
+  findById: jest.fn(),
+  findByIdAndUpdate: jest.fn(),
+  findByIdAndDelete: jest.fn(),
+  create: jest.fn(),
+}));
+
+const GardenCalendar = require('../../../models/gardenManagement/gardenCalendar');
+const {
+  getCalendarEvents,
+  getCalendarEventById,
+  createCalendarEvent,
+  updateCalendarEvent,
+  deleteCalendarEvent,
+  updateCalendarEventStatus,
+} = require('../gardenCalendarController');
+
+describe('Garden Calendar Controller', () => {
+  let req;
+  let res;
+
+  const validId = new mongoose.Types.ObjectId().toString();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    req = {
+      query: {},
+      params: {},
+      body: {},
+    };
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+  });
+
+  // ==================================================
+  // GET ALL CALENDAR EVENTS
+  // ==================================================
+
+  describe('getCalendarEvents', () => {
+    const mockEvents = [
+      {
+        _id: validId,
+        type: 'seeding',
+        name: 'Tomato Seeds',
+      },
+    ];
+
+    const setupFindMock = (events) => {
+      const leanMock = jest.fn().mockResolvedValue(events);
+
+      const sortMock = jest.fn().mockReturnValue({
+        lean: leanMock,
+      });
+
+      GardenCalendar.find.mockReturnValue({
+        sort: sortMock,
+      });
+
+      return {
+        sortMock,
+        leanMock,
+      };
+    };
+
+    it('should return all calendar events successfully', async () => {
+      const { sortMock, leanMock } = setupFindMock(mockEvents);
+
+      await getCalendarEvents(req, res);
+
+      expect(GardenCalendar.find).toHaveBeenCalledWith({});
+
+      expect(sortMock).toHaveBeenCalledWith({
+        startDate: 1,
+        date: 1,
+        createdAt: -1,
+      });
+
+      expect(leanMock).toHaveBeenCalled();
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(mockEvents);
+    });
+
+    it('should search events by name, location, and yield', async () => {
+      setupFindMock(mockEvents);
+
+      req.query = {
+        search: '  tomato.*  ',
+      };
+
+      await getCalendarEvents(req, res);
+
+      const query = GardenCalendar.find.mock.calls[0][0];
+
+      expect(query.$or).toHaveLength(3);
+
+      expect(query.$or[0].name.$regex).toBe(String.raw`tomato\.\*`);
+
+      expect(query.$or[0].name.$options).toBe('i');
+
+      expect(query.$or[1].location.$regex).toBe(String.raw`tomato\.\*`);
+
+      expect(query.$or[2].yield.$regex).toBe(String.raw`tomato\.\*`);
+    });
+
+    it('should ignore empty search values', async () => {
+      setupFindMock(mockEvents);
+
+      req.query = {
+        search: '   ',
+      };
+
+      await getCalendarEvents(req, res);
+
+      expect(GardenCalendar.find).toHaveBeenCalledWith({});
+    });
+
+    it('should ignore non-string search values', async () => {
+      setupFindMock(mockEvents);
+
+      req.query = {
+        search: 123,
+      };
+
+      await getCalendarEvents(req, res);
+
+      expect(GardenCalendar.find).toHaveBeenCalledWith({});
+    });
+
+    it('should filter by valid event type', async () => {
+      setupFindMock(mockEvents);
+
+      req.query = {
+        type: 'seeding',
+      };
+
+      await getCalendarEvents(req, res);
+
+      expect(GardenCalendar.find).toHaveBeenCalledWith({
+        type: 'seeding',
+      });
+    });
+
+    it('should allow type=All', async () => {
+      setupFindMock(mockEvents);
+
+      req.query = {
+        type: 'All',
+      };
+
+      await getCalendarEvents(req, res);
+
+      expect(GardenCalendar.find).toHaveBeenCalledWith({});
+    });
+
+    it('should reject invalid event type', async () => {
+      req.query = {
+        type: 'invalid',
+      };
+
+      await getCalendarEvents(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid event type',
+      });
+
+      expect(GardenCalendar.find).not.toHaveBeenCalled();
+    });
+
+    it('should filter by valid event status', async () => {
+      setupFindMock(mockEvents);
+
+      req.query = {
+        status: 'upcoming',
+      };
+
+      await getCalendarEvents(req, res);
+
+      expect(GardenCalendar.find).toHaveBeenCalledWith({
+        status: 'upcoming',
+      });
+    });
+
+    it('should allow status=All', async () => {
+      setupFindMock(mockEvents);
+
+      req.query = {
+        status: 'All',
+      };
+
+      await getCalendarEvents(req, res);
+
+      expect(GardenCalendar.find).toHaveBeenCalledWith({});
+    });
+
+    it('should reject invalid event status', async () => {
+      req.query = {
+        status: 'invalid',
+      };
+
+      await getCalendarEvents(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid event status',
+      });
+
+      expect(GardenCalendar.find).not.toHaveBeenCalled();
+    });
+
+    it('should filter by start date', async () => {
+      setupFindMock(mockEvents);
+
+      req.query = {
+        startDate: '2026-08-01',
+      };
+
+      await getCalendarEvents(req, res);
+
+      const query = GardenCalendar.find.mock.calls[0][0];
+
+      expect(query.startDate.$gte).toEqual(new Date('2026-08-01'));
+    });
+
+    it('should filter by end date', async () => {
+      setupFindMock(mockEvents);
+
+      req.query = {
+        endDate: '2026-08-31',
+      };
+
+      await getCalendarEvents(req, res);
+
+      const query = GardenCalendar.find.mock.calls[0][0];
+
+      expect(query.startDate.$lte).toEqual(new Date('2026-08-31'));
+    });
+
+    it('should filter by both start and end dates', async () => {
+      setupFindMock(mockEvents);
+
+      req.query = {
+        startDate: '2026-08-01',
+        endDate: '2026-08-31',
+      };
+
+      await getCalendarEvents(req, res);
+
+      const query = GardenCalendar.find.mock.calls[0][0];
+
+      expect(query.startDate.$gte).toEqual(new Date('2026-08-01'));
+
+      expect(query.startDate.$lte).toEqual(new Date('2026-08-31'));
+    });
+
+    it('should reject invalid start date', async () => {
+      req.query = {
+        startDate: 'not-a-date',
+      };
+
+      await getCalendarEvents(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid start date',
+      });
+
+      expect(GardenCalendar.find).not.toHaveBeenCalled();
+    });
+
+    it('should reject invalid end date', async () => {
+      req.query = {
+        endDate: 'not-a-date',
+      };
+
+      await getCalendarEvents(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid end date',
+      });
+
+      expect(GardenCalendar.find).not.toHaveBeenCalled();
+    });
+
+    it('should return 500 when database query fails', async () => {
+      const error = new Error('Database error');
+
+      const leanMock = jest.fn().mockRejectedValue(error);
+
+      GardenCalendar.find.mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          lean: leanMock,
+        }),
+      });
+
+      await getCalendarEvents(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  // ==================================================
+  // GET EVENT BY ID
+  // ==================================================
+
+  describe('getCalendarEventById', () => {
+    it('should return an event by valid ID', async () => {
+      const event = {
+        _id: validId,
+        name: 'Tomato',
+        type: 'seeding',
+      };
+
+      const leanMock = jest.fn().mockResolvedValue(event);
+
+      GardenCalendar.findById.mockReturnValue({
+        lean: leanMock,
+      });
+
+      req.params.id = validId;
+
+      await getCalendarEventById(req, res);
+
+      expect(GardenCalendar.findById).toHaveBeenCalledWith(validId);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+
+      expect(res.json).toHaveBeenCalledWith(event);
+    });
+
+    it('should reject invalid ID', async () => {
+      req.params.id = 'invalid-id';
+
+      await getCalendarEventById(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid calendar event ID',
+      });
+
+      expect(GardenCalendar.findById).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when event does not exist', async () => {
+      const leanMock = jest.fn().mockResolvedValue(null);
+
+      GardenCalendar.findById.mockReturnValue({
+        lean: leanMock,
+      });
+
+      req.params.id = validId;
+
+      await getCalendarEventById(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Calendar event not found',
+      });
+    });
+
+    it('should return 500 when database query fails', async () => {
+      const error = new Error('Database error');
+
+      const leanMock = jest.fn().mockRejectedValue(error);
+
+      GardenCalendar.findById.mockReturnValue({
+        lean: leanMock,
+      });
+
+      req.params.id = validId;
+
+      await getCalendarEventById(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  // ==================================================
+  // CREATE EVENT
+  // ==================================================
+
+  describe('createCalendarEvent', () => {
+    const validBody = {
+      type: 'seeding',
+      name: '  Tomato Seeds  ',
+      startDate: '2026-08-15',
+      endDate: '2026-08-20',
+      location: '  Garden A  ',
+      date: '2026-08-15',
+      from: ' 08:00 ',
+      to: ' 10:00 ',
+      lastSow: '2026-07-01',
+      nextSow: '2026-09-01',
+      interval: ' 2 weeks ',
+      expected: '2026-09-15',
+      yield: ' 50 lbs ',
+      status: 'upcoming',
+    };
+
+    it('should create a calendar event successfully', async () => {
+      const createdEvent = {
+        _id: validId,
+        ...validBody,
+      };
+
+      GardenCalendar.create.mockResolvedValue(createdEvent);
+
+      req.body = validBody;
+
+      await createCalendarEvent(req, res);
+
+      expect(GardenCalendar.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'seeding',
+          name: 'Tomato Seeds',
+          location: 'Garden A',
+          from: '08:00',
+          to: '10:00',
+          interval: '2 weeks',
+          yield: '50 lbs',
+          status: 'upcoming',
+        }),
+      );
+
+      expect(res.status).toHaveBeenCalledWith(201);
+
+      expect(res.json).toHaveBeenCalledWith(createdEvent);
+    });
+
+    it('should use upcoming as the default status', async () => {
+      GardenCalendar.create.mockResolvedValue({
+        _id: validId,
+      });
+
+      req.body = {
+        type: 'seeding',
+        name: 'Tomato',
+      };
+
+      await createCalendarEvent(req, res);
+
+      expect(GardenCalendar.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'upcoming',
+        }),
+      );
+
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('should reject missing type', async () => {
+      req.body = {
+        name: 'Tomato',
+      };
+
+      await createCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Event type and name are required',
+      });
+
+      expect(GardenCalendar.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject missing name', async () => {
+      req.body = {
+        type: 'seeding',
+      };
+
+      await createCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Event type and name are required',
+      });
+
+      expect(GardenCalendar.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject invalid event type', async () => {
+      req.body = {
+        type: 'invalid',
+        name: 'Tomato',
+      };
+
+      await createCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid event type',
+      });
+
+      expect(GardenCalendar.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject invalid event status', async () => {
+      req.body = {
+        type: 'seeding',
+        name: 'Tomato',
+        status: 'invalid',
+      };
+
+      await createCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid event status',
+      });
+
+      expect(GardenCalendar.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject invalid start date', async () => {
+      req.body = {
+        type: 'seeding',
+        name: 'Tomato',
+        startDate: 'invalid-date',
+      };
+
+      await createCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid start date',
+      });
+    });
+
+    it('should reject invalid end date', async () => {
+      req.body = {
+        type: 'seeding',
+        name: 'Tomato',
+        endDate: 'invalid-date',
+      };
+
+      await createCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid end date',
+      });
+    });
+
+    it('should reject invalid date', async () => {
+      req.body = {
+        type: 'seeding',
+        name: 'Tomato',
+        date: 'invalid-date',
+      };
+
+      await createCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid date',
+      });
+    });
+
+    it('should reject invalid last sow date', async () => {
+      req.body = {
+        type: 'seeding',
+        name: 'Tomato',
+        lastSow: 'invalid-date',
+      };
+
+      await createCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid last sow date',
+      });
+    });
+
+    it('should reject invalid next sow date', async () => {
+      req.body = {
+        type: 'seeding',
+        name: 'Tomato',
+        nextSow: 'invalid-date',
+      };
+
+      await createCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid next sow date',
+      });
+    });
+
+    it('should reject invalid expected date', async () => {
+      req.body = {
+        type: 'seeding',
+        name: 'Tomato',
+        expected: 'invalid-date',
+      };
+
+      await createCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid expected date',
+      });
+    });
+
+    it('should reject end date before start date', async () => {
+      req.body = {
+        type: 'seeding',
+        name: 'Tomato',
+        startDate: '2026-08-20',
+        endDate: '2026-08-10',
+      };
+
+      await createCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'End date cannot be before start date',
+      });
+
+      expect(GardenCalendar.create).not.toHaveBeenCalled();
+    });
+
+    it('should return 500 when creation fails', async () => {
+      GardenCalendar.create.mockRejectedValue(new Error('Database error'));
+
+      req.body = {
+        type: 'seeding',
+        name: 'Tomato',
+      };
+
+      await createCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  // ==================================================
+  // UPDATE EVENT
+  // ==================================================
+
+  describe('updateCalendarEvent', () => {
+    const existingEvent = {
+      _id: validId,
+      type: 'seeding',
+      name: 'Old Name',
+      startDate: new Date('2026-08-10'),
+      endDate: new Date('2026-08-20'),
+      status: 'upcoming',
+    };
+
+    const updatedEvent = {
+      ...existingEvent,
+      name: 'Updated Name',
+    };
+
+    const setupUpdateMocks = (existing = existingEvent, updated = updatedEvent) => {
+      GardenCalendar.findById.mockResolvedValue(existing);
+
+      GardenCalendar.findByIdAndUpdate.mockResolvedValue(updated);
+    };
+
+    it('should update an event successfully', async () => {
+      setupUpdateMocks();
+
+      req.params.id = validId;
+
+      req.body = {
+        name: '  Updated Name  ',
+        location: '  Garden B  ',
+        type: 'transplanting',
+        status: 'active',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(GardenCalendar.findByIdAndUpdate).toHaveBeenCalledWith(
+        validId,
+        {
+          name: 'Updated Name',
+          location: 'Garden B',
+          type: 'transplanting',
+          status: 'active',
+        },
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+
+      expect(res.json).toHaveBeenCalledWith(updatedEvent);
+    });
+
+    it('should reject invalid ID', async () => {
+      req.params.id = 'invalid-id';
+
+      await updateCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid calendar event ID',
+      });
+    });
+
+    it('should reject invalid event type', async () => {
+      req.params.id = validId;
+
+      req.body = {
+        type: 'invalid',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid event type',
+      });
+    });
+
+    it('should reject invalid event status', async () => {
+      req.params.id = validId;
+
+      req.body = {
+        status: 'invalid',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid event status',
+      });
+    });
+
+    it('should trim string fields', async () => {
+      setupUpdateMocks();
+
+      req.params.id = validId;
+
+      req.body = {
+        name: ' Name ',
+        location: ' Location ',
+        from: ' From ',
+        to: ' To ',
+        interval: ' Interval ',
+        yield: ' Yield ',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(GardenCalendar.findByIdAndUpdate).toHaveBeenCalledWith(
+        validId,
+        {
+          name: 'Name',
+          location: 'Location',
+          from: 'From',
+          to: 'To',
+          interval: 'Interval',
+          yield: 'Yield',
+        },
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+    });
+
+    it('should parse date fields', async () => {
+      setupUpdateMocks();
+
+      req.params.id = validId;
+
+      req.body = {
+        startDate: '2026-09-01',
+        endDate: '2026-09-10',
+        date: '2026-09-02',
+        lastSow: '2026-08-01',
+        nextSow: '2026-09-20',
+        expected: '2026-10-01',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      const updates = GardenCalendar.findByIdAndUpdate.mock.calls[0][1];
+
+      expect(updates.startDate).toEqual(new Date('2026-09-01'));
+
+      expect(updates.endDate).toEqual(new Date('2026-09-10'));
+
+      expect(updates.date).toEqual(new Date('2026-09-02'));
+
+      expect(updates.lastSow).toEqual(new Date('2026-08-01'));
+
+      expect(updates.nextSow).toEqual(new Date('2026-09-20'));
+
+      expect(updates.expected).toEqual(new Date('2026-10-01'));
+    });
+
+    it('should reject invalid startDate', async () => {
+      req.params.id = validId;
+
+      req.body = {
+        startDate: 'invalid-date',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid startDate',
+      });
+
+      expect(GardenCalendar.findById).not.toHaveBeenCalled();
+    });
+
+    it('should reject invalid endDate', async () => {
+      req.params.id = validId;
+
+      req.body = {
+        endDate: 'invalid-date',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid endDate',
+      });
+    });
+
+    it('should reject invalid date', async () => {
+      req.params.id = validId;
+
+      req.body = {
+        date: 'invalid-date',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid date',
+      });
+    });
+
+    it('should reject invalid lastSow date', async () => {
+      req.params.id = validId;
+
+      req.body = {
+        lastSow: 'invalid-date',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid lastSow',
+      });
+    });
+
+    it('should reject invalid nextSow date', async () => {
+      req.params.id = validId;
+
+      req.body = {
+        nextSow: 'invalid-date',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid nextSow',
+      });
+    });
+
+    it('should reject invalid expected date', async () => {
+      req.params.id = validId;
+
+      req.body = {
+        expected: 'invalid-date',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid expected',
+      });
+    });
+
+    it('should return 404 when event does not exist', async () => {
+      GardenCalendar.findById.mockResolvedValue(null);
+
+      req.params.id = validId;
+
+      req.body = {
+        name: 'Updated Name',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Calendar event not found',
+      });
+
+      expect(GardenCalendar.findByIdAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should reject end date before existing start date', async () => {
+      setupUpdateMocks();
+
+      req.params.id = validId;
+
+      req.body = {
+        endDate: '2026-08-01',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'End date cannot be before start date',
+      });
+
+      expect(GardenCalendar.findByIdAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should reject end date before updated start date', async () => {
+      setupUpdateMocks();
+
+      req.params.id = validId;
+
+      req.body = {
+        startDate: '2026-09-20',
+        endDate: '2026-09-10',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'End date cannot be before start date',
+      });
+
+      expect(GardenCalendar.findByIdAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should update only allowed fields', async () => {
+      setupUpdateMocks();
+
+      req.params.id = validId;
+
+      req.body = {
+        name: 'Updated',
+        unauthorizedField: 'should not update',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      const updates = GardenCalendar.findByIdAndUpdate.mock.calls[0][1];
+
+      expect(updates).toEqual({
+        name: 'Updated',
+      });
+
+      expect(updates.unauthorizedField).toBeUndefined();
+    });
+
+    it('should return 500 when findById fails', async () => {
+      GardenCalendar.findById.mockRejectedValue(new Error('Database error'));
+
+      req.params.id = validId;
+
+      req.body = {
+        name: 'Updated',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+
+    it('should return 500 when findByIdAndUpdate fails', async () => {
+      GardenCalendar.findById.mockResolvedValue(existingEvent);
+
+      GardenCalendar.findByIdAndUpdate.mockRejectedValue(new Error('Database error'));
+
+      req.params.id = validId;
+
+      req.body = {
+        name: 'Updated',
+      };
+
+      await updateCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  // ==================================================
+  // DELETE EVENT
+  // ==================================================
+
+  describe('deleteCalendarEvent', () => {
+    it('should delete an event successfully', async () => {
+      const event = {
+        _id: validId,
+        name: 'Tomato',
+      };
+
+      GardenCalendar.findByIdAndDelete.mockResolvedValue(event);
+
+      req.params.id = validId;
+
+      await deleteCalendarEvent(req, res);
+
+      expect(GardenCalendar.findByIdAndDelete).toHaveBeenCalledWith(validId);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Calendar event deleted successfully',
+      });
+    });
+
+    it('should reject invalid ID', async () => {
+      req.params.id = 'invalid-id';
+
+      await deleteCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid calendar event ID',
+      });
+
+      expect(GardenCalendar.findByIdAndDelete).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when event does not exist', async () => {
+      GardenCalendar.findByIdAndDelete.mockResolvedValue(null);
+
+      req.params.id = validId;
+
+      await deleteCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Calendar event not found',
+      });
+    });
+
+    it('should return 500 when delete fails', async () => {
+      GardenCalendar.findByIdAndDelete.mockRejectedValue(new Error('Database error'));
+
+      req.params.id = validId;
+
+      await deleteCalendarEvent(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  // ==================================================
+  // UPDATE EVENT STATUS
+  // ==================================================
+
+  describe('updateCalendarEventStatus', () => {
+    const updatedEvent = {
+      _id: validId,
+      status: 'completed',
+    };
+
+    it('should update event status successfully', async () => {
+      GardenCalendar.findByIdAndUpdate.mockResolvedValue(updatedEvent);
+
+      req.params.id = validId;
+
+      req.body = {
+        status: 'completed',
+      };
+
+      await updateCalendarEventStatus(req, res);
+
+      expect(GardenCalendar.findByIdAndUpdate).toHaveBeenCalledWith(
+        validId,
+        {
+          status: 'completed',
+        },
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+
+      expect(res.json).toHaveBeenCalledWith(updatedEvent);
+    });
+
+    it('should reject invalid ID', async () => {
+      req.params.id = 'invalid-id';
+
+      req.body = {
+        status: 'completed',
+      };
+
+      await updateCalendarEventStatus(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid calendar event ID',
+      });
+
+      expect(GardenCalendar.findByIdAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should reject invalid status', async () => {
+      req.params.id = validId;
+
+      req.body = {
+        status: 'invalid',
+      };
+
+      await updateCalendarEventStatus(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid event status',
+      });
+
+      expect(GardenCalendar.findByIdAndUpdate).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when event does not exist', async () => {
+      GardenCalendar.findByIdAndUpdate.mockResolvedValue(null);
+
+      req.params.id = validId;
+
+      req.body = {
+        status: 'completed',
+      };
+
+      await updateCalendarEventStatus(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Calendar event not found',
+      });
+    });
+
+    it('should return 500 when status update fails', async () => {
+      GardenCalendar.findByIdAndUpdate.mockRejectedValue(new Error('Database error'));
+
+      req.params.id = validId;
+
+      req.body = {
+        status: 'completed',
+      };
+
+      await updateCalendarEventStatus(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+});

--- a/src/controllers/gardenManagement/__tests__/gardenCalendarController.test.js
+++ b/src/controllers/gardenManagement/__tests__/gardenCalendarController.test.js
@@ -74,7 +74,7 @@ describe('Garden Calendar Controller', () => {
 
       await getCalendarEvents(req, res);
 
-      expect(GardenCalendar.find).toHaveBeenCalledWith({});
+      expect(GardenCalendar.find).toHaveBeenCalledWith();
 
       expect(sortMock).toHaveBeenCalledWith({
         startDate: 1,
@@ -88,211 +88,36 @@ describe('Garden Calendar Controller', () => {
       expect(res.json).toHaveBeenCalledWith(mockEvents);
     });
 
-    it('should search events by name, location, and yield', async () => {
+    it('should ignore query parameters and return all events', async () => {
       setupFindMock(mockEvents);
 
       req.query = {
-        search: '  tomato.*  ',
-      };
-
-      await getCalendarEvents(req, res);
-
-      const query = GardenCalendar.find.mock.calls[0][0];
-
-      expect(query.$or).toHaveLength(3);
-
-      expect(query.$or[0].name.$regex).toBe(String.raw`tomato\.\*`);
-
-      expect(query.$or[0].name.$options).toBe('i');
-
-      expect(query.$or[1].location.$regex).toBe(String.raw`tomato\.\*`);
-
-      expect(query.$or[2].yield.$regex).toBe(String.raw`tomato\.\*`);
-    });
-
-    it('should ignore empty search values', async () => {
-      setupFindMock(mockEvents);
-
-      req.query = {
-        search: '   ',
-      };
-
-      await getCalendarEvents(req, res);
-
-      expect(GardenCalendar.find).toHaveBeenCalledWith({});
-    });
-
-    it('should ignore non-string search values', async () => {
-      setupFindMock(mockEvents);
-
-      req.query = {
-        search: 123,
-      };
-
-      await getCalendarEvents(req, res);
-
-      expect(GardenCalendar.find).toHaveBeenCalledWith({});
-    });
-
-    it('should filter by valid event type', async () => {
-      setupFindMock(mockEvents);
-
-      req.query = {
+        search: 'tomato',
         type: 'seeding',
-      };
-
-      await getCalendarEvents(req, res);
-
-      expect(GardenCalendar.find).toHaveBeenCalledWith({
-        type: 'seeding',
-      });
-    });
-
-    it('should allow type=All', async () => {
-      setupFindMock(mockEvents);
-
-      req.query = {
-        type: 'All',
-      };
-
-      await getCalendarEvents(req, res);
-
-      expect(GardenCalendar.find).toHaveBeenCalledWith({});
-    });
-
-    it('should reject invalid event type', async () => {
-      req.query = {
-        type: 'invalid',
-      };
-
-      await getCalendarEvents(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Invalid event type',
-      });
-
-      expect(GardenCalendar.find).not.toHaveBeenCalled();
-    });
-
-    it('should filter by valid event status', async () => {
-      setupFindMock(mockEvents);
-
-      req.query = {
         status: 'upcoming',
-      };
-
-      await getCalendarEvents(req, res);
-
-      expect(GardenCalendar.find).toHaveBeenCalledWith({
-        status: 'upcoming',
-      });
-    });
-
-    it('should allow status=All', async () => {
-      setupFindMock(mockEvents);
-
-      req.query = {
-        status: 'All',
-      };
-
-      await getCalendarEvents(req, res);
-
-      expect(GardenCalendar.find).toHaveBeenCalledWith({});
-    });
-
-    it('should reject invalid event status', async () => {
-      req.query = {
-        status: 'invalid',
-      };
-
-      await getCalendarEvents(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Invalid event status',
-      });
-
-      expect(GardenCalendar.find).not.toHaveBeenCalled();
-    });
-
-    it('should filter by start date', async () => {
-      setupFindMock(mockEvents);
-
-      req.query = {
-        startDate: '2026-08-01',
-      };
-
-      await getCalendarEvents(req, res);
-
-      const query = GardenCalendar.find.mock.calls[0][0];
-
-      expect(query.startDate.$gte).toEqual(new Date('2026-08-01'));
-    });
-
-    it('should filter by end date', async () => {
-      setupFindMock(mockEvents);
-
-      req.query = {
-        endDate: '2026-08-31',
-      };
-
-      await getCalendarEvents(req, res);
-
-      const query = GardenCalendar.find.mock.calls[0][0];
-
-      expect(query.startDate.$lte).toEqual(new Date('2026-08-31'));
-    });
-
-    it('should filter by both start and end dates', async () => {
-      setupFindMock(mockEvents);
-
-      req.query = {
         startDate: '2026-08-01',
         endDate: '2026-08-31',
       };
 
       await getCalendarEvents(req, res);
 
-      const query = GardenCalendar.find.mock.calls[0][0];
+      expect(GardenCalendar.find).toHaveBeenCalledWith();
+      expect(GardenCalendar.find).toHaveBeenCalledTimes(1);
 
-      expect(query.startDate.$gte).toEqual(new Date('2026-08-01'));
-
-      expect(query.startDate.$lte).toEqual(new Date('2026-08-31'));
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(mockEvents);
     });
 
-    it('should reject invalid start date', async () => {
-      req.query = {
-        startDate: 'not-a-date',
-      };
+    it('should return all events when no query parameters are provided', async () => {
+      setupFindMock(mockEvents);
+
+      req.query = {};
 
       await getCalendarEvents(req, res);
 
-      expect(res.status).toHaveBeenCalledWith(400);
-
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Invalid start date',
-      });
-
-      expect(GardenCalendar.find).not.toHaveBeenCalled();
-    });
-
-    it('should reject invalid end date', async () => {
-      req.query = {
-        endDate: 'not-a-date',
-      };
-
-      await getCalendarEvents(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Invalid end date',
-      });
-
-      expect(GardenCalendar.find).not.toHaveBeenCalled();
+      expect(GardenCalendar.find).toHaveBeenCalledWith();
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(mockEvents);
     });
 
     it('should return 500 when database query fails', async () => {
@@ -692,7 +517,6 @@ describe('Garden Calendar Controller', () => {
 
     const setupUpdateMocks = (existing = existingEvent, updated = updatedEvent) => {
       GardenCalendar.findById.mockResolvedValue(existing);
-
       GardenCalendar.findByIdAndUpdate.mockResolvedValue(updated);
     };
 
@@ -739,6 +563,8 @@ describe('Garden Calendar Controller', () => {
       expect(res.json).toHaveBeenCalledWith({
         message: 'Invalid calendar event ID',
       });
+
+      expect(GardenCalendar.findById).not.toHaveBeenCalled();
     });
 
     it('should reject invalid event type', async () => {
@@ -755,6 +581,8 @@ describe('Garden Calendar Controller', () => {
       expect(res.json).toHaveBeenCalledWith({
         message: 'Invalid event type',
       });
+
+      expect(GardenCalendar.findById).not.toHaveBeenCalled();
     });
 
     it('should reject invalid event status', async () => {
@@ -771,6 +599,8 @@ describe('Garden Calendar Controller', () => {
       expect(res.json).toHaveBeenCalledWith({
         message: 'Invalid event status',
       });
+
+      expect(GardenCalendar.findById).not.toHaveBeenCalled();
     });
 
     it('should trim string fields', async () => {
@@ -825,15 +655,10 @@ describe('Garden Calendar Controller', () => {
       const updates = GardenCalendar.findByIdAndUpdate.mock.calls[0][1];
 
       expect(updates.startDate).toEqual(new Date('2026-09-01'));
-
       expect(updates.endDate).toEqual(new Date('2026-09-10'));
-
       expect(updates.date).toEqual(new Date('2026-09-02'));
-
       expect(updates.lastSow).toEqual(new Date('2026-08-01'));
-
       expect(updates.nextSow).toEqual(new Date('2026-09-20'));
-
       expect(updates.expected).toEqual(new Date('2026-10-01'));
     });
 
@@ -869,6 +694,8 @@ describe('Garden Calendar Controller', () => {
       expect(res.json).toHaveBeenCalledWith({
         message: 'Invalid endDate',
       });
+
+      expect(GardenCalendar.findById).not.toHaveBeenCalled();
     });
 
     it('should reject invalid date', async () => {
@@ -885,6 +712,8 @@ describe('Garden Calendar Controller', () => {
       expect(res.json).toHaveBeenCalledWith({
         message: 'Invalid date',
       });
+
+      expect(GardenCalendar.findById).not.toHaveBeenCalled();
     });
 
     it('should reject invalid lastSow date', async () => {
@@ -901,6 +730,8 @@ describe('Garden Calendar Controller', () => {
       expect(res.json).toHaveBeenCalledWith({
         message: 'Invalid lastSow',
       });
+
+      expect(GardenCalendar.findById).not.toHaveBeenCalled();
     });
 
     it('should reject invalid nextSow date', async () => {
@@ -917,6 +748,8 @@ describe('Garden Calendar Controller', () => {
       expect(res.json).toHaveBeenCalledWith({
         message: 'Invalid nextSow',
       });
+
+      expect(GardenCalendar.findById).not.toHaveBeenCalled();
     });
 
     it('should reject invalid expected date', async () => {
@@ -933,6 +766,8 @@ describe('Garden Calendar Controller', () => {
       expect(res.json).toHaveBeenCalledWith({
         message: 'Invalid expected',
       });
+
+      expect(GardenCalendar.findById).not.toHaveBeenCalled();
     });
 
     it('should return 404 when event does not exist', async () => {
@@ -1033,6 +868,8 @@ describe('Garden Calendar Controller', () => {
       expect(res.json).toHaveBeenCalledWith({
         message: 'Internal server error',
       });
+
+      expect(GardenCalendar.findByIdAndUpdate).not.toHaveBeenCalled();
     });
 
     it('should return 500 when findByIdAndUpdate fails', async () => {

--- a/src/controllers/gardenManagement/__tests__/seedInventoryController.test.js
+++ b/src/controllers/gardenManagement/__tests__/seedInventoryController.test.js
@@ -1,0 +1,1009 @@
+const mongoose = require('mongoose');
+const SeedInventory = require('../../../models/gardenManagement/seedInventory');
+const {
+  getSeedInventory,
+  getSeedInventoryById,
+  createSeedInventory,
+  updateSeedInventory,
+  deleteSeedInventory,
+  updateSeedQuantity,
+} = require('../seedInventoryController');
+
+describe('Seed Inventory Controller', () => {
+  let req;
+  let res;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    req = {
+      query: {},
+      params: {},
+      body: {},
+    };
+
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getSeedInventory', () => {
+    const mockFind = (seeds) => {
+      jest.spyOn(SeedInventory, 'find').mockReturnValue({
+        sort: jest.fn().mockReturnValue({
+          lean: jest.fn().mockResolvedValue(seeds),
+        }),
+      });
+    };
+
+    it('should return all seed inventory', async () => {
+      const seeds = [
+        {
+          _id: '1',
+          name: 'Tomato',
+          quantity: 10,
+          viable: 90,
+        },
+      ];
+
+      mockFind(seeds);
+
+      await getSeedInventory(req, res);
+
+      expect(SeedInventory.find).toHaveBeenCalledWith({});
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(seeds);
+    });
+
+    it('should search seeds by name', async () => {
+      const seeds = [
+        {
+          name: 'Tomato',
+          quantity: 10,
+          viable: 90,
+        },
+      ];
+
+      req.query.search = 'Tomato';
+
+      mockFind(seeds);
+
+      await getSeedInventory(req, res);
+
+      expect(SeedInventory.find).toHaveBeenCalledWith({
+        name: {
+          $regex: 'Tomato',
+          $options: 'i',
+        },
+      });
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(seeds);
+    });
+
+    it('should escape regex characters in search', async () => {
+      req.query.search = 'Tomato.*';
+
+      mockFind([]);
+
+      await getSeedInventory(req, res);
+
+      expect(SeedInventory.find).toHaveBeenCalledWith({
+        name: {
+          $regex: 'Tomato\\.\\*',
+          $options: 'i',
+        },
+      });
+    });
+
+    it('should ignore empty search values', async () => {
+      req.query.search = '   ';
+
+      mockFind([]);
+
+      await getSeedInventory(req, res);
+
+      expect(SeedInventory.find).toHaveBeenCalledWith({});
+    });
+
+    it('should apply minimum quantity filter', async () => {
+      req.query.minQuantity = '10';
+
+      mockFind([]);
+
+      await getSeedInventory(req, res);
+
+      expect(SeedInventory.find).toHaveBeenCalledWith({
+        quantity: {
+          $gte: 10,
+        },
+      });
+    });
+
+    it('should apply maximum quantity filter', async () => {
+      req.query.maxQuantity = '50';
+
+      mockFind([]);
+
+      await getSeedInventory(req, res);
+
+      expect(SeedInventory.find).toHaveBeenCalledWith({
+        quantity: {
+          $lte: 50,
+        },
+      });
+    });
+
+    it('should apply minimum and maximum quantity filters', async () => {
+      req.query.minQuantity = '10';
+      req.query.maxQuantity = '50';
+
+      mockFind([]);
+
+      await getSeedInventory(req, res);
+
+      expect(SeedInventory.find).toHaveBeenCalledWith({
+        quantity: {
+          $gte: 10,
+          $lte: 50,
+        },
+      });
+    });
+
+    it.each([
+      ['invalid minimum quantity', { minQuantity: '-1' }, 'Invalid minimum quantity'],
+      ['non-numeric minimum quantity', { minQuantity: 'abc' }, 'Invalid minimum quantity'],
+      ['invalid maximum quantity', { maxQuantity: '-1' }, 'Invalid maximum quantity'],
+      ['non-numeric maximum quantity', { maxQuantity: 'abc' }, 'Invalid maximum quantity'],
+    ])('should reject %s', async (_description, query, message) => {
+      req.query = query;
+
+      const findSpy = jest.spyOn(SeedInventory, 'find');
+
+      await getSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message,
+      });
+
+      expect(findSpy).not.toHaveBeenCalled();
+    });
+
+    it('should reject when minimum quantity exceeds maximum quantity', async () => {
+      req.query.minQuantity = '100';
+      req.query.maxQuantity = '50';
+
+      const findSpy = jest.spyOn(SeedInventory, 'find');
+
+      await getSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Minimum quantity cannot be greater than maximum quantity',
+      });
+
+      expect(findSpy).not.toHaveBeenCalled();
+    });
+
+    it('should apply minimum viability filter', async () => {
+      req.query.minViable = '25';
+
+      mockFind([]);
+
+      await getSeedInventory(req, res);
+
+      expect(SeedInventory.find).toHaveBeenCalledWith({
+        viable: {
+          $gte: 25,
+        },
+      });
+    });
+
+    it('should apply maximum viability filter', async () => {
+      req.query.maxViable = '90';
+
+      mockFind([]);
+
+      await getSeedInventory(req, res);
+
+      expect(SeedInventory.find).toHaveBeenCalledWith({
+        viable: {
+          $lte: 90,
+        },
+      });
+    });
+
+    it('should apply minimum and maximum viability filters', async () => {
+      req.query.minViable = '25';
+      req.query.maxViable = '90';
+
+      mockFind([]);
+
+      await getSeedInventory(req, res);
+
+      expect(SeedInventory.find).toHaveBeenCalledWith({
+        viable: {
+          $gte: 25,
+          $lte: 90,
+        },
+      });
+    });
+
+    it.each([
+      ['invalid minimum viability', { minViable: '-1' }, 'Invalid minimum viability'],
+      ['minimum viability above 100', { minViable: '101' }, 'Invalid minimum viability'],
+      ['non-numeric minimum viability', { minViable: 'abc' }, 'Invalid minimum viability'],
+      ['invalid maximum viability', { maxViable: '-1' }, 'Invalid maximum viability'],
+      ['maximum viability above 100', { maxViable: '101' }, 'Invalid maximum viability'],
+      ['non-numeric maximum viability', { maxViable: 'abc' }, 'Invalid maximum viability'],
+    ])('should reject %s', async (_description, query, message) => {
+      req.query = query;
+
+      const findSpy = jest.spyOn(SeedInventory, 'find');
+
+      await getSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message,
+      });
+
+      expect(findSpy).not.toHaveBeenCalled();
+    });
+
+    it('should reject when minimum viability exceeds maximum viability', async () => {
+      req.query.minViable = '90';
+      req.query.maxViable = '50';
+
+      const findSpy = jest.spyOn(SeedInventory, 'find');
+
+      await getSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Minimum viability cannot be greater than maximum viability',
+      });
+
+      expect(findSpy).not.toHaveBeenCalled();
+    });
+
+    it('should combine all filters', async () => {
+      req.query = {
+        search: 'Tomato',
+        minQuantity: '10',
+        maxQuantity: '50',
+        minViable: '60',
+        maxViable: '100',
+      };
+
+      mockFind([]);
+
+      await getSeedInventory(req, res);
+
+      expect(SeedInventory.find).toHaveBeenCalledWith({
+        name: {
+          $regex: 'Tomato',
+          $options: 'i',
+        },
+        quantity: {
+          $gte: 10,
+          $lte: 50,
+        },
+        viable: {
+          $gte: 60,
+          $lte: 100,
+        },
+      });
+    });
+
+    it('should return 500 when database query fails', async () => {
+      jest.spyOn(SeedInventory, 'find').mockImplementation(() => {
+        throw new Error('Database error');
+      });
+
+      await getSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  describe('getSeedInventoryById', () => {
+    const validId = '507f1f77bcf86cd799439011';
+
+    it('should return seed by ID', async () => {
+      const seed = {
+        _id: validId,
+        name: 'Tomato',
+        quantity: 20,
+        viable: 90,
+      };
+
+      req.params.id = validId;
+
+      jest.spyOn(SeedInventory, 'findById').mockReturnValue({
+        lean: jest.fn().mockResolvedValue(seed),
+      });
+
+      await getSeedInventoryById(req, res);
+
+      expect(SeedInventory.findById).toHaveBeenCalledWith(validId);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(seed);
+    });
+
+    it('should reject invalid ID', async () => {
+      req.params.id = 'invalid-id';
+
+      const findByIdSpy = jest.spyOn(SeedInventory, 'findById');
+
+      await getSeedInventoryById(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid seed inventory ID',
+      });
+
+      expect(findByIdSpy).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when seed does not exist', async () => {
+      req.params.id = validId;
+
+      jest.spyOn(SeedInventory, 'findById').mockReturnValue({
+        lean: jest.fn().mockResolvedValue(null),
+      });
+
+      await getSeedInventoryById(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Seed inventory item not found',
+      });
+    });
+
+    it('should return 500 when database query fails', async () => {
+      req.params.id = validId;
+
+      jest.spyOn(SeedInventory, 'findById').mockReturnValue({
+        lean: jest.fn().mockRejectedValue(new Error('Database error')),
+      });
+
+      await getSeedInventoryById(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  describe('createSeedInventory', () => {
+    it('should create seed successfully', async () => {
+      req.body = {
+        name: 'Tomato',
+        collectedDate: '2026-08-15',
+        quantity: 25,
+        viable: 90,
+      };
+
+      const createdSeed = {
+        _id: '507f1f77bcf86cd799439011',
+        name: 'Tomato',
+        collectedDate: new Date('2026-08-15'),
+        quantity: 25,
+        viable: 90,
+      };
+
+      jest.spyOn(SeedInventory, 'create').mockResolvedValue(createdSeed);
+
+      await createSeedInventory(req, res);
+
+      expect(SeedInventory.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Tomato',
+          quantity: 25,
+          viable: 90,
+          collectedDate: expect.any(Date),
+        }),
+      );
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith(createdSeed);
+    });
+
+    it('should trim seed name', async () => {
+      req.body = {
+        name: '  Tomato  ',
+        collectedDate: '2026-08-15',
+        quantity: '10',
+        viable: '80',
+      };
+
+      jest.spyOn(SeedInventory, 'create').mockResolvedValue({
+        name: 'Tomato',
+      });
+
+      await createSeedInventory(req, res);
+
+      expect(SeedInventory.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Tomato',
+          quantity: 10,
+          viable: 80,
+        }),
+      );
+    });
+
+    it.each([
+      [
+        'missing name',
+        {
+          collectedDate: '2026-08-15',
+          quantity: 10,
+          viable: 90,
+        },
+        'Seed name is required',
+      ],
+      [
+        'non-string name',
+        {
+          name: 123,
+          collectedDate: '2026-08-15',
+          quantity: 10,
+          viable: 90,
+        },
+        'Seed name is required',
+      ],
+      [
+        'whitespace name',
+        {
+          name: '   ',
+          collectedDate: '2026-08-15',
+          quantity: 10,
+          viable: 90,
+        },
+        'Seed name is required',
+      ],
+    ])('should reject %s', async (_description, body, message) => {
+      req.body = body;
+
+      const createSpy = jest.spyOn(SeedInventory, 'create');
+
+      await createSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message,
+      });
+
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it('should reject missing date', async () => {
+      req.body = {
+        name: 'Tomato',
+        quantity: 10,
+        viable: 90,
+      };
+
+      await createSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'collected date is required',
+      });
+    });
+
+    it('should reject invalid date', async () => {
+      req.body = {
+        name: 'Tomato',
+        collectedDate: 'invalid-date',
+        quantity: 10,
+        viable: 90,
+      };
+
+      await createSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid collected date',
+      });
+    });
+
+    it.each([
+      [
+        'negative quantity',
+        {
+          name: 'Tomato',
+          collectedDate: '2026-08-15',
+          quantity: -1,
+          viable: 90,
+        },
+      ],
+      [
+        'invalid quantity',
+        {
+          name: 'Tomato',
+          collectedDate: '2026-08-15',
+          quantity: 'abc',
+          viable: 90,
+        },
+      ],
+      [
+        'missing quantity',
+        {
+          name: 'Tomato',
+          collectedDate: '2026-08-15',
+          viable: 90,
+        },
+      ],
+    ])('should reject %s', async (_description, body) => {
+      req.body = body;
+
+      const createSpy = jest.spyOn(SeedInventory, 'create');
+
+      await createSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Quantity must be a non-negative number',
+      });
+
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      [
+        'viability below zero',
+        {
+          name: 'Tomato',
+          collectedDate: '2026-08-15',
+          quantity: 10,
+          viable: -1,
+        },
+      ],
+      [
+        'viability above 100',
+        {
+          name: 'Tomato',
+          collectedDate: '2026-08-15',
+          quantity: 10,
+          viable: 101,
+        },
+      ],
+      [
+        'invalid viability',
+        {
+          name: 'Tomato',
+          collectedDate: '2026-08-15',
+          quantity: 10,
+          viable: 'abc',
+        },
+      ],
+    ])('should reject %s', async (_description, body) => {
+      req.body = body;
+
+      const createSpy = jest.spyOn(SeedInventory, 'create');
+
+      await createSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Viability must be a number between 0 and 100',
+      });
+
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    it('should return 500 when create fails', async () => {
+      req.body = {
+        name: 'Tomato',
+        collectedDate: '2026-08-15',
+        quantity: 10,
+        viable: 90,
+      };
+
+      jest.spyOn(SeedInventory, 'create').mockRejectedValue(new Error('Database error'));
+
+      await createSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  describe('updateSeedInventory', () => {
+    const validId = '507f1f77bcf86cd799439011';
+
+    it('should update seed successfully', async () => {
+      req.params.id = validId;
+      req.body = {
+        name: 'Updated Tomato',
+        quantity: 30,
+        viable: 95,
+      };
+
+      const updatedSeed = {
+        _id: validId,
+        name: 'Updated Tomato',
+        quantity: 30,
+        viable: 95,
+      };
+
+      jest.spyOn(SeedInventory, 'findByIdAndUpdate').mockResolvedValue(updatedSeed);
+
+      await updateSeedInventory(req, res);
+
+      expect(SeedInventory.findByIdAndUpdate).toHaveBeenCalledWith(
+        validId,
+        {
+          name: 'Updated Tomato',
+          quantity: 30,
+          viable: 95,
+        },
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(updatedSeed);
+    });
+
+    it('should trim updated name', async () => {
+      req.params.id = validId;
+      req.body = {
+        name: '  Updated Tomato  ',
+      };
+
+      jest.spyOn(SeedInventory, 'findByIdAndUpdate').mockResolvedValue({
+        name: 'Updated Tomato',
+      });
+
+      await updateSeedInventory(req, res);
+
+      expect(SeedInventory.findByIdAndUpdate).toHaveBeenCalledWith(
+        validId,
+        {
+          name: 'Updated Tomato',
+        },
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+    });
+
+    it('should update collected date', async () => {
+      req.params.id = validId;
+      req.body = {
+        collectedDate: '2026-08-15',
+      };
+
+      jest.spyOn(SeedInventory, 'findByIdAndUpdate').mockResolvedValue({});
+
+      await updateSeedInventory(req, res);
+
+      expect(SeedInventory.findByIdAndUpdate).toHaveBeenCalledWith(
+        validId,
+        {
+          collectedDate: expect.any(Date),
+        },
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+    });
+
+    it('should convert quantity to number', async () => {
+      req.params.id = validId;
+      req.body = {
+        quantity: '25',
+      };
+
+      jest.spyOn(SeedInventory, 'findByIdAndUpdate').mockResolvedValue({});
+
+      await updateSeedInventory(req, res);
+
+      expect(SeedInventory.findByIdAndUpdate).toHaveBeenCalledWith(
+        validId,
+        {
+          quantity: 25,
+        },
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+    });
+
+    it('should convert viability to number', async () => {
+      req.params.id = validId;
+      req.body = {
+        viable: '85',
+      };
+
+      jest.spyOn(SeedInventory, 'findByIdAndUpdate').mockResolvedValue({});
+
+      await updateSeedInventory(req, res);
+
+      expect(SeedInventory.findByIdAndUpdate).toHaveBeenCalledWith(
+        validId,
+        {
+          viable: 85,
+        },
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+    });
+
+    it('should reject invalid ID', async () => {
+      req.params.id = 'invalid';
+
+      const updateSpy = jest.spyOn(SeedInventory, 'findByIdAndUpdate');
+
+      await updateSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['empty update', {}, 'No valid fields provided for update'],
+      ['unsupported field', { unsupportedField: 'value' }, 'No valid fields provided for update'],
+      ['empty name', { name: '   ' }, 'Seed name cannot be empty'],
+      ['non-string name', { name: 123 }, 'Seed name cannot be empty'],
+      ['invalid date', { collectedDate: 'invalid-date' }, 'Invalid collected date'],
+      ['invalid quantity', { quantity: -5 }, 'Quantity must be a non-negative number'],
+      ['invalid viability', { viable: 101 }, 'Viability must be a number between 0 and 100'],
+    ])('should reject %s', async (_description, body, message) => {
+      req.params.id = validId;
+      req.body = body;
+
+      const updateSpy = jest.spyOn(SeedInventory, 'findByIdAndUpdate');
+
+      await updateSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message,
+      });
+
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when seed is not found', async () => {
+      req.params.id = validId;
+      req.body = {
+        quantity: 20,
+      };
+
+      jest.spyOn(SeedInventory, 'findByIdAndUpdate').mockResolvedValue(null);
+
+      await updateSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Seed inventory item not found',
+      });
+    });
+
+    it('should return 500 when update fails', async () => {
+      req.params.id = validId;
+      req.body = {
+        quantity: 20,
+      };
+
+      jest.spyOn(SeedInventory, 'findByIdAndUpdate').mockRejectedValue(new Error('Database error'));
+
+      await updateSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  describe('deleteSeedInventory', () => {
+    const validId = '507f1f77bcf86cd799439011';
+
+    it('should delete seed successfully', async () => {
+      req.params.id = validId;
+
+      jest.spyOn(SeedInventory, 'findByIdAndDelete').mockResolvedValue({
+        _id: validId,
+        name: 'Tomato',
+      });
+
+      await deleteSeedInventory(req, res);
+
+      expect(SeedInventory.findByIdAndDelete).toHaveBeenCalledWith(validId);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Seed inventory item deleted successfully',
+      });
+    });
+
+    it('should reject invalid ID', async () => {
+      req.params.id = 'invalid';
+
+      const deleteSpy = jest.spyOn(SeedInventory, 'findByIdAndDelete');
+
+      await deleteSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(deleteSpy).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when seed is not found', async () => {
+      req.params.id = validId;
+
+      jest.spyOn(SeedInventory, 'findByIdAndDelete').mockResolvedValue(null);
+
+      await deleteSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Seed inventory item not found',
+      });
+    });
+
+    it('should return 500 when delete fails', async () => {
+      req.params.id = validId;
+
+      jest.spyOn(SeedInventory, 'findByIdAndDelete').mockRejectedValue(new Error('Database error'));
+
+      await deleteSeedInventory(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  describe('updateSeedQuantity', () => {
+    const validId = '507f1f77bcf86cd799439011';
+
+    it('should update quantity successfully', async () => {
+      req.params.id = validId;
+      req.body = {
+        quantity: 50,
+      };
+
+      const updatedSeed = {
+        _id: validId,
+        quantity: 50,
+      };
+
+      jest.spyOn(SeedInventory, 'findByIdAndUpdate').mockResolvedValue(updatedSeed);
+
+      await updateSeedQuantity(req, res);
+
+      expect(SeedInventory.findByIdAndUpdate).toHaveBeenCalledWith(
+        validId,
+        {
+          quantity: 50,
+        },
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(updatedSeed);
+    });
+
+    it('should convert quantity to number', async () => {
+      req.params.id = validId;
+      req.body = {
+        quantity: '25',
+      };
+
+      jest.spyOn(SeedInventory, 'findByIdAndUpdate').mockResolvedValue({
+        quantity: 25,
+      });
+
+      await updateSeedQuantity(req, res);
+
+      expect(SeedInventory.findByIdAndUpdate).toHaveBeenCalledWith(
+        validId,
+        {
+          quantity: 25,
+        },
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+    });
+
+    it('should reject invalid ID', async () => {
+      req.params.id = 'invalid';
+      req.body = {
+        quantity: 10,
+      };
+
+      const updateSpy = jest.spyOn(SeedInventory, 'findByIdAndUpdate');
+
+      await updateSeedQuantity(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['negative quantity', -1],
+      ['non-numeric quantity', 'abc'],
+      ['missing quantity', undefined],
+    ])('should reject %s', async (_description, quantity) => {
+      req.params.id = validId;
+
+      if (quantity !== undefined) {
+        req.body = { quantity };
+      }
+
+      const updateSpy = jest.spyOn(SeedInventory, 'findByIdAndUpdate');
+
+      await updateSeedQuantity(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Quantity must be a non-negative number',
+      });
+
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when seed is not found', async () => {
+      req.params.id = validId;
+      req.body = {
+        quantity: 20,
+      };
+
+      jest.spyOn(SeedInventory, 'findByIdAndUpdate').mockResolvedValue(null);
+
+      await updateSeedQuantity(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Seed inventory item not found',
+      });
+    });
+
+    it('should return 500 when update fails', async () => {
+      req.params.id = validId;
+      req.body = {
+        quantity: 20,
+      };
+
+      jest.spyOn(SeedInventory, 'findByIdAndUpdate').mockRejectedValue(new Error('Database error'));
+
+      await updateSeedQuantity(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+});

--- a/src/controllers/gardenManagement/__tests__/seedOrderController.test.js
+++ b/src/controllers/gardenManagement/__tests__/seedOrderController.test.js
@@ -53,38 +53,7 @@ describe('Seed Order Controller', () => {
   });
 
   describe('getSeedOrders', () => {
-    test.each([
-      ['search', { search: 'tomato' }],
-      ['supplier', { supplier: 'Garden' }],
-      ['status', { status: 'pending' }],
-      [
-        'search, supplier and status',
-        {
-          search: 'tomato',
-          supplier: 'Garden',
-          status: 'received',
-        },
-      ],
-    ])('should return orders when using %s filters', async (_description, query) => {
-      const req = { query };
-      const res = createResponse();
-
-      const orders = [
-        {
-          orderId: 'ORD-001',
-          supplier: 'Garden Supplier',
-        },
-      ];
-
-      jest.spyOn(SeedOrder, 'find').mockReturnValue(createFindChain(orders));
-
-      await getSeedOrders(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(200);
-      expect(res.json).toHaveBeenCalledWith(orders);
-    });
-
-    test('should return all orders without filters', async () => {
+    test('should return all seed orders', async () => {
       const req = {
         query: {},
       };
@@ -93,6 +62,11 @@ describe('Seed Order Controller', () => {
       const orders = [
         {
           orderId: 'ORD-001',
+          supplier: 'Garden Supplier',
+        },
+        {
+          orderId: 'ORD-002',
+          supplier: 'Another Supplier',
         },
       ];
 
@@ -100,62 +74,9 @@ describe('Seed Order Controller', () => {
 
       await getSeedOrders(req, res);
 
-      expect(findSpy).toHaveBeenCalledWith({});
+      expect(findSpy).toHaveBeenCalledWith();
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(orders);
-    });
-
-    test('should escape regex characters in search', async () => {
-      const req = {
-        query: {
-          search: 'tomato.*',
-        },
-      };
-      const res = createResponse();
-
-      const findSpy = jest.spyOn(SeedOrder, 'find').mockReturnValue(createFindChain([]));
-
-      await getSeedOrders(req, res);
-
-      const query = findSpy.mock.calls[0][0];
-
-      expect(query.$or[0].orderId.$regex).toBe('tomato\\.\\*');
-    });
-
-    test('should accept All status without filtering', async () => {
-      const req = {
-        query: {
-          status: 'All',
-        },
-      };
-      const res = createResponse();
-
-      const findSpy = jest.spyOn(SeedOrder, 'find').mockReturnValue(createFindChain([]));
-
-      await getSeedOrders(req, res);
-
-      expect(findSpy).toHaveBeenCalledWith({});
-      expect(res.status).toHaveBeenCalledWith(200);
-    });
-
-    test('should reject invalid status', async () => {
-      const req = {
-        query: {
-          status: 'invalid',
-        },
-      };
-      const res = createResponse();
-
-      const findSpy = jest.spyOn(SeedOrder, 'find');
-
-      await getSeedOrders(req, res);
-
-      expect(res.status).toHaveBeenCalledWith(400);
-      expect(res.json).toHaveBeenCalledWith({
-        message: 'Invalid order status',
-      });
-
-      expect(findSpy).not.toHaveBeenCalled();
     });
 
     test('should return 500 when database query fails', async () => {
@@ -196,7 +117,6 @@ describe('Seed Order Controller', () => {
       await getSeedOrderById(req, res);
 
       expect(SeedOrder.findById).toHaveBeenCalledWith(validId);
-
       expect(res.status).toHaveBeenCalledWith(200);
       expect(res.json).toHaveBeenCalledWith(order);
     });
@@ -337,7 +257,9 @@ describe('Seed Order Controller', () => {
         'Invalid order status',
       ],
     ])('should reject %s', async (_description, body, message) => {
-      const req = { body };
+      const req = {
+        body,
+      };
       const res = createResponse();
 
       const createSpy = jest.spyOn(SeedOrder, 'create');
@@ -434,7 +356,9 @@ describe('Seed Order Controller', () => {
         'Delivery date cannot be before order date',
       ],
     ])('should reject %s', async (_description, body, message) => {
-      const req = { body };
+      const req = {
+        body,
+      };
       const res = createResponse();
 
       const createSpy = jest.spyOn(SeedOrder, 'create');
@@ -598,12 +522,16 @@ describe('Seed Order Controller', () => {
 
       const res = createResponse();
 
+      const findByIdSpy = jest.spyOn(SeedOrder, 'findById');
+
       await updateSeedOrder(req, res);
 
       expect(res.status).toHaveBeenCalledWith(400);
       expect(res.json).toHaveBeenCalledWith({
         message: 'Invalid seed order ID',
       });
+
+      expect(findByIdSpy).not.toHaveBeenCalled();
     });
 
     test('should reject empty update', async () => {

--- a/src/controllers/gardenManagement/__tests__/seedOrderController.test.js
+++ b/src/controllers/gardenManagement/__tests__/seedOrderController.test.js
@@ -1,0 +1,1071 @@
+const mongoose = require('mongoose');
+const SeedOrder = require('../../../models/gardenManagement/seedOrder');
+const {
+  getSeedOrders,
+  getSeedOrderById,
+  createSeedOrder,
+  updateSeedOrder,
+  deleteSeedOrder,
+  updateSeedOrderStatus,
+} = require('../seedOrderController');
+
+const validId = new mongoose.Types.ObjectId().toString();
+
+const createResponse = () => {
+  const res = {};
+
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+
+  return res;
+};
+
+const createFindChain = (result) => ({
+  sort: jest.fn().mockReturnValue({
+    lean: jest.fn().mockResolvedValue(result),
+  }),
+});
+
+const createFindByIdChain = (result) => ({
+  lean: jest.fn().mockResolvedValue(result),
+});
+
+const validItems = [
+  {
+    name: 'Tomato Seeds',
+    qty: 10,
+    unit: 'packets',
+  },
+];
+
+const validOrderBody = {
+  orderId: 'ORD-001',
+  supplier: 'Garden Supplier',
+  items: validItems,
+  orderDate: '2026-08-15',
+  deliveryDate: '2026-08-20',
+  status: 'pending',
+};
+
+describe('Seed Order Controller', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('getSeedOrders', () => {
+    test.each([
+      ['search', { search: 'tomato' }],
+      ['supplier', { supplier: 'Garden' }],
+      ['status', { status: 'pending' }],
+      [
+        'search, supplier and status',
+        {
+          search: 'tomato',
+          supplier: 'Garden',
+          status: 'received',
+        },
+      ],
+    ])('should return orders when using %s filters', async (_description, query) => {
+      const req = { query };
+      const res = createResponse();
+
+      const orders = [
+        {
+          orderId: 'ORD-001',
+          supplier: 'Garden Supplier',
+        },
+      ];
+
+      jest.spyOn(SeedOrder, 'find').mockReturnValue(createFindChain(orders));
+
+      await getSeedOrders(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(orders);
+    });
+
+    test('should return all orders without filters', async () => {
+      const req = {
+        query: {},
+      };
+      const res = createResponse();
+
+      const orders = [
+        {
+          orderId: 'ORD-001',
+        },
+      ];
+
+      const findSpy = jest.spyOn(SeedOrder, 'find').mockReturnValue(createFindChain(orders));
+
+      await getSeedOrders(req, res);
+
+      expect(findSpy).toHaveBeenCalledWith({});
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(orders);
+    });
+
+    test('should escape regex characters in search', async () => {
+      const req = {
+        query: {
+          search: 'tomato.*',
+        },
+      };
+      const res = createResponse();
+
+      const findSpy = jest.spyOn(SeedOrder, 'find').mockReturnValue(createFindChain([]));
+
+      await getSeedOrders(req, res);
+
+      const query = findSpy.mock.calls[0][0];
+
+      expect(query.$or[0].orderId.$regex).toBe('tomato\\.\\*');
+    });
+
+    test('should accept All status without filtering', async () => {
+      const req = {
+        query: {
+          status: 'All',
+        },
+      };
+      const res = createResponse();
+
+      const findSpy = jest.spyOn(SeedOrder, 'find').mockReturnValue(createFindChain([]));
+
+      await getSeedOrders(req, res);
+
+      expect(findSpy).toHaveBeenCalledWith({});
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    test('should reject invalid status', async () => {
+      const req = {
+        query: {
+          status: 'invalid',
+        },
+      };
+      const res = createResponse();
+
+      const findSpy = jest.spyOn(SeedOrder, 'find');
+
+      await getSeedOrders(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid order status',
+      });
+
+      expect(findSpy).not.toHaveBeenCalled();
+    });
+
+    test('should return 500 when database query fails', async () => {
+      const req = {
+        query: {},
+      };
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'find').mockImplementation(() => {
+        throw new Error('Database error');
+      });
+
+      await getSeedOrders(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  describe('getSeedOrderById', () => {
+    test('should return order by valid ID', async () => {
+      const req = {
+        params: {
+          id: validId,
+        },
+      };
+      const res = createResponse();
+
+      const order = {
+        _id: validId,
+        orderId: 'ORD-001',
+      };
+
+      jest.spyOn(SeedOrder, 'findById').mockReturnValue(createFindByIdChain(order));
+
+      await getSeedOrderById(req, res);
+
+      expect(SeedOrder.findById).toHaveBeenCalledWith(validId);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(order);
+    });
+
+    test('should reject invalid ID', async () => {
+      const req = {
+        params: {
+          id: 'invalid-id',
+        },
+      };
+      const res = createResponse();
+
+      const findByIdSpy = jest.spyOn(SeedOrder, 'findById');
+
+      await getSeedOrderById(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid seed order ID',
+      });
+
+      expect(findByIdSpy).not.toHaveBeenCalled();
+    });
+
+    test('should return 404 when order is not found', async () => {
+      const req = {
+        params: {
+          id: validId,
+        },
+      };
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'findById').mockReturnValue(createFindByIdChain(null));
+
+      await getSeedOrderById(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Seed order not found',
+      });
+    });
+
+    test('should return 500 when database query fails', async () => {
+      const req = {
+        params: {
+          id: validId,
+        },
+      };
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'findById').mockImplementation(() => {
+        throw new Error('Database error');
+      });
+
+      await getSeedOrderById(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  describe('createSeedOrder', () => {
+    test('should create seed order successfully', async () => {
+      const req = {
+        body: validOrderBody,
+      };
+      const res = createResponse();
+
+      const createdOrder = {
+        _id: validId,
+        ...validOrderBody,
+      };
+
+      jest.spyOn(SeedOrder, 'create').mockResolvedValue(createdOrder);
+
+      await createSeedOrder(req, res);
+
+      expect(SeedOrder.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderId: 'ORD-001',
+          supplier: 'Garden Supplier',
+          status: 'pending',
+          items: [
+            {
+              name: 'Tomato Seeds',
+              qty: 10,
+              unit: 'packets',
+            },
+          ],
+        }),
+      );
+
+      expect(res.status).toHaveBeenCalledWith(201);
+      expect(res.json).toHaveBeenCalledWith(createdOrder);
+    });
+
+    test.each([
+      [
+        'missing order ID',
+        {
+          ...validOrderBody,
+          orderId: '',
+        },
+        'Order ID is required',
+      ],
+      [
+        'missing supplier',
+        {
+          ...validOrderBody,
+          supplier: '',
+        },
+        'Supplier is required',
+      ],
+      [
+        'missing items',
+        {
+          ...validOrderBody,
+          items: [],
+        },
+        'An order must contain at least one item',
+      ],
+      [
+        'missing order date',
+        {
+          ...validOrderBody,
+          orderDate: '',
+        },
+        'Order date is required',
+      ],
+      [
+        'invalid status',
+        {
+          ...validOrderBody,
+          status: 'invalid',
+        },
+        'Invalid order status',
+      ],
+    ])('should reject %s', async (_description, body, message) => {
+      const req = { body };
+      const res = createResponse();
+
+      const createSpy = jest.spyOn(SeedOrder, 'create');
+
+      await createSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message,
+      });
+
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    test.each([
+      [
+        'item without name',
+        [
+          {
+            qty: 10,
+            unit: 'packets',
+          },
+        ],
+        'Each order item must have a name',
+      ],
+      [
+        'item with invalid quantity',
+        [
+          {
+            name: 'Tomato',
+            qty: 0,
+            unit: 'packets',
+          },
+        ],
+        'Each order item quantity must be at least 1',
+      ],
+      [
+        'item without unit',
+        [
+          {
+            name: 'Tomato',
+            qty: 10,
+            unit: '',
+          },
+        ],
+        'Each order item must have a unit',
+      ],
+    ])('should reject %s', async (_description, items, message) => {
+      const req = {
+        body: {
+          ...validOrderBody,
+          items,
+        },
+      };
+
+      const res = createResponse();
+
+      const createSpy = jest.spyOn(SeedOrder, 'create');
+
+      await createSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message,
+      });
+
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    test.each([
+      [
+        'invalid order date',
+        {
+          ...validOrderBody,
+          orderDate: 'invalid-date',
+        },
+        'Invalid order date',
+      ],
+      [
+        'invalid delivery date',
+        {
+          ...validOrderBody,
+          deliveryDate: 'invalid-date',
+        },
+        'Invalid delivery date',
+      ],
+      [
+        'delivery date before order date',
+        {
+          ...validOrderBody,
+          orderDate: '2026-08-20',
+          deliveryDate: '2026-08-15',
+        },
+        'Delivery date cannot be before order date',
+      ],
+    ])('should reject %s', async (_description, body, message) => {
+      const req = { body };
+      const res = createResponse();
+
+      const createSpy = jest.spyOn(SeedOrder, 'create');
+
+      await createSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message,
+      });
+
+      expect(createSpy).not.toHaveBeenCalled();
+    });
+
+    test('should use pending as default status', async () => {
+      const req = {
+        body: {
+          ...validOrderBody,
+          status: undefined,
+        },
+      };
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'create').mockResolvedValue({
+        orderId: 'ORD-001',
+      });
+
+      await createSeedOrder(req, res);
+
+      expect(SeedOrder.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 'pending',
+        }),
+      );
+
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    test('should allow order without delivery date', async () => {
+      const req = {
+        body: {
+          ...validOrderBody,
+          deliveryDate: undefined,
+        },
+      };
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'create').mockResolvedValue({
+        orderId: 'ORD-001',
+      });
+
+      await createSeedOrder(req, res);
+
+      expect(SeedOrder.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          deliveryDate: undefined,
+        }),
+      );
+
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    test('should return 409 for duplicate order ID', async () => {
+      const req = {
+        body: validOrderBody,
+      };
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'create').mockRejectedValue({
+        code: 11000,
+      });
+
+      await createSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Order ID already exists',
+      });
+    });
+
+    test('should return 500 when create fails', async () => {
+      const req = {
+        body: validOrderBody,
+      };
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'create').mockRejectedValue(new Error('Database error'));
+
+      await createSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  describe('updateSeedOrder', () => {
+    const updateRequest = (body) => ({
+      params: {
+        id: validId,
+      },
+      body,
+    });
+
+    test('should update seed order successfully', async () => {
+      const req = updateRequest({
+        supplier: ' Updated Supplier ',
+        status: 'received',
+      });
+
+      const res = createResponse();
+
+      const existingOrder = {
+        _id: validId,
+        orderDate: new Date('2026-08-10'),
+        deliveryDate: new Date('2026-08-15'),
+      };
+
+      const updatedOrder = {
+        ...existingOrder,
+        supplier: 'Updated Supplier',
+        status: 'received',
+      };
+
+      jest.spyOn(SeedOrder, 'findById').mockResolvedValue(existingOrder);
+
+      jest.spyOn(SeedOrder, 'findByIdAndUpdate').mockResolvedValue(updatedOrder);
+
+      await updateSeedOrder(req, res);
+
+      expect(SeedOrder.findByIdAndUpdate).toHaveBeenCalledWith(
+        validId,
+        expect.objectContaining({
+          supplier: 'Updated Supplier',
+          status: 'received',
+        }),
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(updatedOrder);
+    });
+
+    test('should reject invalid ID', async () => {
+      const req = {
+        params: {
+          id: 'invalid-id',
+        },
+        body: {
+          supplier: 'Supplier',
+        },
+      };
+
+      const res = createResponse();
+
+      await updateSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid seed order ID',
+      });
+    });
+
+    test('should reject empty update', async () => {
+      const req = updateRequest({});
+      const res = createResponse();
+
+      const findSpy = jest.spyOn(SeedOrder, 'findById');
+
+      await updateSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'No valid fields provided for update',
+      });
+
+      expect(findSpy).not.toHaveBeenCalled();
+    });
+
+    test.each([
+      [
+        'invalid order ID',
+        {
+          orderId: '',
+        },
+        'Order ID is required',
+      ],
+      [
+        'invalid supplier',
+        {
+          supplier: '',
+        },
+        'Supplier is required',
+      ],
+      [
+        'invalid status',
+        {
+          status: 'invalid',
+        },
+        'Invalid order status',
+      ],
+      [
+        'invalid order date',
+        {
+          orderDate: 'invalid-date',
+        },
+        'Invalid order date',
+      ],
+      [
+        'invalid delivery date',
+        {
+          deliveryDate: 'invalid-date',
+        },
+        'Invalid delivery date',
+      ],
+    ])('should reject %s', async (_description, body, message) => {
+      const req = updateRequest(body);
+      const res = createResponse();
+
+      await updateSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message,
+      });
+    });
+
+    test.each([
+      ['empty items', [], 'An order must contain at least one item'],
+      [
+        'item without name',
+        [
+          {
+            qty: 2,
+            unit: 'packets',
+          },
+        ],
+        'Each order item must have a name',
+      ],
+      [
+        'item with invalid quantity',
+        [
+          {
+            name: 'Tomato',
+            qty: 0,
+            unit: 'packets',
+          },
+        ],
+        'Each order item quantity must be at least 1',
+      ],
+      [
+        'item without unit',
+        [
+          {
+            name: 'Tomato',
+            qty: 2,
+            unit: '',
+          },
+        ],
+        'Each order item must have a unit',
+      ],
+    ])('should reject %s', async (_description, items, message) => {
+      const req = updateRequest({
+        items,
+      });
+
+      const res = createResponse();
+
+      await updateSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message,
+      });
+    });
+
+    test('should normalize update items', async () => {
+      const req = updateRequest({
+        items: [
+          {
+            name: ' Tomato Seeds ',
+            qty: '5',
+            unit: ' packets ',
+          },
+        ],
+      });
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'findById').mockResolvedValue({
+        orderDate: new Date('2026-08-10'),
+      });
+
+      jest.spyOn(SeedOrder, 'findByIdAndUpdate').mockResolvedValue({
+        orderId: 'ORD-001',
+      });
+
+      await updateSeedOrder(req, res);
+
+      expect(SeedOrder.findByIdAndUpdate).toHaveBeenCalledWith(
+        validId,
+        expect.objectContaining({
+          items: [
+            {
+              name: 'Tomato Seeds',
+              qty: 5,
+              unit: 'packets',
+            },
+          ],
+        }),
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+    });
+
+    test('should allow clearing delivery date', async () => {
+      const req = updateRequest({
+        deliveryDate: '',
+      });
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'findById').mockResolvedValue({
+        orderDate: new Date('2026-08-10'),
+      });
+
+      jest.spyOn(SeedOrder, 'findByIdAndUpdate').mockResolvedValue({
+        orderId: 'ORD-001',
+      });
+
+      await updateSeedOrder(req, res);
+
+      expect(SeedOrder.findByIdAndUpdate).toHaveBeenCalledWith(
+        validId,
+        expect.objectContaining({
+          deliveryDate: undefined,
+        }),
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
+
+    test('should return 404 when existing order is not found', async () => {
+      const req = updateRequest({
+        supplier: 'New Supplier',
+      });
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'findById').mockResolvedValue(null);
+
+      const updateSpy = jest.spyOn(SeedOrder, 'findByIdAndUpdate');
+
+      await updateSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Seed order not found',
+      });
+
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    test('should reject delivery date before order date', async () => {
+      const req = updateRequest({
+        deliveryDate: '2026-08-01',
+      });
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'findById').mockResolvedValue({
+        orderDate: new Date('2026-08-10'),
+      });
+
+      const updateSpy = jest.spyOn(SeedOrder, 'findByIdAndUpdate');
+
+      await updateSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Delivery date cannot be before order date',
+      });
+
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    test('should return 409 for duplicate order ID', async () => {
+      const req = updateRequest({
+        orderId: 'ORD-999',
+      });
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'findById').mockResolvedValue({
+        orderDate: new Date('2026-08-10'),
+      });
+
+      jest.spyOn(SeedOrder, 'findByIdAndUpdate').mockRejectedValue({
+        code: 11000,
+      });
+
+      await updateSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(409);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Order ID already exists',
+      });
+    });
+
+    test('should return 500 when update fails', async () => {
+      const req = updateRequest({
+        supplier: 'New Supplier',
+      });
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'findById').mockResolvedValue({
+        orderDate: new Date('2026-08-10'),
+      });
+
+      jest.spyOn(SeedOrder, 'findByIdAndUpdate').mockRejectedValue(new Error('Database error'));
+
+      await updateSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  describe('deleteSeedOrder', () => {
+    test('should delete seed order successfully', async () => {
+      const req = {
+        params: {
+          id: validId,
+        },
+      };
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'findByIdAndDelete').mockResolvedValue({
+        _id: validId,
+      });
+
+      await deleteSeedOrder(req, res);
+
+      expect(SeedOrder.findByIdAndDelete).toHaveBeenCalledWith(validId);
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Seed order deleted successfully',
+      });
+    });
+
+    test('should reject invalid ID', async () => {
+      const req = {
+        params: {
+          id: 'invalid-id',
+        },
+      };
+
+      const res = createResponse();
+
+      const deleteSpy = jest.spyOn(SeedOrder, 'findByIdAndDelete');
+
+      await deleteSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Invalid seed order ID',
+      });
+
+      expect(deleteSpy).not.toHaveBeenCalled();
+    });
+
+    test('should return 404 when order does not exist', async () => {
+      const req = {
+        params: {
+          id: validId,
+        },
+      };
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'findByIdAndDelete').mockResolvedValue(null);
+
+      await deleteSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Seed order not found',
+      });
+    });
+
+    test('should return 500 when delete fails', async () => {
+      const req = {
+        params: {
+          id: validId,
+        },
+      };
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'findByIdAndDelete').mockRejectedValue(new Error('Database error'));
+
+      await deleteSeedOrder(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+
+  describe('updateSeedOrderStatus', () => {
+    test('should update status successfully', async () => {
+      const req = {
+        params: {
+          id: validId,
+        },
+        body: {
+          status: 'received',
+        },
+      };
+
+      const res = createResponse();
+
+      const order = {
+        _id: validId,
+        status: 'received',
+      };
+
+      jest.spyOn(SeedOrder, 'findByIdAndUpdate').mockResolvedValue(order);
+
+      await updateSeedOrderStatus(req, res);
+
+      expect(SeedOrder.findByIdAndUpdate).toHaveBeenCalledWith(
+        validId,
+        {
+          status: 'received',
+        },
+        {
+          new: true,
+          runValidators: true,
+        },
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(order);
+    });
+
+    test.each([
+      ['invalid ID', 'invalid-id', 'received'],
+      ['invalid status', validId, 'invalid'],
+    ])('should reject %s', async (_description, id, status) => {
+      const req = {
+        params: {
+          id,
+        },
+        body: {
+          status,
+        },
+      };
+
+      const res = createResponse();
+
+      const updateSpy = jest.spyOn(SeedOrder, 'findByIdAndUpdate');
+
+      await updateSeedOrderStatus(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(updateSpy).not.toHaveBeenCalled();
+    });
+
+    test('should return 404 when order is not found', async () => {
+      const req = {
+        params: {
+          id: validId,
+        },
+        body: {
+          status: 'received',
+        },
+      };
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'findByIdAndUpdate').mockResolvedValue(null);
+
+      await updateSeedOrderStatus(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Seed order not found',
+      });
+    });
+
+    test('should return 500 when status update fails', async () => {
+      const req = {
+        params: {
+          id: validId,
+        },
+        body: {
+          status: 'received',
+        },
+      };
+
+      const res = createResponse();
+
+      jest.spyOn(SeedOrder, 'findByIdAndUpdate').mockRejectedValue(new Error('Database error'));
+
+      await updateSeedOrderStatus(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.json).toHaveBeenCalledWith({
+        message: 'Internal server error',
+      });
+    });
+  });
+});

--- a/src/controllers/gardenManagement/gardenCalendarController.js
+++ b/src/controllers/gardenManagement/gardenCalendarController.js
@@ -34,8 +34,6 @@ const sendServerError = (res, error) => {
   });
 };
 
-const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-
 const parseDate = (value, fieldName) => {
   if (value === undefined || value === null || value === '') {
     return {
@@ -73,73 +71,6 @@ const validateEventStatus = (status) => {
   }
 
   return EVENT_STATUSES.has(status) ? null : 'Invalid event status';
-};
-
-const buildSearchQuery = (search) => {
-  if (typeof search !== 'string' || !search.trim()) {
-    return null;
-  }
-
-  const escapedSearch = escapeRegex(search.trim());
-
-  return {
-    $or: [
-      {
-        name: {
-          $regex: escapedSearch,
-          $options: 'i',
-        },
-      },
-      {
-        location: {
-          $regex: escapedSearch,
-          $options: 'i',
-        },
-      },
-      {
-        yield: {
-          $regex: escapedSearch,
-          $options: 'i',
-        },
-      },
-    ],
-  };
-};
-
-const buildDateQuery = (startDate, endDate) => {
-  if (!startDate && !endDate) {
-    return null;
-  }
-
-  const dateQuery = {};
-
-  if (startDate) {
-    const parsedStartDate = parseDate(startDate, 'start date');
-
-    if (!parsedStartDate.valid) {
-      return {
-        error: parsedStartDate.message,
-      };
-    }
-
-    dateQuery.$gte = parsedStartDate.value;
-  }
-
-  if (endDate) {
-    const parsedEndDate = parseDate(endDate, 'end date');
-
-    if (!parsedEndDate.valid) {
-      return {
-        error: parsedEndDate.message,
-      };
-    }
-
-    dateQuery.$lte = parsedEndDate.value;
-  }
-
-  return {
-    value: dateQuery,
-  };
 };
 
 const parseCreateDates = ({ startDate, endDate, date, lastSow, nextSow, expected }) => {
@@ -232,53 +163,7 @@ const parseUpdateDates = (updates) => {
  */
 const getCalendarEvents = async (req, res) => {
   try {
-    const { search = '', type, status, startDate, endDate } = req.query;
-
-    const query = {};
-
-    const searchQuery = buildSearchQuery(search);
-
-    if (searchQuery) {
-      query.$or = searchQuery.$or;
-    }
-
-    const typeError = validateEventType(type);
-
-    if (typeError) {
-      return res.status(400).json({
-        message: typeError,
-      });
-    }
-
-    if (typeof type === 'string' && type !== 'All') {
-      query.type = type;
-    }
-
-    const statusError = validateEventStatus(status);
-
-    if (statusError) {
-      return res.status(400).json({
-        message: statusError,
-      });
-    }
-
-    if (typeof status === 'string' && status !== 'All') {
-      query.status = status;
-    }
-
-    const dateResult = buildDateQuery(startDate, endDate);
-
-    if (dateResult?.error) {
-      return res.status(400).json({
-        message: dateResult.error,
-      });
-    }
-
-    if (dateResult?.value) {
-      query.startDate = dateResult.value;
-    }
-
-    const events = await GardenCalendar.find(query)
+    const events = await GardenCalendar.find()
       .sort({
         startDate: 1,
         date: 1,

--- a/src/controllers/gardenManagement/gardenCalendarController.js
+++ b/src/controllers/gardenManagement/gardenCalendarController.js
@@ -1,0 +1,593 @@
+const mongoose = require('mongoose');
+const GardenCalendar = require('../../models/gardenManagement/gardenCalendar');
+
+const EVENT_TYPES = new Set(['seeding', 'transplanting', 'succession', 'harvesting']);
+
+const EVENT_STATUSES = new Set(['upcoming', 'active', 'growing', 'completed']);
+
+const ALLOWED_UPDATE_FIELDS = [
+  'type',
+  'name',
+  'startDate',
+  'endDate',
+  'location',
+  'date',
+  'from',
+  'to',
+  'lastSow',
+  'nextSow',
+  'interval',
+  'expected',
+  'yield',
+  'status',
+];
+
+const DATE_UPDATE_FIELDS = ['startDate', 'endDate', 'date', 'lastSow', 'nextSow', 'expected'];
+
+const STRING_UPDATE_FIELDS = ['name', 'location', 'from', 'to', 'interval', 'yield'];
+
+const sendServerError = (res, error) => {
+  console.error(error);
+
+  return res.status(500).json({
+    message: 'Internal server error',
+  });
+};
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+
+const parseDate = (value, fieldName) => {
+  if (value === undefined || value === null || value === '') {
+    return {
+      valid: true,
+      value: undefined,
+    };
+  }
+
+  const parsedDate = new Date(value);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return {
+      valid: false,
+      message: `Invalid ${fieldName}`,
+    };
+  }
+
+  return {
+    valid: true,
+    value: parsedDate,
+  };
+};
+
+const validateEventType = (type) => {
+  if (typeof type !== 'string' || type === 'All') {
+    return null;
+  }
+
+  return EVENT_TYPES.has(type) ? null : 'Invalid event type';
+};
+
+const validateEventStatus = (status) => {
+  if (typeof status !== 'string' || status === 'All') {
+    return null;
+  }
+
+  return EVENT_STATUSES.has(status) ? null : 'Invalid event status';
+};
+
+const buildSearchQuery = (search) => {
+  if (typeof search !== 'string' || !search.trim()) {
+    return null;
+  }
+
+  const escapedSearch = escapeRegex(search.trim());
+
+  return {
+    $or: [
+      {
+        name: {
+          $regex: escapedSearch,
+          $options: 'i',
+        },
+      },
+      {
+        location: {
+          $regex: escapedSearch,
+          $options: 'i',
+        },
+      },
+      {
+        yield: {
+          $regex: escapedSearch,
+          $options: 'i',
+        },
+      },
+    ],
+  };
+};
+
+const buildDateQuery = (startDate, endDate) => {
+  if (!startDate && !endDate) {
+    return null;
+  }
+
+  const dateQuery = {};
+
+  if (startDate) {
+    const parsedStartDate = parseDate(startDate, 'start date');
+
+    if (!parsedStartDate.valid) {
+      return {
+        error: parsedStartDate.message,
+      };
+    }
+
+    dateQuery.$gte = parsedStartDate.value;
+  }
+
+  if (endDate) {
+    const parsedEndDate = parseDate(endDate, 'end date');
+
+    if (!parsedEndDate.valid) {
+      return {
+        error: parsedEndDate.message,
+      };
+    }
+
+    dateQuery.$lte = parsedEndDate.value;
+  }
+
+  return {
+    value: dateQuery,
+  };
+};
+
+const parseCreateDates = ({ startDate, endDate, date, lastSow, nextSow, expected }) => {
+  const fields = [
+    ['startDate', startDate, 'start date'],
+    ['endDate', endDate, 'end date'],
+    ['date', date, 'date'],
+    ['lastSow', lastSow, 'last sow date'],
+    ['nextSow', nextSow, 'next sow date'],
+    ['expected', expected, 'expected date'],
+  ];
+
+  const parsedDates = {};
+
+  for (const [field, value, fieldName] of fields) {
+    const parsed = parseDate(value, fieldName);
+
+    if (!parsed.valid) {
+      return {
+        error: parsed.message,
+      };
+    }
+
+    parsedDates[field] = parsed.value;
+  }
+
+  return {
+    value: parsedDates,
+  };
+};
+
+const validateDateOrder = (startDate, endDate) => {
+  if (startDate && endDate && endDate < startDate) {
+    return 'End date cannot be before start date';
+  }
+
+  return null;
+};
+
+const trimIfString = (value) => (typeof value === 'string' ? value.trim() : value);
+
+const getAllowedUpdates = (body) => {
+  const updates = {};
+
+  ALLOWED_UPDATE_FIELDS.forEach((field) => {
+    if (body[field] !== undefined) {
+      updates[field] = body[field];
+    }
+  });
+
+  return updates;
+};
+
+const trimUpdateFields = (updates) => {
+  STRING_UPDATE_FIELDS.forEach((field) => {
+    if (updates[field] !== undefined) {
+      updates[field] = trimIfString(updates[field]);
+    }
+  });
+
+  return updates;
+};
+
+const parseUpdateDates = (updates) => {
+  for (const field of DATE_UPDATE_FIELDS) {
+    if (updates[field] === undefined) {
+      continue;
+    }
+
+    const parsedDate = parseDate(updates[field], field);
+
+    if (!parsedDate.valid) {
+      return {
+        error: parsedDate.message,
+      };
+    }
+
+    updates[field] = parsedDate.value;
+  }
+
+  return {
+    value: updates,
+  };
+};
+
+/**
+ * GET all garden calendar events
+ *
+ * GET /api/kitchenandinventory/gardenmanagement/calendar
+ */
+const getCalendarEvents = async (req, res) => {
+  try {
+    const { search = '', type, status, startDate, endDate } = req.query;
+
+    const query = {};
+
+    const searchQuery = buildSearchQuery(search);
+
+    if (searchQuery) {
+      query.$or = searchQuery.$or;
+    }
+
+    const typeError = validateEventType(type);
+
+    if (typeError) {
+      return res.status(400).json({
+        message: typeError,
+      });
+    }
+
+    if (typeof type === 'string' && type !== 'All') {
+      query.type = type;
+    }
+
+    const statusError = validateEventStatus(status);
+
+    if (statusError) {
+      return res.status(400).json({
+        message: statusError,
+      });
+    }
+
+    if (typeof status === 'string' && status !== 'All') {
+      query.status = status;
+    }
+
+    const dateResult = buildDateQuery(startDate, endDate);
+
+    if (dateResult?.error) {
+      return res.status(400).json({
+        message: dateResult.error,
+      });
+    }
+
+    if (dateResult?.value) {
+      query.startDate = dateResult.value;
+    }
+
+    const events = await GardenCalendar.find(query)
+      .sort({
+        startDate: 1,
+        date: 1,
+        createdAt: -1,
+      })
+      .lean();
+
+    return res.status(200).json(events);
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * GET garden calendar event by ID
+ *
+ * GET /api/kitchenandinventory/gardenmanagement/calendar/:id
+ */
+const getCalendarEventById = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        message: 'Invalid calendar event ID',
+      });
+    }
+
+    const event = await GardenCalendar.findById(id).lean();
+
+    if (!event) {
+      return res.status(404).json({
+        message: 'Calendar event not found',
+      });
+    }
+
+    return res.status(200).json(event);
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * CREATE garden calendar event
+ *
+ * POST /api/kitchenandinventory/gardenmanagement/calendar
+ */
+const createCalendarEvent = async (req, res) => {
+  try {
+    const {
+      type,
+      name,
+      startDate,
+      endDate,
+      location,
+      date,
+      from,
+      to,
+      lastSow,
+      nextSow,
+      interval,
+      expected,
+      yield: expectedYield,
+      status,
+    } = req.body;
+
+    if (!type || !name) {
+      return res.status(400).json({
+        message: 'Event type and name are required',
+      });
+    }
+
+    const typeError = validateEventType(type);
+
+    if (typeError) {
+      return res.status(400).json({
+        message: typeError,
+      });
+    }
+
+    const statusError = validateEventStatus(status);
+
+    if (statusError) {
+      return res.status(400).json({
+        message: statusError,
+      });
+    }
+
+    const parsedDates = parseCreateDates({
+      startDate,
+      endDate,
+      date,
+      lastSow,
+      nextSow,
+      expected,
+    });
+
+    if (parsedDates.error) {
+      return res.status(400).json({
+        message: parsedDates.error,
+      });
+    }
+
+    const {
+      startDate: parsedStartDate,
+      endDate: parsedEndDate,
+      date: parsedDate,
+      lastSow: parsedLastSow,
+      nextSow: parsedNextSow,
+      expected: parsedExpected,
+    } = parsedDates.value;
+
+    const dateOrderError = validateDateOrder(parsedStartDate, parsedEndDate);
+
+    if (dateOrderError) {
+      return res.status(400).json({
+        message: dateOrderError,
+      });
+    }
+
+    const event = await GardenCalendar.create({
+      type,
+      name: name.trim(),
+
+      startDate: parsedStartDate,
+
+      endDate: parsedEndDate,
+
+      location: trimIfString(location),
+
+      date: parsedDate,
+
+      from: trimIfString(from),
+
+      to: trimIfString(to),
+
+      lastSow: parsedLastSow,
+
+      nextSow: parsedNextSow,
+
+      interval: trimIfString(interval),
+
+      expected: parsedExpected,
+
+      yield: trimIfString(expectedYield),
+
+      status: status || 'upcoming',
+    });
+
+    return res.status(201).json(event);
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * UPDATE garden calendar event
+ *
+ * PUT /api/kitchenandinventory/gardenmanagement/calendar/:id
+ */
+const updateCalendarEvent = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        message: 'Invalid calendar event ID',
+      });
+    }
+
+    const updates = getAllowedUpdates(req.body);
+
+    const typeError = validateEventType(updates.type);
+
+    if (typeError) {
+      return res.status(400).json({
+        message: typeError,
+      });
+    }
+
+    const statusError = validateEventStatus(updates.status);
+
+    if (statusError) {
+      return res.status(400).json({
+        message: statusError,
+      });
+    }
+
+    trimUpdateFields(updates);
+
+    const parsedDates = parseUpdateDates(updates);
+
+    if (parsedDates.error) {
+      return res.status(400).json({
+        message: parsedDates.error,
+      });
+    }
+
+    const existingEvent = await GardenCalendar.findById(id);
+
+    if (!existingEvent) {
+      return res.status(404).json({
+        message: 'Calendar event not found',
+      });
+    }
+
+    const finalStartDate =
+      updates.startDate !== undefined ? updates.startDate : existingEvent.startDate;
+
+    const finalEndDate = updates.endDate !== undefined ? updates.endDate : existingEvent.endDate;
+
+    const dateOrderError = validateDateOrder(finalStartDate, finalEndDate);
+
+    if (dateOrderError) {
+      return res.status(400).json({
+        message: dateOrderError,
+      });
+    }
+
+    const event = await GardenCalendar.findByIdAndUpdate(id, updates, {
+      new: true,
+      runValidators: true,
+    });
+
+    return res.status(200).json(event);
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * DELETE garden calendar event
+ *
+ * DELETE /api/kitchenandinventory/gardenmanagement/calendar/:id
+ */
+const deleteCalendarEvent = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        message: 'Invalid calendar event ID',
+      });
+    }
+
+    const event = await GardenCalendar.findByIdAndDelete(id);
+
+    if (!event) {
+      return res.status(404).json({
+        message: 'Calendar event not found',
+      });
+    }
+
+    return res.status(200).json({
+      message: 'Calendar event deleted successfully',
+    });
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * UPDATE garden calendar event status
+ *
+ * PATCH /api/kitchenandinventory/gardenmanagement/calendar/:id/status
+ */
+const updateCalendarEventStatus = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { status } = req.body;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        message: 'Invalid calendar event ID',
+      });
+    }
+
+    if (!EVENT_STATUSES.has(status)) {
+      return res.status(400).json({
+        message: 'Invalid event status',
+      });
+    }
+
+    const event = await GardenCalendar.findByIdAndUpdate(
+      id,
+      { status },
+      {
+        new: true,
+        runValidators: true,
+      },
+    );
+
+    if (!event) {
+      return res.status(404).json({
+        message: 'Calendar event not found',
+      });
+    }
+
+    return res.status(200).json(event);
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+module.exports = {
+  getCalendarEvents,
+  getCalendarEventById,
+  createCalendarEvent,
+  updateCalendarEvent,
+  deleteCalendarEvent,
+  updateCalendarEventStatus,
+};

--- a/src/controllers/gardenManagement/seedInventoryController.js
+++ b/src/controllers/gardenManagement/seedInventoryController.js
@@ -1,0 +1,521 @@
+const mongoose = require('mongoose');
+const SeedInventory = require('../../models/gardenManagement/seedInventory');
+
+const sendServerError = (res, error) => {
+  console.error(error);
+
+  return res.status(500).json({
+    message: 'Internal server error',
+  });
+};
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+
+/**
+ * Validate a date value.
+ */
+const parseDate = (value, fieldName) => {
+  if (value === undefined || value === null || value === '') {
+    return {
+      valid: false,
+      message: `${fieldName} is required`,
+    };
+  }
+
+  const parsedDate = new Date(value);
+
+  return Number.isNaN(parsedDate.getTime())
+    ? {
+        valid: false,
+        message: `Invalid ${fieldName}`,
+      }
+    : {
+        valid: true,
+        value: parsedDate,
+      };
+};
+
+/**
+ * Validate quantity.
+ */
+const validateQuantity = (quantity) =>
+  quantity !== undefined &&
+  quantity !== null &&
+  quantity !== '' &&
+  !Number.isNaN(Number(quantity)) &&
+  Number(quantity) >= 0;
+
+/**
+ * Validate viability percentage.
+ */
+const validateViability = (viable) =>
+  viable !== undefined &&
+  viable !== null &&
+  viable !== '' &&
+  !Number.isNaN(Number(viable)) &&
+  Number(viable) >= 0 &&
+  Number(viable) <= 100;
+
+/**
+ * Validate numeric query parameter.
+ */
+const validateRangeValue = (value, min, max, message) => {
+  if (
+    Number.isNaN(Number(value)) ||
+    Number(value) < min ||
+    (max !== undefined && Number(value) > max)
+  ) {
+    return {
+      valid: false,
+      message,
+    };
+  }
+
+  return {
+    valid: true,
+    value: Number(value),
+  };
+};
+
+/**
+ * Add quantity filters to query.
+ */
+const addQuantityFilters = (query, minQuantity, maxQuantity) => {
+  if (minQuantity === undefined && maxQuantity === undefined) {
+    return null;
+  }
+
+  const quantityQuery = {};
+
+  if (minQuantity !== undefined) {
+    const result = validateRangeValue(minQuantity, 0, undefined, 'Invalid minimum quantity');
+
+    if (!result.valid) {
+      return result;
+    }
+
+    quantityQuery.$gte = result.value;
+  }
+
+  if (maxQuantity !== undefined) {
+    const result = validateRangeValue(maxQuantity, 0, undefined, 'Invalid maximum quantity');
+
+    if (!result.valid) {
+      return result;
+    }
+
+    quantityQuery.$lte = result.value;
+  }
+
+  if (
+    quantityQuery.$gte !== undefined &&
+    quantityQuery.$lte !== undefined &&
+    quantityQuery.$gte > quantityQuery.$lte
+  ) {
+    return {
+      valid: false,
+      message: 'Minimum quantity cannot be greater than maximum quantity',
+    };
+  }
+
+  query.quantity = quantityQuery;
+
+  return {
+    valid: true,
+  };
+};
+
+/**
+ * Add viability filters to query.
+ */
+const addViabilityFilters = (query, minViable, maxViable) => {
+  if (minViable === undefined && maxViable === undefined) {
+    return null;
+  }
+
+  const viableQuery = {};
+
+  if (minViable !== undefined) {
+    const result = validateRangeValue(minViable, 0, 100, 'Invalid minimum viability');
+
+    if (!result.valid) {
+      return result;
+    }
+
+    viableQuery.$gte = result.value;
+  }
+
+  if (maxViable !== undefined) {
+    const result = validateRangeValue(maxViable, 0, 100, 'Invalid maximum viability');
+
+    if (!result.valid) {
+      return result;
+    }
+
+    viableQuery.$lte = result.value;
+  }
+
+  if (
+    viableQuery.$gte !== undefined &&
+    viableQuery.$lte !== undefined &&
+    viableQuery.$gte > viableQuery.$lte
+  ) {
+    return {
+      valid: false,
+      message: 'Minimum viability cannot be greater than maximum viability',
+    };
+  }
+
+  query.viable = viableQuery;
+
+  return {
+    valid: true,
+  };
+};
+
+/**
+ * Build seed inventory search query.
+ */
+const buildInventoryQuery = (queryParams) => {
+  const { search = '', minQuantity, maxQuantity, minViable, maxViable } = queryParams;
+
+  const query = {};
+
+  if (typeof search === 'string' && search.trim()) {
+    query.name = {
+      $regex: escapeRegex(search.trim()),
+      $options: 'i',
+    };
+  }
+
+  const quantityResult = addQuantityFilters(query, minQuantity, maxQuantity);
+
+  if (quantityResult && !quantityResult.valid) {
+    return quantityResult;
+  }
+
+  const viabilityResult = addViabilityFilters(query, minViable, maxViable);
+
+  if (viabilityResult && !viabilityResult.valid) {
+    return viabilityResult;
+  }
+
+  return {
+    valid: true,
+    query,
+  };
+};
+
+/**
+ * GET all seed inventory
+ *
+ * GET /api/kitchenandinventory/gardenmanagement/seeds
+ */
+const getSeedInventory = async (req, res) => {
+  try {
+    const result = buildInventoryQuery(req.query);
+
+    if (!result.valid) {
+      return res.status(400).json({
+        message: result.message,
+      });
+    }
+
+    const seeds = await SeedInventory.find(result.query).sort({ collectedDate: -1 }).lean();
+
+    return res.status(200).json(seeds);
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * GET seed inventory by ID
+ *
+ * GET /api/kitchenandinventory/gardenmanagement/seeds/:id
+ */
+const getSeedInventoryById = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        message: 'Invalid seed inventory ID',
+      });
+    }
+
+    const seed = await SeedInventory.findById(id).lean();
+
+    if (!seed) {
+      return res.status(404).json({
+        message: 'Seed inventory item not found',
+      });
+    }
+
+    return res.status(200).json(seed);
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * Validate create seed inventory request.
+ */
+const validateCreateSeed = (data) => {
+  const { name, collectedDate, quantity, viable } = data;
+
+  if (typeof name !== 'string' || !name.trim()) {
+    return {
+      valid: false,
+      message: 'Seed name is required',
+    };
+  }
+
+  const parsedDate = parseDate(collectedDate, 'collected date');
+
+  if (!parsedDate.valid) {
+    return parsedDate;
+  }
+
+  if (!validateQuantity(quantity)) {
+    return {
+      valid: false,
+      message: 'Quantity must be a non-negative number',
+    };
+  }
+
+  if (!validateViability(viable)) {
+    return {
+      valid: false,
+      message: 'Viability must be a number between 0 and 100',
+    };
+  }
+
+  return {
+    valid: true,
+    value: {
+      name: name.trim(),
+      collectedDate: parsedDate.value,
+      quantity: Number(quantity),
+      viable: Number(viable),
+    },
+  };
+};
+
+/**
+ * CREATE seed inventory
+ *
+ * POST /api/kitchenandinventory/gardenmanagement/seeds
+ */
+const createSeedInventory = async (req, res) => {
+  try {
+    const validation = validateCreateSeed(req.body);
+
+    if (!validation.valid) {
+      return res.status(400).json({
+        message: validation.message,
+      });
+    }
+
+    const seed = await SeedInventory.create(validation.value);
+
+    return res.status(201).json(seed);
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * Validate and prepare seed inventory updates.
+ */
+const prepareSeedUpdates = (body) => {
+  const allowedFields = ['name', 'collectedDate', 'quantity', 'viable'];
+
+  const updates = {};
+
+  allowedFields.forEach((field) => {
+    if (body[field] !== undefined) {
+      updates[field] = body[field];
+    }
+  });
+
+  if (updates.name !== undefined) {
+    if (typeof updates.name !== 'string' || !updates.name.trim()) {
+      return {
+        valid: false,
+        message: 'Seed name cannot be empty',
+      };
+    }
+
+    updates.name = updates.name.trim();
+  }
+
+  if (updates.collectedDate !== undefined) {
+    const parsedDate = parseDate(updates.collectedDate, 'collected date');
+
+    if (!parsedDate.valid) {
+      return parsedDate;
+    }
+
+    updates.collectedDate = parsedDate.value;
+  }
+
+  if (updates.quantity !== undefined) {
+    if (!validateQuantity(updates.quantity)) {
+      return {
+        valid: false,
+        message: 'Quantity must be a non-negative number',
+      };
+    }
+
+    updates.quantity = Number(updates.quantity);
+  }
+
+  if (updates.viable !== undefined) {
+    if (!validateViability(updates.viable)) {
+      return {
+        valid: false,
+        message: 'Viability must be a number between 0 and 100',
+      };
+    }
+
+    updates.viable = Number(updates.viable);
+  }
+
+  if (Object.keys(updates).length === 0) {
+    return {
+      valid: false,
+      message: 'No valid fields provided for update',
+    };
+  }
+
+  return {
+    valid: true,
+    updates,
+  };
+};
+
+/**
+ * UPDATE seed inventory
+ *
+ * PUT /api/kitchenandinventory/gardenmanagement/seeds/:id
+ */
+const updateSeedInventory = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        message: 'Invalid seed inventory ID',
+      });
+    }
+
+    const validation = prepareSeedUpdates(req.body);
+
+    if (!validation.valid) {
+      return res.status(400).json({
+        message: validation.message,
+      });
+    }
+
+    const seed = await SeedInventory.findByIdAndUpdate(id, validation.updates, {
+      new: true,
+      runValidators: true,
+    });
+
+    if (!seed) {
+      return res.status(404).json({
+        message: 'Seed inventory item not found',
+      });
+    }
+
+    return res.status(200).json(seed);
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * DELETE seed inventory
+ *
+ * DELETE /api/kitchenandinventory/gardenmanagement/seeds/:id
+ */
+const deleteSeedInventory = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        message: 'Invalid seed inventory ID',
+      });
+    }
+
+    const seed = await SeedInventory.findByIdAndDelete(id);
+
+    if (!seed) {
+      return res.status(404).json({
+        message: 'Seed inventory item not found',
+      });
+    }
+
+    return res.status(200).json({
+      message: 'Seed inventory item deleted successfully',
+    });
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * UPDATE seed quantity
+ *
+ * PATCH /api/kitchenandinventory/gardenmanagement/seeds/:id/quantity
+ */
+const updateSeedQuantity = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { quantity } = req.body;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        message: 'Invalid seed inventory ID',
+      });
+    }
+
+    if (!validateQuantity(quantity)) {
+      return res.status(400).json({
+        message: 'Quantity must be a non-negative number',
+      });
+    }
+
+    const seed = await SeedInventory.findByIdAndUpdate(
+      id,
+      {
+        quantity: Number(quantity),
+      },
+      {
+        new: true,
+        runValidators: true,
+      },
+    );
+
+    if (!seed) {
+      return res.status(404).json({
+        message: 'Seed inventory item not found',
+      });
+    }
+
+    return res.status(200).json(seed);
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+module.exports = {
+  getSeedInventory,
+  getSeedInventoryById,
+  createSeedInventory,
+  updateSeedInventory,
+  deleteSeedInventory,
+  updateSeedQuantity,
+};

--- a/src/controllers/gardenManagement/seedOrderController.js
+++ b/src/controllers/gardenManagement/seedOrderController.js
@@ -11,8 +11,6 @@ const sendServerError = (res, error) => {
   });
 };
 
-const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
-
 /**
  * Validate order items.
  */
@@ -278,72 +276,13 @@ const validateFinalDates = (updates, existingOrder) => {
 };
 
 /**
- * Build query for seed orders.
- */
-const buildOrderQuery = ({ search, status, supplier }) => {
-  const query = {};
-
-  if (typeof search === 'string' && search.trim()) {
-    const escapedSearch = escapeRegex(search.trim());
-
-    query.$or = [
-      {
-        orderId: {
-          $regex: escapedSearch,
-          $options: 'i',
-        },
-      },
-      {
-        supplier: {
-          $regex: escapedSearch,
-          $options: 'i',
-        },
-      },
-      {
-        'items.name': {
-          $regex: escapedSearch,
-          $options: 'i',
-        },
-      },
-    ];
-  }
-
-  if (typeof status === 'string' && status !== 'All') {
-    query.status = status;
-  }
-
-  if (typeof supplier === 'string' && supplier.trim()) {
-    query.supplier = {
-      $regex: escapeRegex(supplier.trim()),
-      $options: 'i',
-    };
-  }
-
-  return query;
-};
-
-/**
  * GET all seed orders
  *
  * GET /api/kitchenandinventory/gardenmanagement/seed-orders
  */
 const getSeedOrders = async (req, res) => {
   try {
-    const { search = '', status, supplier } = req.query;
-
-    if (typeof status === 'string' && status !== 'All' && !ORDER_STATUSES.has(status)) {
-      return res.status(400).json({
-        message: 'Invalid order status',
-      });
-    }
-
-    const query = buildOrderQuery({
-      search,
-      status,
-      supplier,
-    });
-
-    const orders = await SeedOrder.find(query).sort({ orderDate: -1 }).lean();
+    const orders = await SeedOrder.find().sort({ orderDate: -1 }).lean();
 
     return res.status(200).json(orders);
   } catch (error) {

--- a/src/controllers/gardenManagement/seedOrderController.js
+++ b/src/controllers/gardenManagement/seedOrderController.js
@@ -1,0 +1,603 @@
+const mongoose = require('mongoose');
+const SeedOrder = require('../../models/gardenManagement/seedOrder');
+
+const ORDER_STATUSES = new Set(['pending', 'received', 'cancelled']);
+
+const sendServerError = (res, error) => {
+  console.error(error);
+
+  return res.status(500).json({
+    message: 'Internal server error',
+  });
+};
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, String.raw`\$&`);
+
+/**
+ * Validate order items.
+ */
+const validateItems = (items) => {
+  if (!Array.isArray(items) || items.length === 0) {
+    return 'An order must contain at least one item';
+  }
+
+  for (const item of items) {
+    if (!item || typeof item.name !== 'string' || !item.name.trim()) {
+      return 'Each order item must have a name';
+    }
+
+    if (item.qty === undefined || Number.isNaN(Number(item.qty)) || Number(item.qty) < 1) {
+      return 'Each order item quantity must be at least 1';
+    }
+
+    if (typeof item.unit !== 'string' || !item.unit.trim()) {
+      return 'Each order item must have a unit';
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Normalize order items before saving.
+ */
+const normalizeItems = (items) =>
+  items.map((item) => ({
+    name: item.name.trim(),
+    qty: Number(item.qty),
+    unit: item.unit.trim(),
+  }));
+
+/**
+ * Validate an order ID.
+ */
+const validateOrderId = (orderId) => {
+  if (!orderId || typeof orderId !== 'string' || !orderId.trim()) {
+    return 'Order ID is required';
+  }
+
+  return null;
+};
+
+/**
+ * Validate supplier.
+ */
+const validateSupplier = (supplier) => {
+  if (!supplier || typeof supplier !== 'string' || !supplier.trim()) {
+    return 'Supplier is required';
+  }
+
+  return null;
+};
+
+/**
+ * Validate order status.
+ */
+const validateStatus = (status) => {
+  if (!ORDER_STATUSES.has(status)) {
+    return 'Invalid order status';
+  }
+
+  return null;
+};
+
+/**
+ * Parse a date.
+ */
+const parseDate = (value, fieldName) => {
+  const parsedDate = new Date(value);
+
+  if (Number.isNaN(parsedDate.getTime())) {
+    return {
+      error: `Invalid ${fieldName}`,
+    };
+  }
+
+  return {
+    value: parsedDate,
+  };
+};
+
+/**
+ * Validate delivery date against order date.
+ */
+const validateDeliveryDate = (deliveryDate, orderDate) => {
+  if (deliveryDate && orderDate && deliveryDate < orderDate) {
+    return 'Delivery date cannot be before order date';
+  }
+
+  return null;
+};
+
+/**
+ * Validate create request fields.
+ */
+const validateCreateFields = ({ orderId, supplier, items, orderDate, status }) => {
+  const orderIdError = validateOrderId(orderId);
+
+  if (orderIdError) {
+    return orderIdError;
+  }
+
+  const supplierError = validateSupplier(supplier);
+
+  if (supplierError) {
+    return supplierError;
+  }
+
+  const itemsError = validateItems(items);
+
+  if (itemsError) {
+    return itemsError;
+  }
+
+  if (!orderDate) {
+    return 'Order date is required';
+  }
+
+  const statusError = validateStatus(status);
+
+  if (statusError) {
+    return statusError;
+  }
+
+  return null;
+};
+
+/**
+ * Parse create order dates.
+ */
+const parseCreateDates = (orderDate, deliveryDate) => {
+  const parsedOrderDate = parseDate(orderDate, 'order date');
+
+  if (parsedOrderDate.error) {
+    return {
+      error: parsedOrderDate.error,
+    };
+  }
+
+  if (!deliveryDate) {
+    return {
+      orderDate: parsedOrderDate.value,
+      deliveryDate: undefined,
+    };
+  }
+
+  const parsedDeliveryDate = parseDate(deliveryDate, 'delivery date');
+
+  if (parsedDeliveryDate.error) {
+    return {
+      error: parsedDeliveryDate.error,
+    };
+  }
+
+  const dateError = validateDeliveryDate(parsedDeliveryDate.value, parsedOrderDate.value);
+
+  if (dateError) {
+    return {
+      error: dateError,
+    };
+  }
+
+  return {
+    orderDate: parsedOrderDate.value,
+    deliveryDate: parsedDeliveryDate.value,
+  };
+};
+
+/**
+ * Build create order payload.
+ */
+const buildCreateOrder = ({ orderId, supplier, items, status, dates }) => ({
+  orderId: orderId.trim(),
+  supplier: supplier.trim(),
+  items: normalizeItems(items),
+  orderDate: dates.orderDate,
+  deliveryDate: dates.deliveryDate,
+  status,
+});
+
+/**
+ * Validate update fields.
+ */
+const validateUpdateFields = (updates) => {
+  if (updates.orderId !== undefined) {
+    const error = validateOrderId(updates.orderId);
+
+    if (error) {
+      return error;
+    }
+
+    updates.orderId = updates.orderId.trim();
+  }
+
+  if (updates.supplier !== undefined) {
+    const error = validateSupplier(updates.supplier);
+
+    if (error) {
+      return error;
+    }
+
+    updates.supplier = updates.supplier.trim();
+  }
+
+  if (updates.items !== undefined) {
+    const error = validateItems(updates.items);
+
+    if (error) {
+      return error;
+    }
+
+    updates.items = normalizeItems(updates.items);
+  }
+
+  return null;
+};
+
+/**
+ * Validate and parse update dates.
+ */
+const parseUpdateDates = (updates) => {
+  if (updates.orderDate !== undefined) {
+    const parsedOrderDate = parseDate(updates.orderDate, 'order date');
+
+    if (parsedOrderDate.error) {
+      return parsedOrderDate.error;
+    }
+
+    updates.orderDate = parsedOrderDate.value;
+  }
+
+  if (updates.deliveryDate !== undefined) {
+    if (updates.deliveryDate === null || updates.deliveryDate === '') {
+      updates.deliveryDate = undefined;
+    } else {
+      const parsedDeliveryDate = parseDate(updates.deliveryDate, 'delivery date');
+
+      if (parsedDeliveryDate.error) {
+        return parsedDeliveryDate.error;
+      }
+
+      updates.deliveryDate = parsedDeliveryDate.value;
+    }
+  }
+
+  return null;
+};
+
+/**
+ * Validate final order/delivery dates.
+ */
+const validateFinalDates = (updates, existingOrder) => {
+  const finalOrderDate = updates.orderDate || existingOrder.orderDate;
+
+  const finalDeliveryDate =
+    updates.deliveryDate !== undefined ? updates.deliveryDate : existingOrder.deliveryDate;
+
+  return validateDeliveryDate(finalDeliveryDate, finalOrderDate);
+};
+
+/**
+ * Build query for seed orders.
+ */
+const buildOrderQuery = ({ search, status, supplier }) => {
+  const query = {};
+
+  if (typeof search === 'string' && search.trim()) {
+    const escapedSearch = escapeRegex(search.trim());
+
+    query.$or = [
+      {
+        orderId: {
+          $regex: escapedSearch,
+          $options: 'i',
+        },
+      },
+      {
+        supplier: {
+          $regex: escapedSearch,
+          $options: 'i',
+        },
+      },
+      {
+        'items.name': {
+          $regex: escapedSearch,
+          $options: 'i',
+        },
+      },
+    ];
+  }
+
+  if (typeof status === 'string' && status !== 'All') {
+    query.status = status;
+  }
+
+  if (typeof supplier === 'string' && supplier.trim()) {
+    query.supplier = {
+      $regex: escapeRegex(supplier.trim()),
+      $options: 'i',
+    };
+  }
+
+  return query;
+};
+
+/**
+ * GET all seed orders
+ *
+ * GET /api/kitchenandinventory/gardenmanagement/seed-orders
+ */
+const getSeedOrders = async (req, res) => {
+  try {
+    const { search = '', status, supplier } = req.query;
+
+    if (typeof status === 'string' && status !== 'All' && !ORDER_STATUSES.has(status)) {
+      return res.status(400).json({
+        message: 'Invalid order status',
+      });
+    }
+
+    const query = buildOrderQuery({
+      search,
+      status,
+      supplier,
+    });
+
+    const orders = await SeedOrder.find(query).sort({ orderDate: -1 }).lean();
+
+    return res.status(200).json(orders);
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * GET seed order by ID
+ *
+ * GET /api/kitchenandinventory/gardenmanagement/seed-orders/:id
+ */
+const getSeedOrderById = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        message: 'Invalid seed order ID',
+      });
+    }
+
+    const order = await SeedOrder.findById(id).lean();
+
+    if (!order) {
+      return res.status(404).json({
+        message: 'Seed order not found',
+      });
+    }
+
+    return res.status(200).json(order);
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * CREATE seed order
+ *
+ * POST /api/kitchenandinventory/gardenmanagement/seed-orders
+ */
+const createSeedOrder = async (req, res) => {
+  try {
+    const { orderId, supplier, items, orderDate, deliveryDate, status = 'pending' } = req.body;
+
+    const validationError = validateCreateFields({
+      orderId,
+      supplier,
+      items,
+      orderDate,
+      status,
+    });
+
+    if (validationError) {
+      return res.status(400).json({
+        message: validationError,
+      });
+    }
+
+    const dates = parseCreateDates(orderDate, deliveryDate);
+
+    if (dates.error) {
+      return res.status(400).json({
+        message: dates.error,
+      });
+    }
+
+    const order = await SeedOrder.create(
+      buildCreateOrder({
+        orderId,
+        supplier,
+        items,
+        status,
+        dates,
+      }),
+    );
+
+    return res.status(201).json(order);
+  } catch (error) {
+    if (error?.code === 11000) {
+      return res.status(409).json({
+        message: 'Order ID already exists',
+      });
+    }
+
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * UPDATE seed order
+ *
+ * PUT /api/kitchenandinventory/gardenmanagement/seed-orders/:id
+ */
+const updateSeedOrder = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        message: 'Invalid seed order ID',
+      });
+    }
+
+    const allowedFields = ['orderId', 'supplier', 'items', 'orderDate', 'deliveryDate', 'status'];
+
+    const updates = {};
+
+    allowedFields.forEach((field) => {
+      if (req.body[field] !== undefined) {
+        updates[field] = req.body[field];
+      }
+    });
+
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({
+        message: 'No valid fields provided for update',
+      });
+    }
+
+    const fieldError = validateUpdateFields(updates);
+
+    if (fieldError) {
+      return res.status(400).json({
+        message: fieldError,
+      });
+    }
+
+    const dateError = parseUpdateDates(updates);
+
+    if (dateError) {
+      return res.status(400).json({
+        message: dateError,
+      });
+    }
+
+    if (updates.status !== undefined && !ORDER_STATUSES.has(updates.status)) {
+      return res.status(400).json({
+        message: 'Invalid order status',
+      });
+    }
+
+    const existingOrder = await SeedOrder.findById(id);
+
+    if (!existingOrder) {
+      return res.status(404).json({
+        message: 'Seed order not found',
+      });
+    }
+
+    const finalDateError = validateFinalDates(updates, existingOrder);
+
+    if (finalDateError) {
+      return res.status(400).json({
+        message: finalDateError,
+      });
+    }
+
+    const order = await SeedOrder.findByIdAndUpdate(id, updates, {
+      new: true,
+      runValidators: true,
+    });
+
+    return res.status(200).json(order);
+  } catch (error) {
+    if (error?.code === 11000) {
+      return res.status(409).json({
+        message: 'Order ID already exists',
+      });
+    }
+
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * DELETE seed order
+ *
+ * DELETE /api/kitchenandinventory/gardenmanagement/seed-orders/:id
+ */
+const deleteSeedOrder = async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        message: 'Invalid seed order ID',
+      });
+    }
+
+    const order = await SeedOrder.findByIdAndDelete(id);
+
+    if (!order) {
+      return res.status(404).json({
+        message: 'Seed order not found',
+      });
+    }
+
+    return res.status(200).json({
+      message: 'Seed order deleted successfully',
+    });
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+/**
+ * UPDATE seed order status
+ *
+ * PATCH /api/kitchenandinventory/gardenmanagement/seed-orders/:id/status
+ */
+const updateSeedOrderStatus = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const { status } = req.body;
+
+    if (!mongoose.Types.ObjectId.isValid(id)) {
+      return res.status(400).json({
+        message: 'Invalid seed order ID',
+      });
+    }
+
+    if (!ORDER_STATUSES.has(status)) {
+      return res.status(400).json({
+        message: 'Invalid order status',
+      });
+    }
+
+    const order = await SeedOrder.findByIdAndUpdate(
+      id,
+      { status },
+      {
+        new: true,
+        runValidators: true,
+      },
+    );
+
+    if (!order) {
+      return res.status(404).json({
+        message: 'Seed order not found',
+      });
+    }
+
+    return res.status(200).json(order);
+  } catch (error) {
+    return sendServerError(res, error);
+  }
+};
+
+module.exports = {
+  getSeedOrders,
+  getSeedOrderById,
+  createSeedOrder,
+  updateSeedOrder,
+  deleteSeedOrder,
+  updateSeedOrderStatus,
+};

--- a/src/models/gardenManagement/gardenCalendar.js
+++ b/src/models/gardenManagement/gardenCalendar.js
@@ -1,0 +1,77 @@
+const mongoose = require('mongoose');
+
+const gardenCalendarSchema = new mongoose.Schema(
+  {
+    type: {
+      type: String,
+      enum: ['seeding', 'transplanting', 'succession', 'harvesting'],
+      required: true,
+    },
+
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+
+    startDate: {
+      type: Date,
+    },
+
+    endDate: {
+      type: Date,
+    },
+
+    location: {
+      type: String,
+      trim: true,
+    },
+
+    date: {
+      type: Date,
+    },
+
+    from: {
+      type: String,
+      trim: true,
+    },
+
+    to: {
+      type: String,
+      trim: true,
+    },
+
+    lastSow: {
+      type: Date,
+    },
+
+    nextSow: {
+      type: Date,
+    },
+
+    interval: {
+      type: String,
+      trim: true,
+    },
+
+    expected: {
+      type: Date,
+    },
+
+    yield: {
+      type: String,
+      trim: true,
+    },
+
+    status: {
+      type: String,
+      enum: ['upcoming', 'active', 'growing', 'completed'],
+      default: 'upcoming',
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+module.exports = mongoose.model('GardenCalendar', gardenCalendarSchema);

--- a/src/models/gardenManagement/seedInventory.js
+++ b/src/models/gardenManagement/seedInventory.js
@@ -1,0 +1,34 @@
+const mongoose = require('mongoose');
+
+const seedInventorySchema = new mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+
+    collectedDate: {
+      type: Date,
+      required: true,
+    },
+
+    quantity: {
+      type: Number,
+      required: true,
+      min: 0,
+    },
+
+    viable: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 100,
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+module.exports = mongoose.model('SeedInventory', seedInventorySchema);

--- a/src/models/gardenManagement/seedOrder.js
+++ b/src/models/gardenManagement/seedOrder.js
@@ -1,0 +1,72 @@
+const mongoose = require('mongoose');
+
+const seedOrderItemSchema = new mongoose.Schema(
+  {
+    name: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+
+    qty: {
+      type: Number,
+      required: true,
+      min: 1,
+    },
+
+    unit: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+  },
+  {
+    _id: false,
+  },
+);
+
+const seedOrderSchema = new mongoose.Schema(
+  {
+    orderId: {
+      type: String,
+      required: true,
+      unique: true,
+      trim: true,
+    },
+
+    supplier: {
+      type: String,
+      required: true,
+      trim: true,
+    },
+
+    items: {
+      type: [seedOrderItemSchema],
+      required: true,
+      validate: {
+        validator: (items) => items.length > 0,
+        message: 'An order must contain at least one item',
+      },
+    },
+
+    orderDate: {
+      type: Date,
+      required: true,
+    },
+
+    deliveryDate: {
+      type: Date,
+    },
+
+    status: {
+      type: String,
+      enum: ['pending', 'received', 'cancelled'],
+      default: 'pending',
+    },
+  },
+  {
+    timestamps: true,
+  },
+);
+
+module.exports = mongoose.model('SeedOrder', seedOrderSchema);

--- a/src/routes/gardenManagement/gardenCalendarRouter.js
+++ b/src/routes/gardenManagement/gardenCalendarRouter.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const {
+  getCalendarEvents,
+  getCalendarEventById,
+  createCalendarEvent,
+  updateCalendarEvent,
+  deleteCalendarEvent,
+  updateCalendarEventStatus,
+} = require('../../controllers/gardenManagement/gardenCalendarController');
+
+const router = express.Router();
+
+router.get('/', getCalendarEvents);
+
+router.get('/:id', getCalendarEventById);
+
+router.post('/', createCalendarEvent);
+
+router.put('/:id', updateCalendarEvent);
+
+router.delete('/:id', deleteCalendarEvent);
+
+router.patch('/:id/status', updateCalendarEventStatus);
+
+module.exports = router;

--- a/src/routes/gardenManagement/seedInventoryRouter.js
+++ b/src/routes/gardenManagement/seedInventoryRouter.js
@@ -1,0 +1,49 @@
+const express = require('express');
+const {
+  getSeedInventory,
+  getSeedInventoryById,
+  createSeedInventory,
+  updateSeedInventory,
+  deleteSeedInventory,
+  updateSeedQuantity,
+} = require('../../controllers/gardenManagement/seedInventoryController');
+
+const router = express.Router();
+
+/**
+ * GET all seed inventory
+ * GET /api/kitchenandinventory/gardenmanagement/seeds
+ */
+router.get('/', getSeedInventory);
+
+/**
+ * GET seed inventory by ID
+ * GET /api/kitchenandinventory/gardenmanagement/seeds/:id
+ */
+router.get('/:id', getSeedInventoryById);
+
+/**
+ * CREATE seed inventory
+ * POST /api/kitchenandinventory/gardenmanagement/seeds
+ */
+router.post('/', createSeedInventory);
+
+/**
+ * UPDATE seed inventory
+ * PUT /api/kitchenandinventory/gardenmanagement/seeds/:id
+ */
+router.put('/:id', updateSeedInventory);
+
+/**
+ * DELETE seed inventory
+ * DELETE /api/kitchenandinventory/gardenmanagement/seeds/:id
+ */
+router.delete('/:id', deleteSeedInventory);
+
+/**
+ * UPDATE seed quantity
+ * PATCH /api/kitchenandinventory/gardenmanagement/seeds/:id/quantity
+ */
+router.patch('/:id/quantity', updateSeedQuantity);
+
+module.exports = router;

--- a/src/routes/gardenManagement/seedOrderRouter.js
+++ b/src/routes/gardenManagement/seedOrderRouter.js
@@ -1,0 +1,49 @@
+const express = require('express');
+const {
+  getSeedOrders,
+  getSeedOrderById,
+  createSeedOrder,
+  updateSeedOrder,
+  deleteSeedOrder,
+  updateSeedOrderStatus,
+} = require('../../controllers/gardenManagement/seedOrderController');
+
+const router = express.Router();
+
+/**
+ * GET all seed orders
+ * GET /api/kitchenandinventory/gardenmanagement/seed-orders
+ */
+router.get('/', getSeedOrders);
+
+/**
+ * GET seed order by ID
+ * GET /api/kitchenandinventory/gardenmanagement/seed-orders/:id
+ */
+router.get('/:id', getSeedOrderById);
+
+/**
+ * CREATE seed order
+ * POST /api/kitchenandinventory/gardenmanagement/seed-orders
+ */
+router.post('/', createSeedOrder);
+
+/**
+ * UPDATE seed order
+ * PUT /api/kitchenandinventory/gardenmanagement/seed-orders/:id
+ */
+router.put('/:id', updateSeedOrder);
+
+/**
+ * DELETE seed order
+ * DELETE /api/kitchenandinventory/gardenmanagement/seed-orders/:id
+ */
+router.delete('/:id', deleteSeedOrder);
+
+/**
+ * UPDATE seed order status
+ * PATCH /api/kitchenandinventory/gardenmanagement/seed-orders/:id/status
+ */
+router.patch('/:id/status', updateSeedOrderStatus);
+
+module.exports = router;

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -442,10 +442,8 @@ const recipeRouter = require('../routes/kitchenInventory/recipeRouter')();
 
 const jobHitsAndApplicationsRoutes = require('../routes/jobAnalytics/JobHitsAndApplicationsRoutes');
 
-
 // Education Portal
 const educatorRoutes = require('../routes/educatorRoutes');
-
 
 // Class Aggregation Reports
 const classAggregationRouter = require('../routes/classAgreegraterRouter');
@@ -463,6 +461,10 @@ const resourceRequestRouter = require('../routes/resourceRequestRouter')(
   userProfile,
   resourceRequestController,
 );
+
+const gardenCalendarRouter = require('../routes/gardenManagement/gardenCalendarRouter');
+const seedInventoryRouter = require('../routes/gardenManagement/seedInventoryRouter');
+const seedOrderRouter = require('../routes/gardenManagement/seedOrderRouter');
 
 module.exports = function (app) {
   app.use('/api/bm/summary-dashboard', summaryDashboardRouter);
@@ -715,4 +717,9 @@ module.exports = function (app) {
   app.use('/api/kitchenandinventory/recipes', recipeRouter);
 
   app.use('/api/analytics', analyticsRouter);
+
+  // Kitchen and Inventory - Garden Management
+  app.use('/api/kitchenandinventory/gardenmanagement/calendar', gardenCalendarRouter);
+  app.use('/api/kitchenandinventory/gardenmanagement/seeds', seedInventoryRouter);
+  app.use('/api/kitchenandinventory/gardenmanagement/orders', seedOrderRouter);
 };


### PR DESCRIPTION
# Description
<img width="717" height="517" alt="Screenshot 2026-07-31 at 1 25 49 PM" src="https://github.com/user-attachments/assets/94e55be1-157e-4b67-ba7c-b294e6057db3" />

## Related PR
- https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5422
- https://github.com/OneCommunityGlobal/HGNRest/pull/2308

## Main changes explained:
- Added Seed Orders section to the Garden Management page.
- Added Online Tools section with gardening resources and external tool links.
- Created `GardenManagementPage.module.css` with scoped CSS module styling.
- Implemented responsive layouts for laptop, tablet, and smaller screens.
- Added light and dark mode support across the new sections.
- Seed Orders section displays:
  - Order ID
  - Supplier name
  - Ordered items
  - Order dates
  - Order status badges
  - View Details button
  - Mark as Received button for pending orders
- Online Tools section displays:
  - Tool name
  - Description
  - Key features
  - External links to gardening tools
- Ensured all styling follows CSS module conventions for component-level scoping.

## How to test:
1. Check out the current branch.
2. Run `npm install` and `npm start` to launch the application.
3. Clear browser cache/site data if needed.
4. Log in as an admin user.
5. Navigate to `/kitchenandinventory/gardenmanagement`.
6. Open the Garden Management page.
7. Verify the Seed Orders section:
   - Confirm order cards display correctly.
   - Verify supplier details, items, dates, and status badges.
   - Test View Details and Mark as Received buttons.
8. Verify the Online Tools section:
   - Confirm tool cards display correctly.
   - Verify external links open properly.
9. Toggle between light and dark modes and verify readability.
10. Resize the browser window to confirm responsive behavior.

## Result:
https://youtu.be/KcSC8IQMKxg

## Note:
This PR implements the frontend UI for Seed Orders and Online Tools sections using mock data. Backend integration and API connectivity can be added in a follow-up PR.