### PR TITLE
Amaresh: Add POST /badge/assign endpoint for multi-user badge assignment

### DIFF
--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -168,6 +168,89 @@ const badgeController = function (Badge) {
     }
   };
 
+  /**
+   * Assigns one or more badges to one or more users in a single request.
+   * Increments the count of a badge a user already has, or adds it as a new
+   * entry with count 1. Used by the bulk "Assign Badge" flow which lets an
+   * admin select multiple users and multiple badges at once.
+   */
+  const assignBadgesToMultipleUsers = async function (req, res) {
+    if (!(await helper.hasPermission(req.body.requestor, 'assignBadges'))) {
+      res.status(403).send('You are not authorized to assign badges.');
+      return;
+    }
+
+    const { userIds, selectedBadges } = req.body;
+
+    if (!Array.isArray(userIds) || userIds.length === 0) {
+      res.status(400).send('userIds must be a non-empty array.');
+      return;
+    }
+
+    if (!Array.isArray(selectedBadges) || selectedBadges.length === 0) {
+      res.status(400).send('selectedBadges must be a non-empty array.');
+      return;
+    }
+
+    try {
+      const results = await Promise.all(
+        userIds.map(async (userId) => {
+          try {
+            const record = await UserProfile.findById(userId);
+            if (!record) {
+              return { userId, success: false, reason: 'User not found' };
+            }
+
+            if (!Array.isArray(record.badgeCollection)) {
+              record.badgeCollection = [];
+            }
+
+            selectedBadges.forEach((badgeId) => {
+              const existing = record.badgeCollection.find(
+                (item) => item.badge && item.badge.toString() === badgeId.toString(),
+              );
+
+              if (existing) {
+                existing.count = (existing.count || 0) + 1;
+                existing.lastModified = Date.now();
+                existing.earnedDate.push(new Date());
+              } else {
+                record.badgeCollection.push({
+                  badge: badgeId,
+                  count: 1,
+                  lastModified: Date.now(),
+                  earnedDate: [new Date()],
+                  featured: false,
+                });
+              }
+            });
+
+            record.badgeCount = (record.badgeCount || 0) + selectedBadges.length;
+
+            if (cache.hasCache(`user-${userId}`)) {
+              cache.removeCache(`user-${userId}`);
+            }
+
+            await record.save();
+            return { userId, success: true };
+          } catch (err) {
+            return { userId, success: false, reason: err.message };
+          }
+        }),
+      );
+
+      const failures = results.filter((result) => !result.success);
+      if (failures.length === userIds.length) {
+        res.status(400).send({ message: 'Failed to assign badges to any user.', results });
+        return;
+      }
+
+      res.status(200).send({ message: 'Badges assigned successfully.', results });
+    } catch (err) {
+      res.status(500).send(`Internal Error: Badge Assignment. ${err.message}`);
+    }
+  };
+
   const postBadge = async function (req, res) {
     if (!(await helper.hasPermission(req.body.requestor, 'createBadges'))) {
       res.status(403).send({ error: 'You are not authorized to create new badges.' });
@@ -344,6 +427,7 @@ const badgeController = function (Badge) {
     awardNewBadges,
     getAllBadges,
     assignBadges,
+    assignBadgesToMultipleUsers,
     postBadge,
     deleteBadge,
     putBadge,

--- a/src/controllers/badgeController.js
+++ b/src/controllers/badgeController.js
@@ -192,63 +192,59 @@ const badgeController = function (Badge) {
       return;
     }
 
-    try {
-      const results = await Promise.all(
-        userIds.map(async (userId) => {
-          try {
-            const record = await UserProfile.findById(userId);
-            if (!record) {
-              return { userId, success: false, reason: 'User not found' };
-            }
+    const assignToUser = async (userId) => {
+      try {
+        const record = await UserProfile.findById(userId);
+        if (!record) {
+          return { userId, success: false, reason: 'User not found' };
+        }
 
-            if (!Array.isArray(record.badgeCollection)) {
-              record.badgeCollection = [];
-            }
+        if (!Array.isArray(record.badgeCollection)) {
+          record.badgeCollection = [];
+        }
 
-            selectedBadges.forEach((badgeId) => {
-              const existing = record.badgeCollection.find(
-                (item) => item.badge && item.badge.toString() === badgeId.toString(),
-              );
+        selectedBadges.forEach((badgeId) => {
+          const existing = record.badgeCollection.find(
+            (item) => item.badge && item.badge.toString() === badgeId.toString(),
+          );
 
-              if (existing) {
-                existing.count = (existing.count || 0) + 1;
-                existing.lastModified = Date.now();
-                existing.earnedDate.push(new Date());
-              } else {
-                record.badgeCollection.push({
-                  badge: badgeId,
-                  count: 1,
-                  lastModified: Date.now(),
-                  earnedDate: [new Date()],
-                  featured: false,
-                });
-              }
+          if (existing) {
+            existing.count = (existing.count || 0) + 1;
+            existing.lastModified = Date.now();
+            existing.earnedDate.push(new Date());
+          } else {
+            record.badgeCollection.push({
+              badge: badgeId,
+              count: 1,
+              lastModified: Date.now(),
+              earnedDate: [new Date()],
+              featured: false,
             });
-
-            record.badgeCount = (record.badgeCount || 0) + selectedBadges.length;
-
-            if (cache.hasCache(`user-${userId}`)) {
-              cache.removeCache(`user-${userId}`);
-            }
-
-            await record.save();
-            return { userId, success: true };
-          } catch (err) {
-            return { userId, success: false, reason: err.message };
           }
-        }),
-      );
+        });
 
-      const failures = results.filter((result) => !result.success);
-      if (failures.length === userIds.length) {
-        res.status(400).send({ message: 'Failed to assign badges to any user.', results });
-        return;
+        record.badgeCount = (record.badgeCount || 0) + selectedBadges.length;
+
+        if (cache.hasCache(`user-${userId}`)) {
+          cache.removeCache(`user-${userId}`);
+        }
+
+        await record.save();
+        return { userId, success: true };
+      } catch (err) {
+        return { userId, success: false, reason: err.message };
       }
+    };
 
-      res.status(200).send({ message: 'Badges assigned successfully.', results });
-    } catch (err) {
-      res.status(500).send(`Internal Error: Badge Assignment. ${err.message}`);
+    const results = await Promise.all(userIds.map(assignToUser));
+
+    const failures = results.filter((result) => !result.success);
+    if (failures.length === userIds.length) {
+      res.status(400).send({ message: 'Failed to assign badges to any user.', results });
+      return;
     }
+
+    res.status(200).send({ message: 'Badges assigned successfully.', results });
   };
 
   const postBadge = async function (req, res) {

--- a/src/controllers/badgeController.test.js
+++ b/src/controllers/badgeController.test.js
@@ -1,0 +1,196 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('../models/userProfile');
+jest.mock('../utilities/permissions', () => ({
+  hasPermission: jest.fn(),
+}));
+jest.mock('../utilities/nodeCache', () => {
+  const mockCache = {
+    getCache: jest.fn(),
+    setCache: jest.fn(),
+    removeCache: jest.fn(),
+    hasCache: jest.fn(() => false),
+  };
+  return jest.fn(() => mockCache);
+});
+jest.mock('../helpers/userHelper', () =>
+  jest.fn(() => ({
+    awardNewBadges: jest.fn(),
+  })),
+);
+
+const UserProfile = require('../models/userProfile');
+const { hasPermission } = require('../utilities/permissions');
+const cacheClosure = require('../utilities/nodeCache');
+const badgeControllerFactory = require('./badgeController');
+
+const cache = cacheClosure();
+const controller = badgeControllerFactory({});
+
+const makeRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  send: jest.fn(),
+});
+
+describe('badgeController - assignBadgesToMultipleUsers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    hasPermission.mockResolvedValue(true);
+    cache.hasCache.mockReturnValue(false);
+  });
+
+  it('returns 403 when the requestor lacks the assignBadges permission', async () => {
+    hasPermission.mockResolvedValue(false);
+    const req = { body: { requestor: {}, userIds: ['u1'], selectedBadges: ['b1'] } };
+    const res = makeRes();
+
+    await controller.assignBadgesToMultipleUsers(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.send).toHaveBeenCalledWith('You are not authorized to assign badges.');
+    expect(UserProfile.findById).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when userIds is missing or not a non-empty array', async () => {
+    const res = makeRes();
+    await controller.assignBadgesToMultipleUsers({ body: { selectedBadges: ['b1'] } }, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith('userIds must be a non-empty array.');
+
+    const res2 = makeRes();
+    await controller.assignBadgesToMultipleUsers(
+      { body: { userIds: [], selectedBadges: ['b1'] } },
+      res2,
+    );
+    expect(res2.status).toHaveBeenCalledWith(400);
+  });
+
+  it('returns 400 when selectedBadges is missing or not a non-empty array', async () => {
+    const res = makeRes();
+    await controller.assignBadgesToMultipleUsers({ body: { userIds: ['u1'] } }, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith('selectedBadges must be a non-empty array.');
+
+    const res2 = makeRes();
+    await controller.assignBadgesToMultipleUsers(
+      { body: { userIds: ['u1'], selectedBadges: [] } },
+      res2,
+    );
+    expect(res2.status).toHaveBeenCalledWith(400);
+  });
+
+  it('adds a new badge entry for a user who does not already have it and bumps badgeCount', async () => {
+    const save = jest.fn().mockResolvedValue(true);
+    const record = { badgeCount: 2, badgeCollection: [], save };
+    UserProfile.findById.mockResolvedValue(record);
+    cache.hasCache.mockReturnValue(true);
+
+    const req = { body: { requestor: {}, userIds: ['u1'], selectedBadges: ['b1', 'b2'] } };
+    const res = makeRes();
+
+    await controller.assignBadgesToMultipleUsers(req, res);
+
+    expect(record.badgeCollection).toHaveLength(2);
+    expect(record.badgeCollection[0]).toMatchObject({ badge: 'b1', count: 1, featured: false });
+    expect(record.badgeCount).toBe(4); // 2 existing + 2 assigned
+    expect(cache.removeCache).toHaveBeenCalledWith('user-u1');
+    expect(save).toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Badges assigned successfully.',
+        results: [{ userId: 'u1', success: true }],
+      }),
+    );
+  });
+
+  it('increments the count of a badge the user already has instead of duplicating it', async () => {
+    const save = jest.fn().mockResolvedValue(true);
+    const record = {
+      badgeCollection: [{ badge: 'b1', count: 3, earnedDate: ['old'], lastModified: 0 }],
+      save,
+    };
+    UserProfile.findById.mockResolvedValue(record);
+
+    const req = { body: { requestor: {}, userIds: ['u1'], selectedBadges: ['b1'] } };
+    const res = makeRes();
+
+    await controller.assignBadgesToMultipleUsers(req, res);
+
+    expect(record.badgeCollection).toHaveLength(1);
+    expect(record.badgeCollection[0].count).toBe(4);
+    expect(record.badgeCollection[0].earnedDate).toHaveLength(2);
+    expect(record.badgeCount).toBe(1); // undefined -> 0 + 1 assigned
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('initializes badgeCollection when the user record has none', async () => {
+    const save = jest.fn().mockResolvedValue(true);
+    const record = { save };
+    UserProfile.findById.mockResolvedValue(record);
+
+    const req = { body: { requestor: {}, userIds: ['u1'], selectedBadges: ['b1'] } };
+    const res = makeRes();
+
+    await controller.assignBadgesToMultipleUsers(req, res);
+
+    expect(Array.isArray(record.badgeCollection)).toBe(true);
+    expect(record.badgeCollection).toHaveLength(1);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('reports per-user failures but still returns 200 when at least one user succeeds', async () => {
+    const save = jest.fn().mockResolvedValue(true);
+    UserProfile.findById
+      .mockResolvedValueOnce(null) // u1: not found
+      .mockResolvedValueOnce({ badgeCollection: [], save }); // u2: ok
+
+    const req = { body: { requestor: {}, userIds: ['u1', 'u2'], selectedBadges: ['b1'] } };
+    const res = makeRes();
+
+    await controller.assignBadgesToMultipleUsers(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        results: [
+          { userId: 'u1', success: false, reason: 'User not found' },
+          { userId: 'u2', success: true },
+        ],
+      }),
+    );
+  });
+
+  it('returns 400 when every user fails', async () => {
+    UserProfile.findById.mockResolvedValue(null);
+
+    const req = { body: { requestor: {}, userIds: ['u1', 'u2'], selectedBadges: ['b1'] } };
+    const res = makeRes();
+
+    await controller.assignBadgesToMultipleUsers(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith(
+      expect.objectContaining({ message: 'Failed to assign badges to any user.' }),
+    );
+  });
+
+  it('captures a save error as a per-user failure reason', async () => {
+    const save = jest.fn().mockRejectedValue(new Error('write failed'));
+    UserProfile.findById.mockResolvedValue({ badgeCollection: [], save });
+
+    const req = { body: { requestor: {}, userIds: ['u1'], selectedBadges: ['b1'] } };
+    const res = makeRes();
+
+    await controller.assignBadgesToMultipleUsers(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        results: [{ userId: 'u1', success: false, reason: 'write failed' }],
+      }),
+    );
+  });
+});

--- a/src/routes/badgeRouter.js
+++ b/src/routes/badgeRouter.js
@@ -13,6 +13,8 @@ const routes = function (badge) {
 
   badgeRouter.route('/badge/assign/:userId').put(controller.assignBadges);
 
+  badgeRouter.route('/badge/assign').post(controller.assignBadgesToMultipleUsers);
+
   badgeRouter
     .route('/badge/badgecount/:userId')
     .get(controller.getBadgeCount)


### PR DESCRIPTION
## Description
The Badge Assignment feature on the frontend lets an admin select multiple users and multiple badges and assign them in one action. The frontend action `assignBadgesToMultipleUserID` sends `POST /api/badge/assign` with `{ userIds, selectedBadges }`, but that route never existed on the backend; only the single-user `PUT /api/badge/assign/:userId` did. Every bulk assignment hit a 404, and the UI showed "Oops, something went wrong while assigning badges!".

This PR adds the missing endpoint.

Fixes the badge-assignment failure reported on frontend PR [#4734](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4734)

## Related PRS (if any):
Paired with frontend PR OneCommunityGlobal/HighestGoodNetworkApp[#4734](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4734) (branch `Amalesh-3940-bugfix`).
To test this backend PR you need to check out the [#4734](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4734) frontend branch and run it against this backend branch.

## Main changes explained:
- Update `src/controllers/badgeController.js`: add `assignBadgesToMultipleUsers`:
  - Requires the `assignBadges` permission (403 otherwise)
  - Validates `userIds` and `selectedBadges` are non-empty arrays (400 otherwise)
  - For each user, for each selected badge: increments `count` and pushes a new `earnedDate` if the user already has that badge; otherwise, adds a new `badgeCollection` entry with `count: 1` and `featured: false`; bumps `badgeCount` by `selectedBadges.length`; clears that user's cache
  - Per-user try/catch so one bad ID does not fail the whole batch; returns `200` with a per-user results array, and `400` only if every user failed
- Update `src/routes/badgeRouter.js`: wire `POST /badge/assign` to `controller.assignBadgesToMultipleUsers` (added alongside the existing `PUT /badge/assign/:userId`)

## How to test:
1. Check out this branch (`amaresh/badge-assign-multiple-users`) in `HGNRest`, run `npm install`, then `npm run dev` (backend on `http://localhost:4500`)
2. In `HighestGoodNetworkApp`, check out `Amalesh-3940-bugfix`, run `npm install`, then `npm run start:local` (frontend on `http://localhost:5173`)
3. Clear site data / cache, log in as an Admin or Owner account (needs the `assignBadges` permission)
4. Go to `/badgemanagement` → Badge Assignment tab
5. Search a name, tick 2+ users → the status line should read `N user(s) selected`
6. Click Assign Badge, tick 1+ badges → status line shows `N badge(s) selected`
7. Click Confirm → expected: green success alert "Awesomesauce! ...for multiple users!" (not the red "Oops" error)
8. Open one of the selected users' profiles → Featured Badges section shows the assigned badge with the correct count; assigning increments the count again rather than adding a duplicate entry
9. Repeat as an Owner and as an Admin; both succeed. A user without `assignBadges` gets a 403.

## Screenshots or videos of changes:
<img width="1469" height="882" alt="Screenshot 2026-09-05 at 1 48 28 PM" src="https://github.com/user-attachments/assets/255dba88-199a-40f2-863a-d7d6a2a69524" />
<img width="1470" height="882" alt="Screenshot 2026-09-05 at 1 49 14 PM" src="https://github.com/user-attachments/assets/22cb4564-c099-43a7-9ac9-b88687e5a2b0" />
<img width="1450" height="867" alt="Screenshot 2026-09-05 at 1 49 28 PM" src="https://github.com/user-attachments/assets/c89f6941-d6c8-4ed1-90de-2fa286dde87f" />


## Note: