### PR TITLE
Amaresh: Fix oversized TimeEntry/users response slowing the Dashboard

### DIFF
--- a/src/controllers/timeEntryController.js
+++ b/src/controllers/timeEntryController.js
@@ -1139,7 +1139,7 @@ const timeEntrycontroller = function (TimeEntry) {
       },
       '-createdDateTime',
     )
-      .populate('personId')
+      .populate('personId', '_id email')
       .populate('projectId')
       .populate('taskId')
       .populate('wbsId')


### PR DESCRIPTION
## Description
The Dashboard's "Team Member Tasks" widget calls `POST /api/TimeEntry/users` (`getTimeEntriesForUsersList`). That query populated `personId` with **no field projection**, so the entire UserProfile document (~60 fields including the password hash, `weeklySummaries`, `badgeCollection`, `permissions`, etc.) was attached to **every time-entry row**, not once per person. On teams with a lot of logged time, this multiplies into a multi-MB response and stalls the widget / Dashboard load.

The other three populates in the same function (`projectId`, `taskId`, `wbsId`) are already trimmed to the fields the response actually returns; this change brings `personId` in line.

The frontend only reads two fields off each row's `userProfile`: `_id` and `email` (in `Timelog/TimeEntry.jsx`, rendered via `TeamMemberTasks.jsx`), so the populate is narrowed to exactly those.

[Link to issue](https://docs.google.com/document/d/1lZYJGWGjv8GQxU6nuIWbhIbBmy8S_GNqnJbT_RKD110/edit?tab=t.0#bookmark=id.s8dwzqoxjqvw)

<img width="671" height="657" alt="Screenshot 2026-09-03 at 10 08 45 AM" src="https://github.com/user-attachments/assets/77806af8-f61a-4791-b2b6-ac3009449cf2" />


## Related PRS (if any):
Backend-only. No frontend PR needed.

## Main changes explained:
- Update `src/controllers/timeEntryController.js` in `getTimeEntriesForUsersList`, change `.populate('personId')` to `.populate('personId', '_id email')` so only the fields the client uses are returned instead of the full UserProfile per row.

## How to test:
1. Check out this branch, run `npm install`, start the backend
2. Run the frontend against this backend, clear site data/cache
3. Log in as an admin user
4. Open the Dashboard, open DevTools → Network → Fetch/XHR
5. Find the `POST /api/TimeEntry/users` request
6. Expand any element of the response array and check `userProfile` it should now contain only `_id` and `email` (previously ~60 fields including `password`)
7. In the Team Member Tasks widget, activate a day filter (1/2/3/7 day) so individual time entries render; confirm entries still show date/hours/project/task and the edit-pencil / tangibility toggle still opens without a console error

## Screenshots or videos of changes:

Before:
<img width="1470" height="884" alt="Screenshot 2026-08-29 at 9 33 24 AM" src="https://github.com/user-attachments/assets/16787f99-9bce-4881-8095-80dab165a96a" />

After:
<img width="1470" height="881" alt="Screenshot 2026-08-28 at 2 29 10 PM" src="https://github.com/user-attachments/assets/57f08292-2c41-4312-aa30-a617d51b6fbe" />


| | Before | After |
|---|---|---|
| Response body (uncompressed) | 153,058 B | 3,147 B |
| Transferred (gzip) | 88.2 kB | 1.3 kB |
| `userProfile` per row | full ~60-field document | `{ _id, email }` |

~98% smaller. The same ratio applied to the reported production payload takes it from ~15 MB to roughly ~300 KB.

## Note: