### PR TITLE
Amaresh: Restore dropped eventRouter mount and fix its route ordering bug

### DIFF
--- a/src/routes/eventRouter.js
+++ b/src/routes/eventRouter.js
@@ -4,9 +4,9 @@ const eventsController = require('../controllers/eventController');
 const eventRouter = express.Router();
 
 eventRouter.get('/events', eventsController.getEvents);
-eventRouter.get('/events/:id', eventsController.getEventById);
 eventRouter.get('/events/types', eventsController.getEventTypes);
 eventRouter.get('/events/locations', eventsController.getEventLocations);
+eventRouter.get('/events/:id', eventsController.getEventById);
 eventRouter.post('/events', eventsController.createEvent);
 eventRouter.post('/events/:id/register', eventsController.registerForEvent);
 eventRouter.delete('/events/:id/register/:userId', eventsController.unregisterFromEvent);

--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -355,6 +355,7 @@ const userBidRouter = require('../routes/lbdashboard/userBidNotificationRouter')
 //commnunity portal
 const cpNoShowRouter = require('../routes/CommunityPortal/NoshowVizRouter')();
 const cpEventFeedbackRouter = require('../routes/CommunityPortal/eventFeedbackRouter');
+const eventRouter = require('../routes/eventRouter');
 
 const collaborationRouter = require('../routes/collaborationRouter');
 const questionSetRouter = require('../routes/questionSetRouter');
@@ -630,6 +631,7 @@ module.exports = function (app) {
   app.use('/api/communityportal/reports/participation', cpNoShowRouter);
   app.use('/api/communityportal/activities/', cpEventFeedbackRouter);
   app.use('/api/communityportal', NoShowFollowUpRouter);
+  app.use('/api', eventRouter);
 
   // lb dashboard
   app.use('/api/lbdashboard', lbRegisterRouter);


### PR DESCRIPTION
## Description
Restores a real, fully-built Event API (`GET/POST /api/events`, `/events/types`, `/events/locations`, waitlist/registration endpoints) that was silently dropped from `src/startup/routes.js` during an unrelated merge (`fix(1342): adjust backend logic`, Nov 13 2025), the mount line and `bmIssueRouter`'s mount both got dropped in that merge's conflict resolution; `bmIssueRouter` was restored later, `eventRouter` never was. This left the route unreachable (404) even though the controller, model, and 192 real event documents in the dev database were all already there and working. Also fixes a route-ordering bug inside `eventRouter.js` itself that was invisible while the router was unmounted: `/events/:id` was registered before `/events/types` and `/events/locations`, so Express matched those two literal paths as if `"types"`/`"locations"` were an `:id` param and routed them to `getEventById` instead, which threw a Mongoose CastError.


## Related PRS (if any):
This backend PR is related to the frontend PR [#5453](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5453) (`amaresh/fix-event-participation-static-metrics-and-nav-links` wires the Event Participation Analytics page to this restored API).
To test this backend PR, you need to check out the [#5453](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5453) frontend PR.

## Main changes explained:
- Update `src/startup/routes.js` for re-adding the `eventRouter` require and its `app.use('/api', eventRouter)` mount, restoring the route to reachable.
- Update src/routes/eventRouter.js for reordering the route registrations so /events/types and /events/locations are registered before the /events/:id wildcard, so they match their own handlers instead of being caught by it first.

## How to test:
1. Check into the current branch.
2. Do `npm install` and `npm run dev` to run this PR locally.
3. With a valid session token, hit `GET localhost:4500/api/events`, `GET localhost:4500/api/events/types`, and `GET localhost:4500/api/events/locations` (Postman or `curl -H "Authorization: <token>"`) all three should return real data instead of a 404, and `/events/types`/`/events/locations` specifically should no longer 500/error out on a Mongoose CastError.
4. Alternatively, check out the companion frontend PR [#5453](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5453) and log in as any user, then visit `localhost:5173/communityportal/database/design` this page (an already-shipped feature) that was broken by the same dropped mount and should now load real event cards with working Event Type/Location filter dropdowns instead of a "Failed to fetch filter" error.
5. Also visit `localhost:5173/communityportal/reports/participation` (needs the frontend PR) to see the same real data flowing into the Event Participation Analytics page.

## Screenshots or videos of changes:
<img width="1470" height="879" alt="Screenshot 2026-08-19 at 10 13 51 PM" src="https://github.com/user-attachments/assets/a76d8442-33e6-4df4-bad7-c3933e8bea1c" />
<img width="1470" height="882" alt="Screenshot 2026-08-19 at 10 14 18 PM" src="https://github.com/user-attachments/assets/064589d8-7a05-43cd-a301-476ea04ffd6a" />
<img width="1470" height="876" alt="Screenshot 2026-08-19 at 10 15 58 PM" src="https://github.com/user-attachments/assets/39707caf-e526-45b0-8539-53a09ea3a3a2" />
<img width="1469" height="879" alt="Screenshot 2026-08-19 at 10 16 10 PM" src="https://github.com/user-attachments/assets/67b66855-befe-43f8-9531-6ae40789f96d" />
<img width="1470" height="881" alt="Screenshot 2026-08-19 at 10 16 19 PM" src="https://github.com/user-attachments/assets/f1109592-dc04-4a63-849b-67c2a5d7273f" />


## Note: