### PR TITLE
Fixed existing issue present in 'Task Completed' bar chart

### DIFF
--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -1141,8 +1141,14 @@ const overviewReportHelper = function () {
       };
     }
 
-    // non-comparison branch
+    // non-comparison branch — filter by the same date range so the count reflects                                        
+    // tasks modified (completed/activated) within the selected period, not all time. 
     const taskStats = await Task.aggregate([
+      {
+        $match: {
+          modifiedDatetime: { $gte: startDate, $lte: endDate },
+        },
+      },
       {
         $group: {
           _id: '$status',


### PR DESCRIPTION
# Description
<img width="782" height="543" alt="Screenshot 2026-09-01 at 2 20 02 PM" src="https://github.com/user-attachments/assets/99673df1-d49b-45a4-bba2-49709e7cfeff" />


## Related PRS (if any):
This backend PR is related to the [#5489](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5489) frontend PR.
To test this backend PR you need to checkout the #XXX frontend PR.
…

## Main changes explained:
-  Updated the ```getTasksStats``` function in ```overviewReportHelper.js``` to include a date filter on the non-comparison branch of the aggregation query. Previously, the query had no date constraint and counted
  every task ever created in the system regardless of the selected date range. The fix count to tasks modified within the selected startDate and endDate, consistent with how the Hours Completed chart already filters its data.
…

## How to test:
1. check out to the current branch
2. do `npm install` and run this PR locally
3. Clear site data/cache
4. log as admin user
5. go to Dashboard → Total Org Summary → Volunteer Workload and Task Completion Analysis → Hours Completed / Task Completed charts → Date range selected: 6/26/2026 - 8/21/2026
6. verify the following., 
  a. With the date range 6/26/2026 – 8/21/2026, the subtitle should read something like x% of Total Logged Hours (Tasks) | y% of Total Logged Hours (Projects) - both values visible, not just Tasks.
  b. The percentage in parentheses on each bar should match the footer split. Previously bars showed (0.00%) and (1.00%) while the footer showed 31.3% and 68.7%. After the fix, the bar labels should show the correct percentages respectively not 0% or 1%.
  c. Previously showed 1275 completed tasks for the date range 6/26/2026 – 8/21/2026. After the fix, re-run with the same date range and verify the count drops significantly to a number that is realistic for that ~2 month window.
  
- The tester flagged that 1275 tasks against 25.32 hours works out to ~0.02 hours per task, which is unrealistic. The fixed count should be the correct number for the selected period.

## Note:
Note that the local pre-commit related-test command may still fail because the unrelated reasonSchedulingController integration tests cannot connect to the local test database; the backend build itself succeeds.