### PR TITLE
Bosu - fix: expose user profile id in HGN questionnaire responses

### DIFF
--- a/src/controllers/communityController.js
+++ b/src/controllers/communityController.js
@@ -41,6 +41,7 @@ const communityMemberController = function () {
         const { userInfo, frontend, backend, general } = member;
         return {
           _id: member._id,
+          userId: member.user_id,
           name: userInfo?.name || 'N/A',
           email: userInfo?.email || 'N/A',
           slack: userInfo?.slack || '',

--- a/src/controllers/communityController.test.js
+++ b/src/controllers/communityController.test.js
@@ -1,0 +1,38 @@
+jest.mock('../models/hgnFormResponse');
+
+const FormResponse = require('../models/hgnFormResponse');
+const communityMemberController = require('./communityController');
+
+describe('communityController', () => {
+  it('preserves the response _id and exposes userId from user_id', async () => {
+    FormResponse.find.mockReturnValue({
+      lean: jest.fn().mockReturnThis(),
+      sort: jest.fn().mockResolvedValue([
+        {
+          _id: 'response-1',
+          user_id: 'profile-1',
+          userInfo: { name: 'John', email: 'john@example.com', slack: 'john' },
+          general: { location: 'Remote' },
+          frontend: { React: '8' },
+          backend: { MongoDB: '7' },
+        },
+      ]),
+    });
+
+    const req = { query: {} };
+    const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+
+    await communityMemberController().getCommunityMembers(req, res);
+
+    expect(res.json).toHaveBeenCalledWith([
+      expect.objectContaining({
+        _id: 'response-1',
+        userId: 'profile-1',
+        name: 'John',
+        email: 'john@example.com',
+        slack: 'john',
+        team: 'Remote',
+      }),
+    ]);
+  });
+});

--- a/src/controllers/hgnFormResponseController.js
+++ b/src/controllers/hgnFormResponseController.js
@@ -106,6 +106,7 @@ const hgnFormController = () => {
 
         return {
           _id: user._id,
+          userId: user.user_id,
           name: user.userInfo?.name,
           email: user.userInfo?.email,
           slack: user.userInfo?.slack,

--- a/src/controllers/hgnFormResponseController.test.js
+++ b/src/controllers/hgnFormResponseController.test.js
@@ -171,6 +171,7 @@ describe('HgnFormResponseController', () => {
 
       expect(FormResponse.find).toHaveBeenCalled();
       expect(result[0]._id).toBe('2'); // Jane should be ranked higher
+      expect(result[0].userId).toBe('456');
       expect(result[0].topSkills).toEqual(expect.arrayContaining(['React']));
       expect(result[1]._id).toBe('1');
     });
@@ -207,7 +208,7 @@ describe('HgnFormResponseController', () => {
       expect(mockRes.json).toHaveBeenCalledWith(
         expect.arrayContaining([
           expect.objectContaining({ _id: '1' }),
-          expect.objectContaining({ _id: '2' }),
+          expect.objectContaining({ _id: '2', userId: '456' }),
         ]),
       );
     });


### PR DESCRIPTION
# Description

Fixes the backend identifier mismatch affecting HGN Questionnaire Dashboard profile navigation.

The HGN ranked and community endpoints return records from `HGNFormResponses`. Their existing `_id` field represents the questionnaire response document ID, while `/api/skills/profile/:userId` expects the corresponding `UserProfile._id`.

Because the actual profile ID was not exposed by the ranked/community responses, the frontend was previously navigating with the questionnaire response `_id`. The profile endpoint could not resolve that value as a user profile and returned placeholder data such as `Unknown User`.

This PR preserves the existing `_id` field and adds the associated `user_id` value as `userId` to the relevant API responses.

## Related PRs

1. This backend PR is related to frontend PR **#5462**.
2. The frontend PR uses the new `userId` field for `/hgnhelp/profile/:userId`.
3. Both PRs should be tested together.

## Main changes explained

1. Updated `hgnFormResponseController.js` ranked responses to preserve:

   `_id: user._id`

   and additionally expose:

   `userId: user.user_id`

2. Updated `communityController.js` to preserve:

   `_id: member._id`

   and additionally expose:

   `userId: member.user_id`

3. Preserved all existing response fields and behavior for backward compatibility.

4. Added focused assertions to the existing HGN form response controller tests.

5. Added focused tests for the community controller response.

6. No database schema, route, or user skills profile controller changes were made.

## How to test

1. Checkout this backend branch.

2. Checkout the related frontend PR branch.

3. Run:

   `npm run build`

4. Start the backend locally.

5. Start the related frontend locally.

6. Navigate to the HGN questionnaire community member list.

7. Inspect the ranked/community API response in DevTools.

8. Verify each applicable user object contains both:

   * `_id` — questionnaire response document ID
   * `userId` — actual user profile ID

9. Click a user's name in the frontend.

10. Verify the frontend uses `userId` when navigating to:

    `/hgnhelp/profile/<userId>`

11. Verify the subsequent request to:

    `/api/skills/profile/<userId>`

    returns the real user profile instead of placeholder `Unknown User` data.

12. Test multiple users and verify skills, experience, and team information are returned when available.

## Validation performed

* Focused backend controller tests: **9/9 passed**
* ESLint: **0 new errors**
* `git diff --check`: **passed**
* Backend build with `npm run build`: **passed**
* End-to-end local FE/BE integration test: **passed**
* Real user profile resolution: **passed**
* Skills and experience data: **passed**
* Team data: **passed**

## Screenshots or videos of changes

<img width="1512" height="653" alt="Screenshot 2026-08-22 at 11 45 33 AM" src="https://github.com/user-attachments/assets/2fe0a92d-c732-4ba8-bdc3-d36b5f60df93" />


## Note

This is an additive and backward-compatible response change. The existing `_id` field remains unchanged because other functionality may depend on the questionnaire response document ID. No schema, database migration, route, or unrelated controller changes are included.
