### PR TITLE
Roshini Seelamsetty: Create permission to see and interact with the deadline tracking details

### DIFF
--- a/src/controllers/taskController.js
+++ b/src/controllers/taskController.js
@@ -1280,6 +1280,17 @@ const taskController = function (Task) {
   };
 
   const updateTaskStatus = async (req, res) => {
+    if (
+      !(await hasPermission(
+        req.body.requestor,
+        'viewAndInteractWithTaskDeadlinesBoxes',
+      ))
+    ) {
+      return res.status(403).send({
+        error: 'You are not authorized to update task deadline status.',
+      });
+    }
+
     const { taskId } = req.params;
     Task.findById(taskId).then((currentTask) => {
       WBS.findById(currentTask.wbsId).then((currentwbs) => {

--- a/src/controllers/taskController.spec.js
+++ b/src/controllers/taskController.spec.js
@@ -1394,6 +1394,7 @@ describe('Unit Tests for taskController.js', () => {
 
     test('Returns 200 on success - updateTaskStatus', async () => {
       const { updateTaskStatus } = makeSut();
+      hasPermission.mockResolvedValueOnce(true);
 
       mockReq.params = {
         ...mockReq.params,
@@ -1419,8 +1420,24 @@ describe('Unit Tests for taskController.js', () => {
       expect(projectFindByIdSpy).toHaveBeenCalled();
     });
 
+    test('Returns 403 when task deadline permission is missing', async () => {
+      const { updateTaskStatus } = makeSut();
+      hasPermission.mockResolvedValueOnce(false);
+
+      const response = await updateTaskStatus(mockReq, mockRes);
+
+      assertResMock(
+        403,
+        { error: 'You are not authorized to update task deadline status.' },
+        response,
+        mockRes,
+      );
+      expect(Task.findOneAndUpdate).not.toHaveBeenCalled();
+    });
+
     test('Returns 400 on error', async () => {
       const { updateTaskStatus } = makeSut();
+      hasPermission.mockResolvedValueOnce(true);
       const error = new Error('some error');
 
       mockReq.params = {

--- a/src/test/createTestPermissions.js
+++ b/src/test/createTestPermissions.js
@@ -29,6 +29,7 @@ const permissionsRoles = [
       'updateTask',
       'swapTask',
       'deleteTask',
+      'viewAndInteractWithTaskDeadlinesBoxes',
       'viewTaskExtensionCount', // to view task extension count
       'updateNum',
       // Teams
@@ -198,6 +199,7 @@ const permissionsRoles = [
       'updateTask',
       'swapTask',
       'deleteTask',
+      'viewAndInteractWithTaskDeadlinesBoxes',
       'postTeam',
       'deleteTeam',
       'putTeam',

--- a/src/utilities/createInitialPermissions.js
+++ b/src/utilities/createInitialPermissions.js
@@ -31,6 +31,7 @@ const permissionsRoles = [
       'updateTask',
       'swapTask',
       'deleteTask',
+      'viewAndInteractWithTaskDeadlinesBoxes',
       'viewTaskExtensionCount', // to view task extension count
       'updateNum',
       // Teams
@@ -240,6 +241,7 @@ const permissionsRoles = [
       'updateTask',
       'swapTask',
       'deleteTask',
+      'viewAndInteractWithTaskDeadlinesBoxes',
       'resolveTask',
       'suggestTask',
       'putReviewStatus',


### PR DESCRIPTION
## Description

<img width="789" height="551" alt="Screenshot 2026-08-28 at 08 22 46" src="https://github.com/user-attachments/assets/712910ec-0f1d-430c-8b71-f58630f55dc4" />

## Related PRs

This is a backend PR is related to https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5477

**Project Management → Work Breakdown Structures → Tasks → View and Interact with Task Deadlines Boxes**

## Main Changes Explained

- Added `viewAndInteractWithTaskDeadlinesBoxes` to the default Administrator permissions.
- Added `viewAndInteractWithTaskDeadlinesBoxes` to the default Owner permissions.
- Added the permission to the test permission configuration.
- Updated task status/deadline updates to require the new permission.
- Users without the permission receive a `403 Forbidden` response.
- Added unit tests covering authorized and unauthorized access.

## How to Test

1. Check out the current branch.
2. Run:
   npm install
   npm run build
   npm start
3. Log in as an Administrator or Owner.
4. Go to **Other Links → Permissions Management**.
5. Select a user and open:
   **Project Management → Work Breakdown Structures → Tasks**
6. Verify that **View and Interact with Task Deadlines Boxes** is available.

## Test Results

Task controller tests: 56 passed
