### PR TITLE
Purav filter resolved tasks from Dashboard teams tasks endpoint

### DIFF
--- a/src/helpers/taskHelper.js
+++ b/src/helpers/taskHelper.js
@@ -7,6 +7,13 @@ const Task = require('../models/task');
 const TaskNotification = require('../models/taskNotification');
 const { hasPermission } = require('../utilities/permissions');
 
+const isTaskCompletedForUser = (task, userIdStr) => {
+  const userResource = (task.resources || []).find((r) => r.userID?.toString() === userIdStr);
+  return Boolean(userResource && userResource.completedTask === true);
+};
+
+const isTaskActiveForUser = (task, userIdStr) => !isTaskCompletedForUser(task, userIdStr);
+
 const taskHelper = function () {
   const getTasksForTeams = async function (userId, requestor) {
     const userid = mongoose.Types.ObjectId(userId);
@@ -218,6 +225,7 @@ const taskHelper = function () {
       });
 
       const taskByPerson = {};
+      const completedCountByPerson = {};
       teamMemberTasks.forEach((teamMemberTask) => {
         const projId = teamMemberTask.wbsId?.projectId;
         const _teamMemberTask = { ...teamMemberTask._doc };
@@ -226,16 +234,23 @@ const taskHelper = function () {
 
         teamMemberTask.resources.forEach((resource) => {
           const resourceIdStr = resource.userID?.toString();
+          if (!resourceIdStr) return;
+
+          if (isTaskCompletedForUser(_teamMemberTask, resourceIdStr)) {
+            completedCountByPerson[resourceIdStr] = (completedCountByPerson[resourceIdStr] || 0) + 1;
+            return;
+          }
+          if (!isTaskActiveForUser(_teamMemberTask, resourceIdStr)) return;
+
           const taskNdUserID = `${taskIdStr},${resourceIdStr}`;
-          // initialize taskNotifications if not exists
-          if (!_teamMemberTask.taskNotifications) _teamMemberTask.taskNotifications = [];
-          // push all notifications into the list if taskNdUserId key exists
-          if (taskNotificationByTaskNdUser[taskNdUserID])
-            _teamMemberTask.taskNotifications.push(...taskNotificationByTaskNdUser[taskNdUserID]);
+          const taskForUser = { ..._teamMemberTask, taskNotifications: [] };
+          if (taskNotificationByTaskNdUser[taskNdUserID]) {
+            taskForUser.taskNotifications.push(...taskNotificationByTaskNdUser[taskNdUserID]);
+          }
           if (taskByPerson[resourceIdStr]) {
-            taskByPerson[resourceIdStr].push(_teamMemberTask);
+            taskByPerson[resourceIdStr].push(taskForUser);
           } else {
-            taskByPerson[resourceIdStr] = [_teamMemberTask];
+            taskByPerson[resourceIdStr] = [taskForUser];
           }
         });
       });
@@ -255,6 +270,7 @@ const taskHelper = function () {
           totaltangibletime_hrs: tangible / 3600,
           totaltime_hrs: total / 3600,
           tasks: taskByPerson[teamMember._id.toString()] || [],
+          completedTasksCount: completedCountByPerson[teamMember._id.toString()] || 0,
           timeOffFrom: teamMember.timeOffFrom || null,
           timeOffTill: teamMember.timeOffTill || null,
           teamCode: teamMember.teamCode || null,
@@ -716,16 +732,70 @@ const taskHelper = function () {
         },
       },
       {
-        $project: {
+        $addFields: {
+          completedTasksCount: {
+            $size: {
+              $filter: {
+                input: '$tasks',
+                as: 'task',
+                cond: {
+                  $anyElementTrue: {
+                    $map: {
+                      input: '$$task.resources',
+                      as: 'res',
+                      in: {
+                        $and: [
+                          { $eq: ['$$res.userID', '$personId'] },
+                          { $eq: ['$$res.completedTask', true] },
+                        ],
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
           tasks: {
             $filter: {
               input: '$tasks',
               as: 'task',
               cond: {
-                $ne: ['$$task.isActive', false],
+                $and: [
+                  { $ne: ['$$task.isActive', false] },
+                  {
+                    $not: {
+                      $anyElementTrue: {
+                        $map: {
+                          input: '$$task.resources',
+                          as: 'res',
+                          in: {
+                            $and: [
+                              { $eq: ['$$res.userID', '$personId'] },
+                              { $eq: ['$$res.completedTask', true] },
+                            ],
+                          },
+                        },
+                      },
+                    },
+                  },
+                ],
               },
             },
           },
+        },
+      },
+      {
+        $project: {
+          completedTasksCount: 1,
+          tasks: 1,
+          personId: 1,
+          name: 1,
+          weeklycommittedHours: 1,
+          timeOffFrom: 1,
+          timeOffTill: 1,
+          role: 1,
+          totaltime_hrs: 1,
+          totaltangibletime_hrs: 1,
           'tasks.resources.profilePic': 0,
         },
       },
@@ -757,6 +827,7 @@ const taskHelper = function () {
       {
         $project: {
           projectId: 0,
+          completedTasksCount: 1,
           tasks: {
             projectId: {
               _id: 0,
@@ -825,3 +896,5 @@ const taskHelper = function () {
 };
 
 module.exports = taskHelper;
+module.exports.isTaskActiveForUser = isTaskActiveForUser;
+module.exports.isTaskCompletedForUser = isTaskCompletedForUser;

--- a/src/helpers/taskHelper.spec.js
+++ b/src/helpers/taskHelper.spec.js
@@ -1,4 +1,40 @@
-const { isTaskActiveForUser, isTaskCompletedForUser } = require('./taskHelper');
+const mongoose = require('mongoose');
+
+jest.mock('../models/userProfile');
+jest.mock('../models/timeentry');
+jest.mock('../models/team');
+jest.mock('../models/task');
+jest.mock('../models/taskNotification');
+jest.mock('../utilities/permissions');
+
+const userProfile = require('../models/userProfile');
+const timeentry = require('../models/timeentry');
+const team = require('../models/team');
+const Task = require('../models/task');
+const TaskNotification = require('../models/taskNotification');
+const { hasPermission } = require('../utilities/permissions');
+const taskHelperModule = require('./taskHelper');
+
+const { isTaskActiveForUser, isTaskCompletedForUser } = taskHelperModule;
+const { getTasksForTeams, getTasksForSingleUser, getUserProfileFirstAndLastName } =
+  taskHelperModule();
+
+const makeObjectId = () => new mongoose.Types.ObjectId();
+
+const makeTaskDoc = ({ taskId, taskName, resources, projectId }) => ({
+  _id: taskId,
+  taskName,
+  resources,
+  isActive: true,
+  wbsId: projectId,
+});
+
+const makePopulatedTask = ({ taskId, taskName, resources, projectId }) => ({
+  _id: taskId,
+  _doc: makeTaskDoc({ taskId, taskName, resources, projectId }),
+  resources,
+  wbsId: { projectId },
+});
 
 describe('taskHelper dashboard task filters', () => {
   const userId = 'user123';
@@ -16,6 +52,11 @@ describe('taskHelper dashboard task filters', () => {
 
   test('isTaskCompletedForUser returns false for active assignment', () => {
     expect(isTaskCompletedForUser(makeTask(), userId)).toBe(false);
+  });
+
+  test('isTaskCompletedForUser returns false when user has no resource entry', () => {
+    const task = makeTask({ resources: [{ userID: 'someoneElse', completedTask: true }] });
+    expect(isTaskCompletedForUser(task, userId)).toBe(false);
   });
 
   test('isTaskActiveForUser returns false for completed assignment', () => {
@@ -40,5 +81,328 @@ describe('taskHelper dashboard task filters', () => {
     });
     expect(isTaskActiveForUser(task, 'userA')).toBe(false);
     expect(isTaskActiveForUser(task, 'userB')).toBe(true);
+  });
+});
+
+describe('getTasksForTeams dashboard filtering', () => {
+  const userId = makeObjectId();
+  const teammateId = makeObjectId();
+  const requestorId = makeObjectId();
+  const projectId = makeObjectId();
+  const activeTaskId = makeObjectId();
+  const completedTaskId = makeObjectId();
+  const sharedTaskId = makeObjectId();
+  const notificationId = makeObjectId();
+
+  const requestor = { requestorId: requestorId.toString(), role: 'Manager' };
+
+  const teamMembers = [
+    {
+      _id: userId,
+      role: 'Volunteer',
+      firstName: 'Main',
+      lastName: 'User',
+      weeklycommittedHours: 10,
+      weeklySummaryOption: null,
+      weeklySummariesCount: 0,
+      timeOffFrom: null,
+      timeOffTill: null,
+      teamCode: null,
+      teams: [],
+      adminLinks: null,
+    },
+    {
+      _id: teammateId,
+      role: 'Volunteer',
+      firstName: 'Team',
+      lastName: 'Mate',
+      weeklycommittedHours: 5,
+      weeklySummaryOption: null,
+      weeklySummariesCount: 0,
+      timeOffFrom: null,
+      timeOffTill: null,
+      teamCode: null,
+      teams: [],
+      adminLinks: null,
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    hasPermission.mockResolvedValue(false);
+
+    userProfile.findOne.mockResolvedValue({
+      _id: userId,
+      role: 'Volunteer',
+      firstName: 'Main',
+      lastName: 'User',
+      weeklycommittedHours: 10,
+      weeklySummaryOption: null,
+      timeOffFrom: null,
+      timeOffTill: null,
+      teamCode: null,
+      teams: [],
+      adminLinks: null,
+    });
+
+    team.find.mockResolvedValue([
+      {
+        members: [
+          { userId, visible: true },
+          { userId: teammateId, visible: true },
+        ],
+      },
+    ]);
+
+    userProfile.find.mockReturnValue({
+      populate: jest.fn().mockResolvedValue(teamMembers),
+    });
+
+    timeentry.find.mockResolvedValue([]);
+
+    Task.find.mockReturnValue({
+      populate: jest.fn().mockResolvedValue([
+        makePopulatedTask({
+          taskId: activeTaskId,
+          taskName: 'Active Task',
+          resources: [{ userID: userId, completedTask: false }],
+          projectId,
+        }),
+        makePopulatedTask({
+          taskId: completedTaskId,
+          taskName: 'Completed Task',
+          resources: [{ userID: userId, completedTask: true }],
+          projectId,
+        }),
+        makePopulatedTask({
+          taskId: sharedTaskId,
+          taskName: 'Shared Task',
+          resources: [
+            { userID: userId, completedTask: true },
+            { userID: teammateId, completedTask: false },
+          ],
+          projectId,
+        }),
+        makePopulatedTask({
+          taskId: makeObjectId(),
+          taskName: 'Missing Resource User',
+          resources: [{ userID: null, completedTask: false }],
+          projectId,
+        }),
+      ]),
+    });
+
+    TaskNotification.find.mockResolvedValue([
+      {
+        _id: notificationId,
+        taskId: activeTaskId,
+        userId,
+      },
+    ]);
+  });
+
+  test('excludes completed tasks, keeps active tasks, and sets completedTasksCount per user', async () => {
+    const result = await getTasksForTeams(userId, requestor);
+
+    expect(result).toHaveLength(2);
+
+    const mainUser = result.find((entry) => entry.personId.toString() === userId.toString());
+    const teammate = result.find((entry) => entry.personId.toString() === teammateId.toString());
+
+    expect(mainUser.tasks).toHaveLength(1);
+    expect(mainUser.tasks[0].taskName).toBe('Active Task');
+    expect(mainUser.completedTasksCount).toBe(2);
+    expect(mainUser.tasks[0].taskNotifications).toHaveLength(1);
+
+    expect(teammate.tasks).toHaveLength(1);
+    expect(teammate.tasks[0].taskName).toBe('Shared Task');
+    expect(teammate.completedTasksCount).toBe(0);
+  });
+
+  test('returns null when user is not found', async () => {
+    userProfile.findOne.mockResolvedValue(null);
+
+    const result = await getTasksForTeams(userId, requestor);
+
+    expect(result).toBeNull();
+  });
+
+  test('returns zero completedTasksCount when user has only active tasks', async () => {
+    Task.find.mockReturnValue({
+      populate: jest.fn().mockResolvedValue([
+        makePopulatedTask({
+          taskId: activeTaskId,
+          taskName: 'Only Active',
+          resources: [{ userID: teammateId, completedTask: false }],
+          projectId,
+        }),
+      ]),
+    });
+    TaskNotification.find.mockResolvedValue([]);
+
+    const result = await getTasksForTeams(userId, requestor);
+    const teammate = result.find((entry) => entry.personId.toString() === teammateId.toString());
+
+    expect(teammate.tasks).toHaveLength(1);
+    expect(teammate.completedTasksCount).toBe(0);
+  });
+
+  test('uses owner-like case 1 when requestor and user both have dashboard access', async () => {
+    hasPermission.mockResolvedValue(true);
+    userProfile.find.mockReturnValue({
+      populate: jest.fn().mockResolvedValue([teamMembers[0]]),
+    });
+    Task.find.mockReturnValue({
+      populate: jest.fn().mockResolvedValue([
+        makePopulatedTask({
+          taskId: activeTaskId,
+          taskName: 'Owner Case Task',
+          resources: [{ userID: userId, completedTask: false }],
+          projectId,
+        }),
+      ]),
+    });
+    TaskNotification.find.mockResolvedValue([]);
+
+    const result = await getTasksForTeams(userId, requestor);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tasks[0].taskName).toBe('Owner Case Task');
+    expect(userProfile.find).toHaveBeenCalledWith({ isActive: true }, expect.any(Object));
+  });
+
+  test('uses case 2 when requestor has dashboard access but target user does not', async () => {
+    hasPermission.mockImplementation(async (actor) => actor.requestorId === requestorId.toString());
+    team.find.mockResolvedValue([
+      {
+        members: [{ userId, visible: true }],
+      },
+    ]);
+    userProfile.find.mockReturnValue({
+      populate: jest.fn().mockResolvedValue([teamMembers[0]]),
+    });
+    Task.find.mockReturnValue({
+      populate: jest.fn().mockResolvedValue([
+        makePopulatedTask({
+          taskId: activeTaskId,
+          taskName: 'Case Two Task',
+          resources: [{ userID: userId, completedTask: false }],
+          projectId,
+        }),
+      ]),
+    });
+    TaskNotification.find.mockResolvedValue([]);
+
+    const result = await getTasksForTeams(userId, requestor);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].tasks[0].taskName).toBe('Case Two Task');
+  });
+
+  test('aggregates tangible and total time entries for team members', async () => {
+    timeentry.find.mockResolvedValue([
+      {
+        personId: userId,
+        totalSeconds: 7200,
+        isTangible: true,
+      },
+      {
+        personId: userId,
+        totalSeconds: 1800,
+        isTangible: false,
+      },
+    ]);
+
+    const result = await getTasksForTeams(userId, requestor);
+    const mainUser = result.find((entry) => entry.personId.toString() === userId.toString());
+
+    expect(mainUser.totaltangibletime_hrs).toBe(2);
+    expect(mainUser.totaltime_hrs).toBe(2.5);
+  });
+
+  test('groups multiple notifications and multiple active tasks for the same user', async () => {
+    const secondActiveTaskId = makeObjectId();
+
+    Task.find.mockReturnValue({
+      populate: jest.fn().mockResolvedValue([
+        makePopulatedTask({
+          taskId: activeTaskId,
+          taskName: 'Active One',
+          resources: [{ userID: userId, completedTask: false }],
+          projectId,
+        }),
+        makePopulatedTask({
+          taskId: secondActiveTaskId,
+          taskName: 'Active Two',
+          resources: [{ userID: userId, completedTask: false }],
+          projectId,
+        }),
+      ]),
+    });
+    TaskNotification.find.mockResolvedValue([
+      { taskId: activeTaskId, userId },
+      { taskId: activeTaskId, userId },
+    ]);
+
+    const result = await getTasksForTeams(userId, requestor);
+    const mainUser = result.find((entry) => entry.personId.toString() === userId.toString());
+
+    expect(mainUser.tasks).toHaveLength(2);
+    expect(mainUser.tasks[0].taskNotifications).toHaveLength(2);
+  });
+
+  test('returns an Error when task lookup fails', async () => {
+    Task.find.mockReturnValue({
+      populate: jest.fn().mockRejectedValue(new Error('task lookup failed')),
+    });
+
+    const result = await getTasksForTeams(userId, requestor);
+
+    expect(result).toBeInstanceOf(Error);
+  });
+});
+
+describe('getTasksForSingleUser dashboard filtering', () => {
+  test('builds aggregation pipeline with completedTasksCount and active-task filter', async () => {
+    const userId = makeObjectId();
+    const mockExec = jest.fn().mockResolvedValue([
+      {
+        personId: userId,
+        name: 'Test User',
+        tasks: [],
+        completedTasksCount: 2,
+      },
+    ]);
+
+    userProfile.aggregate.mockReturnValue({ exec: mockExec });
+
+    const result = await getTasksForSingleUser(userId).exec();
+
+    expect(userProfile.aggregate).toHaveBeenCalledTimes(1);
+    const pipeline = userProfile.aggregate.mock.calls[0][0];
+
+    const addFieldsStage = pipeline.find((stage) => stage.$addFields?.completedTasksCount);
+    expect(addFieldsStage).toBeDefined();
+    expect(addFieldsStage.$addFields.tasks.$filter).toBeDefined();
+    expect(result[0].completedTasksCount).toBe(2);
+  });
+});
+
+describe('getUserProfileFirstAndLastName', () => {
+  test('returns full name when profile exists', async () => {
+    userProfile.findById.mockReturnValue(Promise.resolve({ firstName: 'Purav', lastName: 'Test' }));
+
+    const name = await getUserProfileFirstAndLastName(makeObjectId());
+
+    expect(name).toBe('Purav Test');
+  });
+
+  test('returns blank name when profile is missing', async () => {
+    userProfile.findById.mockReturnValue(Promise.resolve(null));
+
+    const name = await getUserProfileFirstAndLastName(makeObjectId());
+
+    expect(name).toBe(' ');
   });
 });

--- a/src/helpers/taskHelper.spec.js
+++ b/src/helpers/taskHelper.spec.js
@@ -1,0 +1,44 @@
+const { isTaskActiveForUser, isTaskCompletedForUser } = require('./taskHelper');
+
+describe('taskHelper dashboard task filters', () => {
+  const userId = 'user123';
+
+  const makeTask = (overrides = {}) => ({
+    isActive: true,
+    resources: [{ userID: userId, completedTask: false }],
+    ...overrides,
+  });
+
+  test('isTaskCompletedForUser returns true when user resource has completedTask true', () => {
+    const task = makeTask({ resources: [{ userID: userId, completedTask: true }] });
+    expect(isTaskCompletedForUser(task, userId)).toBe(true);
+  });
+
+  test('isTaskCompletedForUser returns false for active assignment', () => {
+    expect(isTaskCompletedForUser(makeTask(), userId)).toBe(false);
+  });
+
+  test('isTaskActiveForUser returns false for completed assignment', () => {
+    const task = makeTask({ resources: [{ userID: userId, completedTask: true }] });
+    expect(isTaskActiveForUser(task, userId)).toBe(false);
+  });
+
+  test('isTaskActiveForUser returns true for inactive tasks when not completed', () => {
+    expect(isTaskActiveForUser(makeTask({ isActive: false }), userId)).toBe(true);
+  });
+
+  test('isTaskActiveForUser returns true for active non-completed assignment', () => {
+    expect(isTaskActiveForUser(makeTask(), userId)).toBe(true);
+  });
+
+  test('per-user isolation: completed for A, active for B', () => {
+    const task = makeTask({
+      resources: [
+        { userID: 'userA', completedTask: true },
+        { userID: 'userB', completedTask: false },
+      ],
+    });
+    expect(isTaskActiveForUser(task, 'userA')).toBe(false);
+    expect(isTaskActiveForUser(task, 'userB')).toBe(true);
+  });
+});


### PR DESCRIPTION
# Description
Fixes Dashboard downloading resolved/completed tasks that are never rendered in the UI.

When the Dashboard loads the Team Member Tasks tab, it calls `GET /user/:userId/teams/tasks`. That endpoint was returning all assigned tasks (~5.5 MB on dev), including tasks where the user has `completedTask: true` on their resource entry. The frontend filters those out before render, so ~37% of the task payload was wasted bandwidth and parsing.

This PR filters resolved tasks on the server for that Dashboard-specific endpoint only, and returns `completedTasksCount` per user so the frontend completed-count badge can still work without sending full task objects.

Fixes (PRIORITY MEDIUM) Dashboard downloading resolved Tasks — backend portion.

## Related PRS (if any):
Frontend follow-up needed in HighestGoodNetworkApp: read `user.completedTasksCount` for the completed badge (fall back to counting task objects if absent). No frontend PR is linked yet.

## Main changes explained:
- Update `src/helpers/taskHelper.js` — in `getTasksForTeams`, exclude tasks where that user''s resource has `completedTask: true`; add `completedTasksCount` per user; apply the same filter in `getTasksForSingleUser` aggregation fallback path.
- Create `src/helpers/taskHelper.spec.js` — unit tests for per-user active/completed task filter logic.

## How to test:
1. Check out branch `Purav-dashboard-filter-resolved-tasks`
2. Run `npm install` and start backend (`yarn dev` or `npm start`) on port 4500
3. Log in as an admin/owner user (e.g. Dashboard with Tasks tab access)
4. Open DevTools → Network → Fetch/XHR and load Dashboard → Tasks tab
5. Find request `GET /api/user/{userId}/teams/tasks`
6. Verify response size is smaller than before (~3.7 MB vs ~5.2 MB on dev)
7. Search response JSON for completedTask: true` on tasks in user task lists — should be **0**
8. Verify each user object includes `completedTasksCount` matching previously filtered completed tasks
9. Verify active tasks still appear on the Dashboard task list
10. Test dark mode on Dashboard Tasks tab (frontend) — task list and completed badge should render correctly in both themes once frontend reads `completedTasksCount`

## Screenshots or videos of changes:

https://github.com/user-attachments/assets/b8040c7f-c648-497b-8d4a-446555a7c548

## Note:
- Does **not** change global `/tasks` or `/tasks/user/:userId` endpoints.
- Filter matches existing frontend logic in `TeamMemberTask.jsx` (`completedTask` per user, not global `status === Complete`).
- Verified on dev: 2,639 users, 2,091 active tasks in payload, 0 completed tasks in payload, 1,239 total in `completedTasksCount`.