### PR TITLE
Aditya - Job Application Listing Page: allow public read access to the FAQ list

### DIFF
--- a/src/routes/faqRouter.js
+++ b/src/routes/faqRouter.js
@@ -51,7 +51,10 @@ const checkFaqPermission = (requiredPermission) => (req, res, next) => {
 
 // Define routes with verifyToken and checkFaqPermission
 router.get('/faqs/search', verifyToken, faqController.searchFAQs);
-router.get('/faqs', verifyToken, faqController.getAllFAQs);
+// Public: the job listing page at /collaboration is reachable without signing in,
+// and its FAQ section reads from here. getAllFAQs does not use req.user.
+// Every other FAQ route below stays behind verifyToken.
+router.get('/faqs', faqController.getAllFAQs);
 router.post('/faqs', verifyToken, checkFaqPermission('manageFAQs'), faqController.createFAQ);
 router.put('/faqs/:id', verifyToken, checkFaqPermission('manageFAQs'), faqController.updateFAQ);
 router.delete('/faqs/:id', verifyToken, checkFaqPermission('manageFAQs'), faqController.deleteFAQ);

--- a/src/startup/middleware.js
+++ b/src/startup/middleware.js
@@ -91,6 +91,14 @@ module.exports = function (app) {
       return;
     }
 
+    // Public FAQ list: the job listing page at /collaboration is reachable without
+    // signing in, and its FAQ section reads from here. Matched exactly so the
+    // search, history and unanswered FAQ routes stay behind authentication.
+    if (req.path === '/api/faqs' && req.method === 'GET') {
+      next();
+      return;
+    }
+
     if (req.originalUrl.startsWith('/api/bluesky')) {
       next();
       return;


### PR DESCRIPTION
# Description

The job listing page at `/collaboration` is public - it does not require signing in. Its FAQ section reads from `GET /faqs`, which required a token, so a signed-out visitor received a 401 and got an error where the FAQs should be. This PR makes the changes to allow public read access to the FAQ list

This issue concerns [Item 33](https://docs.google.com/document/d/1zifX1otZPl-VJLQk0sZqZbQFginRytlQ2vKHeQAh_Lo/edit#bookmark=id.npvbdnnivxe9).

<img width="732" height="679" alt="Screenshot 2026-08-27 at 8 18 25 PM" src="https://github.com/user-attachments/assets/784f1087-18c0-4422-83b3-3eb0de13caf3" />


## Related PRS (if any):

Frontend: OneCommunityGlobal/HighestGoodNetworkApp#5473

## Main changes explained:

1. Added `GET /api/faqs` to the global auth allowlist in `startup/middleware.js`. That `app.all('*')` gate runs before every route, so removing the router's own guard alone had no effect. It is matched on `req.path` exactly rather than as a prefix, so the search, history, unanswered and write routes are untouched.
2. Removed `verifyToken` from the `/faqs` route in `faqRouter.js`. `getAllFAQs` does not read `req.user`, so nothing in the handler depended on it.

`GET /api/jobs` is already public in the same allowlist — that is how the job listing itself loads for visitors — so this follows the existing pattern for this page.

## How to test:

1. Check out this branch and run `npm install`
2. Start Redis: `redis-server --daemonize yes`
3. Run `npm run dev`
4. Confirm the FAQ list is now public, and that nothing else opened up:

```
curl -o /dev/null -w "%{http_code}\n" http://localhost:4500/api/faqs              # 200
curl -o /dev/null -w "%{http_code}\n" "http://localhost:4500/api/faqs/search?q=a" # 401
curl -o /dev/null -w "%{http_code}\n" http://localhost:4500/api/faqs/unanswered   # 401
curl -o /dev/null -w "%{http_code}\n" http://localhost:4500/api/faqs/123/history  # 401
curl -o /dev/null -w "%{http_code}\n" -X POST -H "Content-Type: application/json" -d '{}' http://localhost:4500/api/faqs   # 401
curl -o /dev/null -w "%{http_code}\n" -X DELETE http://localhost:4500/api/faqs/123 # 401
```

5. Signed in, confirm `/api/faqs`, `/api/faqs/search` and `/api/faqs/unanswered` all return 200 as before — authenticated access is unchanged.
6. Run `npm run lint`

## Note:

Not addressed here, found while testing:

- `GET /faqs/unanswered` and `DELETE /faqs/unanswered/:id` check only for a token, not for `manageFAQs`, unlike the other management endpoints. The UI hides that page behind the permission, but any signed-in user can call those endpoints directly. Raised separately rather than mixed into this change.
