### PR TITLE
Ansh - 🔥 Total Org Summary badge stats aggregation

### DIFF
--- a/src/helpers/overviewReportHelper.js
+++ b/src/helpers/overviewReportHelper.js
@@ -1980,22 +1980,34 @@ const overviewReportHelper = function () {
       { $unwind: '$badgeCollection.earnedDate' },
       {
         $addFields: {
+          earnedDateString: {
+            $convert: {
+              input: '$badgeCollection.earnedDate',
+              to: 'string',
+              onError: '',
+              onNull: '',
+            },
+          },
+        },
+      },
+      {
+        $addFields: {
           fixedDateString: {
             $cond: {
               if: {
                 $regexMatch: {
-                  input: '$badgeCollection.earnedDate',
+                  input: '$earnedDateString',
                   regex: /^[A-Z][a-z]{2}-\d{2}-\d{2}$/,
                 },
               },
               then: {
                 $concat: [
-                  { $substr: ['$badgeCollection.earnedDate', 0, 6] },
+                  { $substr: ['$earnedDateString', 0, 6] },
                   '-20',
-                  { $substr: ['$badgeCollection.earnedDate', 7, 2] },
+                  { $substr: ['$earnedDateString', 7, 2] },
                 ],
               },
-              else: '$badgeCollection.earnedDate',
+              else: '$earnedDateString',
             },
           },
         },


### PR DESCRIPTION
# Description

Total Org Summary was still failing after the frontend crash was fixed because the `/reports/volunteerstats` endpoint returned a 500 error during badge statistics aggregation.

The failure occurred when `$regexMatch` received a non-string `badgeCollection.earnedDate` value.

This hotfix safely converts `earnedDate` values to strings before applying regex and substring operations.

## Root Cause

`getTotalBadgesAwardedCount()` assumed all `badgeCollection.earnedDate` values were strings.

At least one badge record contained an `earnedDate` value with a different type, causing MongoDB to throw:

`$regexMatch needs 'input' to be of type string`

That exception caused the volunteer stats endpoint to return 500 and prevented Total Org Summary from loading.

## Main Changes

- Convert `badgeCollection.earnedDate` to a string using `$convert`
- Handle null/error values safely
- Use the normalized string for regex and substring operations
- Preserve the existing badge date parsing behavior

## How to test

1. Run HGNRest locally.
2. Run the frontend locally.
3. Log in as an admin.
4. Navigate to Total Org Summary.
5. Verify Total Org Summary loads normally.

## Related Frontend PR

Frontend hotfix: [OneCommunityGlobal/HighestGoodNetworkApp#5512](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5512)