### PR TITLE
Mahathi - Fix applicant volunteer ratio API route registration

### DIFF
--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -397,7 +397,7 @@ const listOverviewRouter = require('../routes/lbdashboard/listOverviewRouter')()
 const blueskyRouter = require('../routes/blueskyRouter');
 
 const NoShowFollowUpRouter = require('../routes/CommunityPortal/noShowFollowUpRouter')();
-const applicantVolunteerRatioRouter = require('../routes/applicantAnalyticsRouter');
+const applicantVolunteerRatioRouter = require('../routes/applicantVolunteerRatioRouter');
 const analyticsRouter = require('../routes/optanalyticsRoutes')();
 const applicationRoutes = require('../routes/applications');
 const educatorGroupRouter = require('../routes/educatorGroupRoutes');


### PR DESCRIPTION
## Description
<img width="581" height="457" alt="Screenshot 2026-08-21 at 2 52 30 AM" src="https://github.com/user-attachments/assets/f4364692-c730-48b9-9149-2904021362e8" />

Fixes the Applicant-Volunteer Ratio analytics API returning a 404 response for:

GET /api/applicant-volunteer-ratio/analytics

## Related PRS (if any):
This backend PR is related to the [https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5457](url) Frontend PR.

This PR is hotfix for https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5123

## Changes

- Updated the router import in `src/startup/routes.js`.
- Connected `/api/applicant-volunteer-ratio` to `applicantVolunteerRatioRouter`.
- Verified `/analytics` maps to `getAllApplicantVolunteerRatios`.
- Rebuilt the backend and verified the compiled routing configuration.

## How to test

- Rebuild HGNRest.
- Restart the backend.
- Test `GET /api/applicant-volunteer-ratio/analytics`.
- Confirm the request no longer returns `Cannot GET /api/applicant-volunteer-ratio/analytics`.
- Verify analytics data can be returned to the frontend.