### PR TITLE
Bosu fix: secure HGN help request eligibility backend

### DIFF
--- a/src/controllers/helpRequestController.js
+++ b/src/controllers/helpRequestController.js
@@ -1,10 +1,20 @@
 const mongoose = require('mongoose');
 const HelpRequest = require('../models/helpRequest');
 const HelpFeedback = require('../models/helpFeedback');
+const { getHelpRequestEligibility } = require('../helpers/helpRequestEligibility');
 
 const createHelpRequest = async (req, res) => {
   try {
-    const { userId, topic, description } = req.body;
+    const { topic, description } = req.body;
+    const userId = req.user?.requestorId;
+
+    const { eligible } = await getHelpRequestEligibility(userId);
+    if (!eligible) {
+      return res.status(403).json({
+        message:
+          'You must complete the HGN questionnaire and belong to an eligible HGN team or role to submit a help request.',
+      });
+    }
 
     const helpRequest = new HelpRequest({
       userId,
@@ -14,6 +24,16 @@ const createHelpRequest = async (req, res) => {
 
     await helpRequest.save();
     res.status(201).json(helpRequest);
+  } catch (error) {
+    res.status(500).json({ error: error.message });
+  }
+};
+
+const checkHelpRequestEligibility = async (req, res) => {
+  try {
+    const userId = req.user?.requestorId;
+    const result = await getHelpRequestEligibility(userId);
+    res.status(200).json(result);
   } catch (error) {
     res.status(500).json({ error: error.message });
   }
@@ -94,4 +114,5 @@ module.exports = {
   checkIfModalShouldShow,
   updateRequestDate,
   getAllHelpRequests,
+  checkHelpRequestEligibility,
 };

--- a/src/controllers/helpRequestController.spec.js
+++ b/src/controllers/helpRequestController.spec.js
@@ -1,0 +1,157 @@
+jest.mock('../models/helpRequest');
+jest.mock('../models/helpFeedback');
+jest.mock('../helpers/helpRequestEligibility', () => ({
+  getHelpRequestEligibility: jest.fn(),
+}));
+
+const HelpRequest = require('../models/helpRequest');
+const { getHelpRequestEligibility } = require('../helpers/helpRequestEligibility');
+const { createHelpRequest, checkHelpRequestEligibility } = require('./helpRequestController');
+
+const makeRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('helpRequestController', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createHelpRequest', () => {
+    it('creates the help request for an authenticated, eligible caller (201)', async () => {
+      getHelpRequestEligibility.mockResolvedValue({ eligible: true, questionnaireCompleted: true });
+      const savedRequest = { _id: 'hr1', userId: 'authenticatedUser1', topic: 'HTML Semantics' };
+      HelpRequest.mockImplementation(() => ({
+        ...savedRequest,
+        save: jest.fn().mockResolvedValue(savedRequest),
+      }));
+
+      const req = {
+        user: { requestorId: 'authenticatedUser1' },
+        body: { topic: 'HTML Semantics', description: 'desc' },
+      };
+      const res = makeRes();
+
+      await createHelpRequest(req, res);
+
+      expect(getHelpRequestEligibility).toHaveBeenCalledWith('authenticatedUser1');
+      expect(HelpRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'authenticatedUser1' }),
+      );
+      expect(res.status).toHaveBeenCalledWith(201);
+    });
+
+    it('rejects an authenticated but ineligible caller with 403 and does not create a request', async () => {
+      getHelpRequestEligibility.mockResolvedValue({
+        eligible: false,
+        questionnaireCompleted: false,
+      });
+
+      const req = {
+        user: { requestorId: 'ineligibleCallerId' },
+        body: { topic: 'HTML Semantics', description: 'desc' },
+      };
+      const res = makeRes();
+
+      await createHelpRequest(req, res);
+
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ message: expect.any(String) }),
+      );
+      expect(HelpRequest).not.toHaveBeenCalled();
+    });
+
+    it('ignores a spoofed body.userId: eligibility is checked only for the authenticated caller', async () => {
+      getHelpRequestEligibility.mockResolvedValue({ eligible: true, questionnaireCompleted: true });
+      HelpRequest.mockImplementation(() => ({ save: jest.fn().mockResolvedValue({}) }));
+
+      const req = {
+        user: { requestorId: 'ineligibleCallerId' },
+        body: { userId: 'eligibleVictimId', topic: 'HTML Semantics', description: 'desc' },
+      };
+      const res = makeRes();
+
+      await createHelpRequest(req, res);
+
+      expect(getHelpRequestEligibility).toHaveBeenCalledWith('ineligibleCallerId');
+      expect(getHelpRequestEligibility).not.toHaveBeenCalledWith('eligibleVictimId');
+    });
+
+    it('ignores a spoofed body.userId when saving: HelpRequest.userId is the authenticated caller', async () => {
+      getHelpRequestEligibility.mockResolvedValue({ eligible: true, questionnaireCompleted: true });
+      HelpRequest.mockImplementation(() => ({ save: jest.fn().mockResolvedValue({}) }));
+
+      const req = {
+        user: { requestorId: 'authenticatedUser1' },
+        body: { userId: 'eligibleVictimId', topic: 'HTML Semantics', description: 'desc' },
+      };
+      const res = makeRes();
+
+      await createHelpRequest(req, res);
+
+      expect(HelpRequest).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'authenticatedUser1' }),
+      );
+      expect(HelpRequest).not.toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 'eligibleVictimId' }),
+      );
+    });
+
+    it('treats a missing authenticated identity as ineligible rather than trusting the request body', async () => {
+      getHelpRequestEligibility.mockResolvedValue({
+        eligible: false,
+        questionnaireCompleted: false,
+      });
+
+      const req = {
+        user: undefined,
+        body: { userId: 'eligibleVictimId', topic: 'HTML Semantics' },
+      };
+      const res = makeRes();
+
+      await createHelpRequest(req, res);
+
+      expect(getHelpRequestEligibility).toHaveBeenCalledWith(undefined);
+      expect(res.status).toHaveBeenCalledWith(403);
+      expect(HelpRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('checkHelpRequestEligibility', () => {
+    it('returns the eligibility result for the authenticated caller', async () => {
+      getHelpRequestEligibility.mockResolvedValue({ eligible: true, questionnaireCompleted: true });
+
+      const req = { user: { requestorId: 'authenticatedUser1' } };
+      const res = makeRes();
+
+      await checkHelpRequestEligibility(req, res);
+
+      expect(getHelpRequestEligibility).toHaveBeenCalledWith('authenticatedUser1');
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ eligible: true, questionnaireCompleted: true });
+    });
+
+    it("cannot be used to query another user's eligibility via the request", async () => {
+      getHelpRequestEligibility.mockResolvedValue({
+        eligible: false,
+        questionnaireCompleted: false,
+      });
+
+      // No :userId param exists on this route anymore; only req.user is consulted.
+      const req = {
+        user: { requestorId: 'authenticatedUser1' },
+        params: { userId: 'otherUserId' },
+      };
+      const res = makeRes();
+
+      await checkHelpRequestEligibility(req, res);
+
+      expect(getHelpRequestEligibility).toHaveBeenCalledWith('authenticatedUser1');
+      expect(getHelpRequestEligibility).not.toHaveBeenCalledWith('otherUserId');
+    });
+  });
+});

--- a/src/controllers/hgnFormResponseController.eligibility.spec.js
+++ b/src/controllers/hgnFormResponseController.eligibility.spec.js
@@ -1,0 +1,77 @@
+// Proves the real HGN questionnaire submission path (hgnFormResponseController) and the
+// help-request eligibility check (helpRequestEligibility) read/write the same persisted
+// source: the same model (models/hgnFormResponse), keyed on the same `user_id` field.
+jest.mock('../models/hgnFormResponse');
+jest.mock('../models/userProfile', () => ({
+  findById: jest.fn(),
+}));
+jest.mock('../utilities/permissions', () => ({
+  hasPermission: jest.fn(),
+}));
+
+const FormResponse = require('../models/hgnFormResponse');
+const UserProfile = require('../models/userProfile');
+const { getHelpRequestEligibility } = require('../helpers/helpRequestEligibility');
+const hgnFormController = require('./hgnFormResponseController');
+
+const makeRes = () => {
+  const res = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res;
+};
+
+describe('HGN questionnaire submission -> help request eligibility (same persisted source)', () => {
+  const AUTHENTICATED_USER_ID = '507f1f77bcf86cd799439011';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('a submitted HGNFormResponses document (real submission shape) yields questionnaireCompleted: true', async () => {
+    // Mirrors the exact payload shape sent by FollowupQuestions.jsx (groupFormDataByPage).
+    const submissionBody = {
+      user_id: AUTHENTICATED_USER_ID,
+      userInfo: { name: 'Test User', email: 'test@example.com', github: '', slack: '' },
+      general: { hours: '10', period: 'week' },
+      frontend: { overall: '5' },
+      backend: { Overall: '5' },
+      followUp: { platform: 'Slack' },
+    };
+
+    const savedDoc = { ...submissionBody, _id: 'formresponse1' };
+    FormResponse.mockImplementation(() => ({
+      ...savedDoc,
+      save: jest.fn().mockResolvedValue(savedDoc),
+    }));
+
+    const { submitFormResponse } = hgnFormController();
+    const req = { body: submissionBody };
+    const res = makeRes();
+
+    await submitFormResponse(req, res);
+
+    expect(FormResponse).toHaveBeenCalledWith(
+      expect.objectContaining({ user_id: AUTHENTICATED_USER_ID }),
+    );
+    expect(res.status).toHaveBeenCalledWith(201);
+
+    // Now the eligibility helper reads the same model, keyed on the same user_id.
+    FormResponse.findOne = jest
+      .fn()
+      .mockReturnValue({ lean: jest.fn().mockResolvedValue(savedDoc) });
+    UserProfile.findById.mockReturnValue({
+      populate: jest.fn().mockReturnThis(),
+      lean: jest.fn().mockResolvedValue({ role: 'Owner', isActive: true, teams: [] }),
+    });
+
+    const eligibility = await getHelpRequestEligibility(AUTHENTICATED_USER_ID);
+
+    expect(FormResponse.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        $or: expect.arrayContaining([{ user_id: expect.anything() }]),
+      }),
+    );
+    expect(eligibility).toEqual({ eligible: true, questionnaireCompleted: true });
+  });
+});

--- a/src/helpers/helpRequestEligibility.js
+++ b/src/helpers/helpRequestEligibility.js
@@ -1,0 +1,54 @@
+const mongoose = require('mongoose');
+const UserProfile = require('../models/userProfile');
+const HGNFormResponses = require('../models/hgnFormResponse');
+
+const SOFTWARE_DEV_TEAM_MATCH = 'software development team';
+
+const normalize = (value) => (typeof value === 'string' ? value.trim().toLowerCase() : '');
+
+// Authoritative, server-side computation of HGN Help request eligibility.
+// Never trust a client-supplied role/team/isActive/questionnaire value for this check.
+const getHelpRequestEligibility = async (userId) => {
+  if (!userId || !mongoose.Types.ObjectId.isValid(String(userId))) {
+    return { eligible: false, questionnaireCompleted: false };
+  }
+
+  const userObjectId = mongoose.Types.ObjectId(String(userId));
+
+  const [profile, formResponse] = await Promise.all([
+    UserProfile.findById(userObjectId, 'role isActive teams')
+      .populate({ path: 'teams', select: 'teamName' })
+      .lean(),
+    HGNFormResponses.findOne({
+      $or: [{ user_id: userObjectId }, { user_id: String(userId) }],
+    }).lean(),
+  ]);
+
+  const questionnaireCompleted = Boolean(formResponse);
+
+  if (!profile) {
+    return { eligible: false, questionnaireCompleted };
+  }
+
+  const role = normalize(profile.role);
+  const isCoreTeam = role === 'core team';
+  const isAdministrator = role === 'administrator';
+  const isOwner = role === 'owner';
+
+  const teams = Array.isArray(profile.teams) ? profile.teams : [];
+  // "Active SD" is a strict subset of SD membership here (SD members are eligible regardless of
+  // isActive), so it does not need its own branch to satisfy the confirmed business rule.
+  const isSoftwareDevelopmentMember = teams.some((team) =>
+    normalize(team?.teamName).includes(SOFTWARE_DEV_TEAM_MATCH),
+  );
+
+  const belongsToAllowedGroup =
+    isCoreTeam || isAdministrator || isOwner || isSoftwareDevelopmentMember;
+
+  return {
+    eligible: questionnaireCompleted && belongsToAllowedGroup,
+    questionnaireCompleted,
+  };
+};
+
+module.exports = { getHelpRequestEligibility };

--- a/src/helpers/helpRequestEligibility.spec.js
+++ b/src/helpers/helpRequestEligibility.spec.js
@@ -1,0 +1,129 @@
+jest.mock('../models/userProfile', () => ({
+  findById: jest.fn(),
+}));
+jest.mock('../models/hgnFormResponse', () => ({
+  findOne: jest.fn(),
+}));
+
+const UserProfile = require('../models/userProfile');
+const HGNFormResponses = require('../models/hgnFormResponse');
+const { getHelpRequestEligibility } = require('./helpRequestEligibility');
+
+const VALID_OID = '507f1f77bcf86cd799439011';
+
+const mockProfileQuery = (profile) => ({
+  populate: jest.fn().mockReturnThis(),
+  lean: jest.fn().mockResolvedValue(profile),
+});
+
+describe('getHelpRequestEligibility', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns ineligible for a missing/invalid userId', async () => {
+    const result = await getHelpRequestEligibility(undefined);
+    expect(result).toEqual({ eligible: false, questionnaireCompleted: false });
+  });
+
+  it('returns ineligible for a malformed userId', async () => {
+    const result = await getHelpRequestEligibility('not-a-valid-id');
+    expect(result).toEqual({ eligible: false, questionnaireCompleted: false });
+  });
+
+  it('denies safely when the user profile does not exist', async () => {
+    UserProfile.findById.mockReturnValue(mockProfileQuery(null));
+    HGNFormResponses.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
+
+    const result = await getHelpRequestEligibility(VALID_OID);
+    expect(result).toEqual({ eligible: false, questionnaireCompleted: false });
+  });
+
+  it('denies when the questionnaire has not been completed, even for an eligible role', async () => {
+    UserProfile.findById.mockReturnValue(
+      mockProfileQuery({ role: 'Administrator', isActive: true, teams: [] }),
+    );
+    HGNFormResponses.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue(null) });
+
+    const result = await getHelpRequestEligibility(VALID_OID);
+    expect(result).toEqual({ eligible: false, questionnaireCompleted: false });
+  });
+
+  it('denies a questionnaire-completed user outside all allowed groups', async () => {
+    UserProfile.findById.mockReturnValue(
+      mockProfileQuery({ role: 'Volunteer', isActive: true, teams: [{ teamName: 'Marketing' }] }),
+    );
+    HGNFormResponses.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue({ _id: 'x' }) });
+
+    const result = await getHelpRequestEligibility(VALID_OID);
+    expect(result).toEqual({ eligible: false, questionnaireCompleted: true });
+  });
+
+  it('allows a Core Team member who completed the questionnaire', async () => {
+    UserProfile.findById.mockReturnValue(
+      mockProfileQuery({ role: 'Core Team', isActive: true, teams: [] }),
+    );
+    HGNFormResponses.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue({ _id: 'x' }) });
+
+    const result = await getHelpRequestEligibility(VALID_OID);
+    expect(result).toEqual({ eligible: true, questionnaireCompleted: true });
+  });
+
+  it('allows an Administrator who completed the questionnaire', async () => {
+    UserProfile.findById.mockReturnValue(
+      mockProfileQuery({ role: 'Administrator', isActive: true, teams: [] }),
+    );
+    HGNFormResponses.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue({ _id: 'x' }) });
+
+    const result = await getHelpRequestEligibility(VALID_OID);
+    expect(result).toEqual({ eligible: true, questionnaireCompleted: true });
+  });
+
+  it('allows an Owner who completed the questionnaire', async () => {
+    UserProfile.findById.mockReturnValue(
+      mockProfileQuery({ role: 'Owner', isActive: true, teams: [] }),
+    );
+    HGNFormResponses.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue({ _id: 'x' }) });
+
+    const result = await getHelpRequestEligibility(VALID_OID);
+    expect(result).toEqual({ eligible: true, questionnaireCompleted: true });
+  });
+
+  it('allows a Software Development Team member (non-exact team name) who completed the questionnaire', async () => {
+    UserProfile.findById.mockReturnValue(
+      mockProfileQuery({
+        role: 'Volunteer',
+        isActive: false,
+        teams: [{ teamName: 'HGN Software Development Team' }],
+      }),
+    );
+    HGNFormResponses.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue({ _id: 'x' }) });
+
+    const result = await getHelpRequestEligibility(VALID_OID);
+    expect(result).toEqual({ eligible: true, questionnaireCompleted: true });
+  });
+
+  it('allows an active Software Development Team member who completed the questionnaire', async () => {
+    UserProfile.findById.mockReturnValue(
+      mockProfileQuery({
+        role: 'Volunteer',
+        isActive: true,
+        teams: [{ teamName: 'HGN Software Development Team' }],
+      }),
+    );
+    HGNFormResponses.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue({ _id: 'x' }) });
+
+    const result = await getHelpRequestEligibility(VALID_OID);
+    expect(result).toEqual({ eligible: true, questionnaireCompleted: true });
+  });
+
+  it('handles unknown/malformed team information safely', async () => {
+    UserProfile.findById.mockReturnValue(
+      mockProfileQuery({ role: 'Volunteer', isActive: true, teams: [null, { teamName: null }] }),
+    );
+    HGNFormResponses.findOne.mockReturnValue({ lean: jest.fn().mockResolvedValue({ _id: 'x' }) });
+
+    const result = await getHelpRequestEligibility(VALID_OID);
+    expect(result).toEqual({ eligible: false, questionnaireCompleted: true });
+  });
+});

--- a/src/middleware/authenticateHelpRequest.js
+++ b/src/middleware/authenticateHelpRequest.js
@@ -1,0 +1,16 @@
+const jwtVerificationLogic = require('../utilities/jwtVerificationLogic');
+
+// Reuses the repo-wide JWT verification pattern so req.user reflects the authenticated caller,
+// not client-supplied data. Scoped to routes that must not trust a client-provided identity.
+const authenticateHelpRequest = (req, res, next) => {
+  const payload = jwtVerificationLogic(req.header('Authorization'), res);
+  if (res.headersSent) return;
+  req.user = {
+    requestorId: payload.userid,
+    role: payload.role,
+    permissions: payload.permissions,
+  };
+  next();
+};
+
+module.exports = authenticateHelpRequest;

--- a/src/middleware/authenticateHelpRequest.spec.js
+++ b/src/middleware/authenticateHelpRequest.spec.js
@@ -1,0 +1,50 @@
+jest.mock('../utilities/jwtVerificationLogic');
+
+const jwtVerificationLogic = require('../utilities/jwtVerificationLogic');
+const authenticateHelpRequest = require('./authenticateHelpRequest');
+
+const makeReqResNext = (authHeader) => {
+  const req = { header: jest.fn().mockReturnValue(authHeader) };
+  const res = { headersSent: false, status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const next = jest.fn();
+  return { req, res, next };
+};
+
+describe('authenticateHelpRequest middleware', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('populates req.user from the verified JWT payload and calls next()', () => {
+    jwtVerificationLogic.mockReturnValue({
+      userid: 'authenticatedUser1',
+      role: 'Volunteer',
+      permissions: { frontPermissions: [] },
+    });
+    const { req, res, next } = makeReqResNext('Bearer valid.token');
+
+    authenticateHelpRequest(req, res, next);
+
+    expect(req.user).toEqual({
+      requestorId: 'authenticatedUser1',
+      role: 'Volunteer',
+      permissions: { frontPermissions: [] },
+    });
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('rejects a missing/invalid token without calling next()', () => {
+    jwtVerificationLogic.mockImplementation((authHeader, res) => {
+      res.status(401).json({ error: 'Invalid token' });
+      res.headersSent = true;
+      return undefined;
+    });
+    const { req, res, next } = makeReqResNext(undefined);
+
+    authenticateHelpRequest(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+    expect(req.user).toBeUndefined();
+  });
+});

--- a/src/routes/helpRequestRouter.js
+++ b/src/routes/helpRequestRouter.js
@@ -1,25 +1,20 @@
 const express = require('express');
-
-const router = express.Router();
+const authenticateHelpRequest = require('../middleware/authenticateHelpRequest');
 const {
   createHelpRequest,
   checkIfModalShouldShow,
   updateRequestDate,
   getAllHelpRequests,
+  checkHelpRequestEligibility,
 } = require('../controllers/helpRequestController');
 
-// Temporarily bypass auth for testing
-router.post(
-  '/create',
-  (req, res, next) => {
-    req.body.requestor = { requestorId: req.body.userId };
-    next();
-  },
-  createHelpRequest,
-);
+const router = express.Router();
+
+router.post('/create', authenticateHelpRequest, createHelpRequest);
 
 router.get('/check-modal/:userId', checkIfModalShouldShow);
 router.put('/update-date', updateRequestDate);
 router.get('/all', getAllHelpRequests);
+router.get('/eligibility', authenticateHelpRequest, checkHelpRequestEligibility);
 
 module.exports = router;


### PR DESCRIPTION
## Description

Fixes and secures the backend eligibility flow for the HGN Questionnaire Dashboard `/hgnhelp` functionality.

Previously, HGN Help request creation did not enforce questionnaire/role/team eligibility on the backend, and the Help Request router used a temporary authentication bypass that allowed client-provided user IDs to influence request creation.

This update adds server-side HGN Help eligibility validation, authenticates the caller using the existing JWT verification pattern, and ensures help requests can only be created for the authenticated user.

Fixes: (PRIORITY URGENT) HGN Questionnaire Dashboard - Fix Access Restriction Too Strict on `/hgnhelp`

## Related PRS (if any):

- Related original frontend PR: #3360
- This backend PR is related to frontend PR #5449.
- Both PRs should be tested together.

## Main changes explained:

- Added a centralized HGN Help eligibility helper.
- Added authenticated eligibility endpoint: `GET /api/helprequest/eligibility`.
- Added JWT authentication middleware specifically for HGN Help eligibility and request creation.
- Updated `POST /api/helprequest/create` to use the authenticated user's ID instead of trusting a client-provided `userId`.
- Added server-side validation requiring questionnaire completion and an eligible role/team.
- Added `403` handling for ineligible users.
- Prevented user-ID spoofing when creating help requests.
- Added focused tests covering eligibility, authentication, questionnaire completion, allowed/denied roles, and user-ID spoofing.
- Preserved unrelated Help Request routes and functionality.

## How to test:

1. Checkout the backend branch:
   `Bosu-fix-hgnhelp-access-restriction-backend`

2. Checkout the related frontend PR #FRONTEND_PR_NUMBER.

3. Run the backend:
   `nvm use 20`
   `npm install`
   `npm run build`
   `npm start`

4. Run the frontend locally.

5. Log in using an eligible test account that has not completed the questionnaire.

6. Verify:
   `GET /api/helprequest/eligibility`
   returns `eligible: false` and `questionnaireCompleted: false`.

7. Complete and successfully submit the HGN questionnaire.

8. Verify the eligibility endpoint now returns:
   `eligible: true`
   and
   `questionnaireCompleted: true`.

9. Submit an HGN Help request and verify:
   `POST /api/helprequest/create`
   returns HTTP `201`.

10. Verify the backend determines the user from the authenticated JWT and does not rely on a client-provided `userId`.

11. Verify an ineligible authenticated user receives HTTP `403`.

12. Verify changing/spoofing `userId` in the request body cannot submit a request on behalf of another eligible user.
<img width="1510" height="620" alt="Screenshot 2026-08-16 at 12 09 21 AM" src="https://github.com/user-attachments/assets/9d082cd4-f6a9-4dd4-abd2-4528fd24efe8" />
<img width="472" height="359" alt="Screenshot 2026-08-15 at 7 42 46 PM" src="https://github.com/user-attachments/assets/2cf0f5fc-632a-42ea-9699-5f6f02300e0b" />

## Note:

This backend PR should be tested together with frontend PR #FRONTEND_PR_NUMBER. Authentication and eligibility are determined server-side to prevent frontend-only access restrictions from being bypassed.