### PR TITLE
Gayatri - Add backend for Job Analytics device-specific engagement metrics (Ticket #34)

### DIFF
--- a/src/controllers/__tests__/applicantAnalyticsController.deviceBreakdown.test.js
+++ b/src/controllers/__tests__/applicantAnalyticsController.deviceBreakdown.test.js
@@ -1,0 +1,143 @@
+const analyticsControllerFactory = require('../applicantAnalyticsController');
+
+describe('applicantAnalyticsController - getDeviceBreakdown', () => {
+  let mockAnonymousInteraction;
+  let controller;
+  let req;
+  let res;
+
+  beforeEach(() => {
+    mockAnonymousInteraction = {
+      aggregate: jest.fn(),
+    };
+
+    controller = analyticsControllerFactory(
+      {}, // Applicant (unused here)
+      mockAnonymousInteraction,
+      {}, // AnonymousApplication (unused here)
+      {}, // AnalyticsSummary (unused here)
+    );
+
+    req = {
+      body: { requestor: { role: 'Administrator' } },
+      query: {},
+    };
+    res = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns 403 when requestor is not Owner or Administrator', async () => {
+    req.body.requestor.role = 'Volunteer';
+
+    await controller.getDeviceBreakdown(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Insufficient permissions' });
+    expect(mockAnonymousInteraction.aggregate).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when startDate or endDate is missing', async () => {
+    req.query = { startDate: '2024-06-01' };
+
+    await controller.getDeviceBreakdown(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'startDate and endDate are required' });
+  });
+
+  it('returns 400 when dates are invalid', async () => {
+    req.query = { startDate: 'not-a-date', endDate: '2024-06-30' };
+
+    await controller.getDeviceBreakdown(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Invalid date format' });
+  });
+
+  it('returns 400 when startDate is after endDate', async () => {
+    req.query = { startDate: '2024-06-30', endDate: '2024-06-01' };
+
+    await controller.getDeviceBreakdown(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: 'Invalid date range: startDate cannot be after endDate',
+    });
+  });
+
+  it('computes sessions, bounce rate, and avg engagement time per device', async () => {
+    req.query = { startDate: '2024-06-01', endDate: '2024-06-30' };
+
+    mockAnonymousInteraction.aggregate
+      .mockResolvedValueOnce([
+        { _id: 'desktop', sessions: 80, bouncedSessions: 20, avgEngagementTime: 300 },
+        { _id: 'mobile', sessions: 20, bouncedSessions: 15, avgEngagementTime: 90 },
+      ])
+      .mockResolvedValueOnce([
+        { _id: 'desktop', sessions: 60, bouncedSessions: 10, avgEngagementTime: 280 },
+        { _id: 'tablet', sessions: 40, bouncedSessions: 5, avgEngagementTime: 200 },
+      ]);
+
+    await controller.getDeviceBreakdown(req, res);
+
+    expect(mockAnonymousInteraction.aggregate).toHaveBeenCalledTimes(2);
+    expect(res.status).toHaveBeenCalledWith(200);
+
+    const response = res.json.mock.calls[0][0];
+    expect(response.deviceBreakdown).toHaveLength(3);
+
+    const desktop = response.deviceBreakdown.find(d => d.name === 'Desktop');
+    expect(desktop.sessions).toBe(80);
+    expect(desktop.bounceRate).toBe(25);
+    expect(desktop.avgEngagementTime).toBe(300);
+    expect(desktop.value).toBe(80);
+    expect(desktop.previousValue).toBe(60);
+
+    const mobile = response.deviceBreakdown.find(d => d.name === 'Mobile');
+    expect(mobile.sessions).toBe(20);
+    expect(mobile.bounceRate).toBe(75);
+    expect(mobile.value).toBe(20);
+    expect(mobile.previousValue).toBe(0);
+
+    const tablet = response.deviceBreakdown.find(d => d.name === 'Tablet');
+    expect(tablet.sessions).toBe(0);
+    expect(tablet.bounceRate).toBe(0);
+    expect(tablet.previousValue).toBe(40);
+  });
+
+  it('returns zeroed-out breakdown when there is no data at all', async () => {
+    req.query = { startDate: '2024-06-01', endDate: '2024-06-30' };
+    mockAnonymousInteraction.aggregate.mockResolvedValue([]);
+
+    await controller.getDeviceBreakdown(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    const response = res.json.mock.calls[0][0];
+    expect(response.deviceBreakdown).toHaveLength(3);
+    response.deviceBreakdown.forEach(device => {
+      expect(device.sessions).toBe(0);
+      expect(device.bounceRate).toBe(0);
+      expect(device.value).toBe(0);
+      expect(device.previousValue).toBe(0);
+      expect(device.avgEngagementTime).toBe(0);
+    });
+  });
+
+  it('returns 500 when the aggregation throws', async () => {
+    req.query = { startDate: '2024-06-01', endDate: '2024-06-30' };
+    mockAnonymousInteraction.aggregate.mockRejectedValue(new Error('DB error'));
+
+    await controller.getDeviceBreakdown(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith({ error: 'Internal Server Error' });
+  });
+});

--- a/src/controllers/applicantAnalyticsController.js
+++ b/src/controllers/applicantAnalyticsController.js
@@ -379,6 +379,123 @@ const analyticsController = function (
     }
   };
 
+
+  // Get device-specific engagement breakdown (sessions, bounce rate, avg
+  // engagement time per device type), for the Job Analytics device chart.
+  // Admin/owner only.
+  const getDeviceBreakdown = async (req, res) => {
+    try {
+      if (req.body.requestor.role !== 'Owner' && req.body.requestor.role !== 'Administrator') {
+        return res.status(403).json({ error: 'Insufficient permissions' });
+      }
+
+      const { startDate, endDate } = req.query;
+
+      if (!startDate || !endDate) {
+        return res.status(400).json({ error: 'startDate and endDate are required' });
+      }
+
+      const start = new Date(startDate);
+      const end = new Date(endDate);
+
+      if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
+        return res.status(400).json({ error: 'Invalid date format' });
+      }
+
+      if (start > end) {
+        return res.status(400).json({
+          error: 'Invalid date range: startDate cannot be after endDate',
+        });
+      }
+
+      // Previous period: same length, immediately preceding startDate.
+      const rangeMs = end.getTime() - start.getTime();
+      const prevEnd = new Date(start.getTime() - 1);
+      const prevStart = new Date(prevEnd.getTime() - rangeMs);
+
+      const buildDeviceStatsPipeline = (rangeStart, rangeEnd) => [
+        {
+          $match: {
+            timestamp: { $gte: rangeStart, $lte: rangeEnd },
+          },
+        },
+        // Stage 1: collapse raw interactions into one row per session,
+        // capturing how many interactions happened and the session's
+        // recorded duration (engagement time).
+        {
+          $group: {
+            _id: { sessionId: '$sessionId', deviceType: '$deviceType' },
+            interactionCount: { $sum: 1 },
+            sessionDuration: { $max: '$sessionDuration' },
+          },
+        },
+        // Stage 2: aggregate sessions by device type.
+        {
+          $group: {
+            _id: '$_id.deviceType',
+            sessions: { $sum: 1 },
+            bouncedSessions: {
+              $sum: { $cond: [{ $eq: ['$interactionCount', 1] }, 1, 0] },
+            },
+            avgEngagementTime: { $avg: '$sessionDuration' },
+          },
+        },
+      ];
+
+      const [currentStats, previousStats] = await Promise.all([
+        AnonymousInteraction.aggregate(buildDeviceStatsPipeline(start, end)),
+        AnonymousInteraction.aggregate(buildDeviceStatsPipeline(prevStart, prevEnd)),
+      ]);
+
+      const DEVICE_TYPES = ['desktop', 'mobile', 'tablet'];
+
+      const toMap = stats => {
+        const map = {};
+        stats.forEach(row => {
+          map[row._id] = row;
+        });
+        return map;
+      };
+
+      const currentMap = toMap(currentStats);
+      const previousMap = toMap(previousStats);
+
+      const currentTotalSessions = currentStats.reduce((sum, row) => sum + row.sessions, 0);
+      const previousTotalSessions = previousStats.reduce((sum, row) => sum + row.sessions, 0);
+
+      const deviceBreakdown = DEVICE_TYPES.map(device => {
+        const current = currentMap[device] || { sessions: 0, bouncedSessions: 0, avgEngagementTime: 0 };
+        const previous = previousMap[device] || { sessions: 0, bouncedSessions: 0, avgEngagementTime: 0 };
+
+        const value =
+          currentTotalSessions > 0
+            ? Math.round((current.sessions / currentTotalSessions) * 100)
+            : 0;
+        const previousValue =
+          previousTotalSessions > 0
+            ? Math.round((previous.sessions / previousTotalSessions) * 100)
+            : 0;
+        const bounceRate =
+          current.sessions > 0
+            ? Math.round((current.bouncedSessions / current.sessions) * 1000) / 10
+            : 0;
+
+        return {
+          name: device.charAt(0).toUpperCase() + device.slice(1),
+          value,
+          previousValue,
+          sessions: current.sessions,
+          bounceRate,
+          avgEngagementTime: Math.round(current.avgEngagementTime || 0),
+        };
+      });
+
+      return res.status(200).json({ deviceBreakdown });
+    } catch (error) {
+      console.error('Error fetching device breakdown:', error);
+      return res.status(500).json({ error: 'Internal Server Error' });
+    }
+  };
   // Manual aggregation trigger (admin/owner only) - backup for cron job
   const triggerAggregation = async (req, res) => {
     try {
@@ -651,6 +768,7 @@ const analyticsController = function (
     trackApplication,
     getInteractionSummary,
     getConversionMetrics,
+    getDeviceBreakdown,
     triggerAggregation,
   };
 };

--- a/src/routes/applicantAnalyticsRoutes.js
+++ b/src/routes/applicantAnalyticsRoutes.js
@@ -15,6 +15,7 @@ const {
   trackApplication,
   getInteractionSummary,
   getConversionMetrics,
+  getDeviceBreakdown,
   triggerAggregation,
 } = analyticsController(Applicant, AnonymousInteraction, AnonymousApplication, AnalyticsSummary);
 
@@ -29,6 +30,7 @@ router.post('/track-application', trackApplication);
 // admin only - auth handled in controller
 router.get('/summary', getInteractionSummary);
 router.get('/conversions', getConversionMetrics);
+router.get('/device-breakdown', getDeviceBreakdown);
 
 // Manual aggregation trigger (admin only - backup for cron job)
 router.post('/trigger-aggregation', triggerAggregation);


### PR DESCRIPTION
Description
<img width="337" height="414" alt="backend" src="https://github.com/user-attachments/assets/ac5747b9-b728-4afa-9da5-7d4912613cf6" />

Adds the missing backend endpoint for Ticket #34 (Job Analytics Page - Add Device-Specific Engagement Metrics). This is the companion backend for frontend PR #4998, which currently uses mock data.

New Endpoint
`GET /api/applicant-analytics/device-breakdown?startDate=YYYY-MM-DD&endDate=YYYY-MM-DD`

Returns real, computed per-device engagement metrics from the existing `AnonymousInteraction` collection:
- sessions (distinct session count per device)
- bounceRate (% of sessions with only 1 interaction)
- avgEngagementTime (average session duration)
- value / previousValue (% share of total sessions, current vs. previous period of equal length)

Response shape matches exactly what the frontend's `generateMockAnalyticsData().deviceBreakdown` already expects, so wiring it in should be a drop-in replacement of the mock.

## Related PR
Frontend: #[4998](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4998) (needs this backend, per its own description: "This frontend PR is not related to any backend PR")

How to test
1. Check out this branch, run `npm install` and `npm run dev`
2. Get a valid JWT for an Administrator/Owner user
3. `curl -H "Authorization: <token>" "http://localhost:4500/api/applicant-analytics/device-breakdown?startDate=2025-08-01&endDate=2025-08-31"`
4. Confirm the response includes Desktop/Mobile/Tablet entries with sessions, bounceRate, avgEngagementTime, value, previousValue

 Testing
Added 7 new unit tests covering: permission checks, date validation, the core aggregation math (verified against hand-calculated expected values), no-data edge case, and error handling. All existing tests (150/151 suites) and lint pass — the one pre-existing failure (`reasonSchedulingController`) is a local MongoDB timeout unrelated to this change.

Also manually verified live against the dev database — confirmed real session/bounce-rate/engagement-time data is correctly aggregated and returned.