### PR TITLE
Akshay Fix Task Completed chart date filtering

### DIFF
--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -1141,8 +1141,13 @@ const overviewReportHelper = function () {
       };
     }
 
-    // non-comparison branch
+    // Apply the selected range even when comparison mode is off.
     const taskStats = await Task.aggregate([
+      {
+        $match: {
+          modifiedDatetime: { $gte: startDate, $lte: endDate },
+        },
+      },
       {
         $group: {
           _id: '$status',

--- a/src/helpers/overviewReportHelper.spec.js
+++ b/src/helpers/overviewReportHelper.spec.js
@@ -1,4 +1,5 @@
 const UserProfile = require('../models/userProfile');
+const Task = require('../models/task');
 const overviewReportHelper = require('./overviewReportHelper');
 
 // const makeSut = () => {
@@ -8,6 +9,24 @@ const overviewReportHelper = require('./overviewReportHelper');
 // };
 
 describe('overviewReportHelper tests', () => {
+  describe('getTasksStats date boundaries', () => {
+    afterEach(() => jest.restoreAllMocks());
+
+    test('filters the non-comparison totals by the selected date range', async () => {
+      const startDate = new Date('2026-07-19T00:00:00-07:00');
+      const endDate = new Date('2026-07-25T23:59:00-07:00');
+      const aggregateSpy = jest.spyOn(Task, 'aggregate').mockResolvedValue([]);
+
+      const { getTasksStats } = overviewReportHelper();
+      await getTasksStats(startDate, endDate);
+
+      expect(aggregateSpy).toHaveBeenCalledWith([
+        { $match: { modifiedDatetime: { $gte: startDate, $lte: endDate } } },
+        { $group: { _id: '$status', count: { $sum: 1 } } },
+      ]);
+    });
+  });
+
   describe('getHoursStats date boundaries', () => {
     const originalTimezone = process.env.TZ;
 


### PR DESCRIPTION
<img width="550" height="500" alt="image" src="https://github.com/user-attachments/assets/dc97492c-5aea-4972-8b47-c83967a2337c" />

# Description
Fixes bug list priority medium: the Total Org Summary "Task Completed" chart showed all-time Assigned and Completed totals when no comparison range was selected, so changing the date range did not change the chart.

## Related PRs (if any):
N/A. This is a backend-only fix and does not require a frontend PR.

## Main changes explained:
- Update `overviewReportHelper.js` so the non-comparison task aggregation uses the selected start and end dates.
- Update `overviewReportHelper.spec.js` with a regression test that verifies the date-range match is applied.

## How to test:
1. Check out `Akshay_fix_task_completed_date_filter`.
2. Run `npm install`, then start the backend with `npm start`.
3. Run `npx jest src/helpers/overviewReportHelper.spec.js --runInBand --noStackTrace`.
4. Start the frontend normally, clear site data/cache, and log in as a Manager, Admin, or Tester.
5. Go to Dashboard → Total Org Summary → Volunteer Workload and Task Completion Analysis.
6. Change the date range and verify the Assigned and Completed totals update for the selected range.
7. Enable dark mode and verify the chart still renders correctly with the filtered values.

## Screenshots or videos of changes:


https://github.com/user-attachments/assets/7c04421b-de92-48fa-a6c1-0a26adc8f9dd


## Note:
Root cause: `getTasksStats` applied `modifiedDatetime` boundaries only when comparison dates were present. With "No Comparison" selected, it grouped every task in the database.

Prettier passes for both modified files. ESLint reports zero errors and 68 pre-existing warnings in `overviewReportHelper.js`. The focused suite passes all 8 tests. The repository pre-commit related-test run passed 6 of 7 suites; the unrelated `reasonSchedulingController` integration suite failed because its database connection timed out.
