### PR TITLE
Sitaram - Fix paused users not being reactivated on their reactivation date

### DIFF
--- a/src/controllers/__tests__/userStatusPauseResume.spec.js
+++ b/src/controllers/__tests__/userStatusPauseResume.spec.js
@@ -1,0 +1,366 @@
+/**
+ * Tests for pausing and resuming a user.
+ *
+ * There are two implementations of "pause" in this controller. The buttons in
+ * User Management and on the profile page call `pauseResumeUser`, which wrote
+ * only `isActive` and `reactivationDate`, while `changeUserStatus` writes the
+ * full lifecycle field set. Everything that reads the missing fields was
+ * therefore wrong for anyone paused from the UI: the resume email had no
+ * paused-on date to report, and a final day set before the pause was left on
+ * the record.
+ *
+ * These tests pin both endpoints to the same field set so they cannot drift
+ * apart again, and pin the reactivation date to the start of that day in
+ * company time. The date matters: the modal sends a plain 'YYYY-MM-DD' string,
+ * and parsing it in the server's timezone before converting lands on the
+ * previous Pacific day on any server east of Los Angeles, which is every
+ * server we run on.
+ */
+
+const mockCache = {
+  getCache: jest.fn(),
+  setCache: jest.fn(),
+  removeCache: jest.fn(),
+  hasCache: jest.fn(),
+  clearByPrefix: jest.fn(),
+};
+
+const mockHasPermission = jest.fn();
+const mockCanRequestorUpdateUser = jest.fn();
+
+const mockUserHelper = {
+  getEmailRecipientsForStatusChange: jest.fn(),
+  checkTeamCodeMismatch: jest.fn(),
+  sendUserResumedEmail: jest.fn(),
+  sendUserReactivatedAfterSeparation: jest.fn(),
+  sendUserCancelledSeparationEmail: jest.fn(),
+  sendUserActivatedEmail: jest.fn(),
+  sendUserPausedEmail: jest.fn(),
+  sendUserSeparatedEmail: jest.fn(),
+  sendUserScheduledSeparationEmail: jest.fn(),
+  notifyInfringements: jest.fn(),
+};
+
+const mockLogger = { logInfo: jest.fn(), logError: jest.fn(), logException: jest.fn() };
+const mockIsProdIdentityEnforced = jest.fn();
+const mockEmitProductionUserStatusChange = jest.fn();
+
+jest.mock('../../utilities/nodeCache', () => () => mockCache);
+jest.mock('../../helpers/userHelper', () => () => mockUserHelper);
+jest.mock('../../utilities/permissions', () => ({
+  hasPermission: (...args) => mockHasPermission(...args),
+  canRequestorUpdateUser: (...args) => mockCanRequestorUpdateUser(...args),
+}));
+jest.mock('../../config/productionIdentityConfig', () => ({
+  isProductionIdentityEnforcementActive: (...args) => mockIsProdIdentityEnforced(...args),
+}));
+jest.mock('../../services/productionIdentityService', () => ({
+  verifyVerificationToken: jest.fn(),
+  verifyProductionCredentials: jest.fn(),
+}));
+jest.mock('../productionIdentityController', () => ({ logVerificationAttempt: jest.fn() }));
+jest.mock('../../services/productionWebhookEmitter', () => ({
+  emitProductionUserStatusChange: (...args) => mockEmitProductionUserStatusChange(...args),
+}));
+jest.mock('../../startup/logger', () => mockLogger);
+jest.mock('../reportsController', () => () => ({ invalidateWeeklySummariesCache: jest.fn() }));
+
+const moment = require('moment-timezone');
+const userProfileController = require('../userProfileController');
+const { COMPANY_TZ } = require('../../constants/company');
+const { InactiveReason, UserStatusOperations } = require('../../constants/userProfile');
+
+const USER_ID = '507f191e810c19729de860ea';
+const PAUSE_UNTIL = '2026-09-20';
+const NOW = '2026-09-01T18:30:00.000Z';
+
+/** The fields that together say where a user is in their lifecycle. */
+const LIFECYCLE_FIELDS = [
+  'isActive',
+  'inactiveReason',
+  'deactivatedAt',
+  'reactivationDate',
+  'endDate',
+  'isSet',
+  'finalEmailThreeWeeksSent',
+];
+
+const lifecycleFields = (doc) => {
+  const picked = {};
+  LIFECYCLE_FIELDS.forEach((field) => {
+    const value = doc[field];
+    picked[field] = value instanceof Date ? value.toISOString() : value ?? null;
+  });
+  return picked;
+};
+
+/**
+ * A stored user, handed back through the same field projection the controller
+ * asks for. A field the query does not select is genuinely absent, which is
+ * what made the resume email lose the paused-on date.
+ */
+const makeUserProfileModel = (stored) => {
+  const saved = [];
+  const model = {
+    findById: jest.fn((id, projection) => {
+      const doc = { _id: id, save: jest.fn(async () => saved.push(doc)) };
+      const fields = projection ? projection.split(/\s+/).filter(Boolean) : Object.keys(stored);
+      fields.forEach((field) => {
+        if (field in stored) doc[field] = stored[field];
+      });
+      doc.set = (values) => Object.assign(doc, values);
+      model.doc = doc;
+      return Promise.resolve(doc);
+    }),
+    saved,
+  };
+  return model;
+};
+
+const storedPausedUser = (overrides = {}) => ({
+  _id: USER_ID,
+  firstName: 'Ann',
+  lastName: 'Adams',
+  email: 'ann@example.com',
+  isActive: true,
+  endDate: null,
+  isSet: false,
+  finalEmailThreeWeeksSent: false,
+  reactivationDate: null,
+  inactiveReason: undefined,
+  deactivatedAt: null,
+  teams: [],
+  teamCode: 'A-TEAM',
+  ...overrides,
+});
+
+const requestor = {
+  requestorId: USER_ID,
+  role: 'Owner',
+  permissions: { frontPermissions: [] },
+  email: 'owner@example.com',
+};
+
+const makeRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  send: jest.fn(),
+  json: jest.fn(),
+});
+
+/** Pause or resume through the endpoint the UI buttons actually call. */
+const callPauseEndpoint = async (stored, { status, reactivationDate }) => {
+  const model = makeUserProfileModel(stored);
+  const controller = userProfileController(model, {});
+  const res = makeRes();
+  await controller.pauseResumeUser(
+    { params: { userId: USER_ID }, body: { requestor, status, reactivationDate } },
+    res,
+  );
+  return { doc: model.doc, res };
+};
+
+/** Pause or resume through the lifecycle endpoint. */
+const callLifecycleEndpoint = async (stored, body) => {
+  const model = makeUserProfileModel(stored);
+  const controller = userProfileController(model, {});
+  const res = makeRes();
+  await controller.changeUserStatus(
+    { params: { userId: USER_ID }, body: { requestor, ...body } },
+    res,
+  );
+  return { doc: model.doc, res };
+};
+
+describe('pausing and resuming a user', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+    jest.setSystemTime(new Date(NOW));
+
+    // Production runs on UTC, so a date-only string parsed without an explicit
+    // zone is a UTC date there, not a Pacific one.
+    moment.tz.setDefault('UTC');
+
+    mockCache.getCache.mockReturnValue(null);
+    mockCache.hasCache.mockReturnValue(false);
+    mockCanRequestorUpdateUser.mockResolvedValue(true);
+    mockHasPermission.mockResolvedValue(true);
+    mockIsProdIdentityEnforced.mockReturnValue(false);
+    mockEmitProductionUserStatusChange.mockResolvedValue();
+    mockUserHelper.getEmailRecipientsForStatusChange.mockResolvedValue(['admin@example.com']);
+    mockUserHelper.checkTeamCodeMismatch.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    moment.tz.setDefault();
+  });
+
+  test('pausing records that the user is paused, and when', async () => {
+    const { doc } = await callPauseEndpoint(storedPausedUser(), {
+      status: 'Inactive',
+      reactivationDate: PAUSE_UNTIL,
+    });
+
+    expect(doc.isActive).toBe(false);
+    expect(doc.inactiveReason).toBe(InactiveReason.PAUSED);
+    expect(moment(doc.deactivatedAt).toISOString()).toBe(NOW);
+  });
+
+  test('pausing brings the user back on the chosen day, not the day before', async () => {
+    const { doc } = await callPauseEndpoint(storedPausedUser(), {
+      status: 'Inactive',
+      reactivationDate: PAUSE_UNTIL,
+    });
+
+    expect(moment(doc.reactivationDate).tz(COMPANY_TZ).format('YYYY-MM-DD HH:mm')).toBe(
+      '2026-09-20 00:00',
+    );
+  });
+
+  test('pausing clears a final day left over from an earlier separation', async () => {
+    const { doc } = await callPauseEndpoint(
+      storedPausedUser({ endDate: new Date('2026-10-05T06:59:59.000Z'), isSet: true }),
+      { status: 'Inactive', reactivationDate: PAUSE_UNTIL },
+    );
+
+    expect(doc.endDate).toBeNull();
+    expect(doc.isSet).toBe(false);
+  });
+
+  test('pausing tells management when the user is due back', async () => {
+    const { doc } = await callPauseEndpoint(storedPausedUser(), {
+      status: 'Inactive',
+      reactivationDate: PAUSE_UNTIL,
+    });
+
+    expect(mockUserHelper.sendUserPausedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: 'ann@example.com',
+        reactivationDate: doc.reactivationDate,
+        recipients: ['admin@example.com'],
+      }),
+    );
+  });
+
+  test('resuming clears every field the pause set', async () => {
+    const { doc } = await callPauseEndpoint(
+      storedPausedUser({
+        isActive: false,
+        inactiveReason: InactiveReason.PAUSED,
+        deactivatedAt: new Date('2026-08-01T12:00:00.000Z'),
+        reactivationDate: new Date('2026-09-20T07:00:00.000Z'),
+      }),
+      { status: 'Active' },
+    );
+
+    expect(doc.isActive).toBe(true);
+    expect(doc.reactivationDate ?? null).toBeNull();
+    expect(doc.deactivatedAt ?? null).toBeNull();
+    expect(doc.endDate ?? null).toBeNull();
+    expect(doc.inactiveReason ?? null).toBeNull();
+    expect(doc.isSet).toBe(false);
+    expect(doc.finalEmailThreeWeeksSent).toBe(false);
+  });
+
+  test('resuming reports the date the user was paused on', async () => {
+    const pausedOn = new Date('2026-08-01T12:00:00.000Z');
+    await callPauseEndpoint(
+      storedPausedUser({
+        isActive: false,
+        inactiveReason: InactiveReason.PAUSED,
+        deactivatedAt: pausedOn,
+        reactivationDate: new Date('2026-09-20T07:00:00.000Z'),
+      }),
+      { status: 'Active' },
+    );
+
+    expect(mockUserHelper.sendUserResumedEmail).toHaveBeenCalledWith(
+      expect.objectContaining({ email: 'ann@example.com', pausedOn }),
+    );
+  });
+
+  test('a pause with no date is refused rather than pausing the user forever', async () => {
+    const model = makeUserProfileModel(storedPausedUser());
+    const controller = userProfileController(model, {});
+    const res = makeRes();
+
+    await controller.pauseResumeUser(
+      { params: { userId: USER_ID }, body: { requestor, status: 'Inactive' } },
+      res,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(model.saved).toHaveLength(0);
+  });
+
+  test('the cached user list keeps the reactivation date after a pause', async () => {
+    mockCache.hasCache.mockReturnValue(true);
+    mockCache.getCache.mockReturnValue(JSON.stringify([{ _id: USER_ID, isActive: true }]));
+
+    const { doc } = await callPauseEndpoint(storedPausedUser(), {
+      status: 'Inactive',
+      reactivationDate: PAUSE_UNTIL,
+    });
+
+    const cached = JSON.parse(mockCache.setCache.mock.calls[0][1])[0];
+    expect(cached.isActive).toBe(false);
+    expect(moment(cached.reactivationDate).toISOString()).toBe(
+      moment(doc.reactivationDate).toISOString(),
+    );
+  });
+});
+
+describe('the two pause implementations agree', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+    jest.setSystemTime(new Date(NOW));
+    moment.tz.setDefault('UTC');
+
+    mockCache.getCache.mockReturnValue(null);
+    mockCache.hasCache.mockReturnValue(false);
+    mockCanRequestorUpdateUser.mockResolvedValue(true);
+    mockHasPermission.mockResolvedValue(true);
+    mockIsProdIdentityEnforced.mockReturnValue(false);
+    mockEmitProductionUserStatusChange.mockResolvedValue();
+    mockUserHelper.getEmailRecipientsForStatusChange.mockResolvedValue(['admin@example.com']);
+    mockUserHelper.checkTeamCodeMismatch.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    moment.tz.setDefault();
+  });
+
+  test('a pause writes the same lifecycle fields whichever endpoint runs it', async () => {
+    const stored = storedPausedUser();
+
+    const legacy = await callPauseEndpoint(stored, {
+      status: 'Inactive',
+      reactivationDate: PAUSE_UNTIL,
+    });
+    const lifecycle = await callLifecycleEndpoint(stored, {
+      action: UserStatusOperations.PAUSE,
+      reactivationDate: PAUSE_UNTIL,
+    });
+
+    expect(lifecycleFields(legacy.doc)).toEqual(lifecycleFields(lifecycle.doc));
+  });
+
+  test('a resume writes the same lifecycle fields whichever endpoint runs it', async () => {
+    const stored = storedPausedUser({
+      isActive: false,
+      inactiveReason: InactiveReason.PAUSED,
+      deactivatedAt: new Date('2026-08-01T12:00:00.000Z'),
+      reactivationDate: new Date('2026-09-20T07:00:00.000Z'),
+    });
+
+    const legacy = await callPauseEndpoint(stored, { status: 'Active' });
+    const lifecycle = await callLifecycleEndpoint(stored, {
+      action: UserStatusOperations.ACTIVATE,
+    });
+
+    expect(lifecycleFields(legacy.doc)).toEqual(lifecycleFields(lifecycle.doc));
+  });
+});

--- a/src/controllers/userProfileController.js
+++ b/src/controllers/userProfileController.js
@@ -110,6 +110,7 @@ const {
   UserStatusOperations,
   LifecycleStatus,
 } = require('../constants/userProfile');
+const { pauseFields, activeFields, LIFECYCLE_PROJECTION } = require('../helpers/userStatusFields');
 
 async function ValidatePassword(req, res) {
   const { userId } = req.params;
@@ -2008,9 +2009,12 @@ const createControllerMethods = function (UserProfile, Project, cache) {
       cache.removeCache(`user-${userId}`);
       const recipients = await userHelper.getEmailRecipientsForStatusChange(userId);
 
+      // deactivatedAt is in the projection because the resume email reports the
+      // date the user was paused on, and a field left out of the projection
+      // reads as undefined rather than as its stored value.
       const user = await UserProfile.findById(
         userId,
-        'isActive email firstName lastName teams teamCode endDate isSet finalEmailThreeWeeksSent reactivationDate inactiveReason deactivatedByProductionSync',
+        `email firstName lastName teams teamCode deactivatedByProductionSync ${LIFECYCLE_PROJECTION}`,
       );
 
       if (!user) {
@@ -2036,13 +2040,7 @@ const createControllerMethods = function (UserProfile, Project, cache) {
                 'This Dev account was deactivated because the linked Production account is inactive. It can only be reactivated when Production reactivates the account.',
             });
           }
-          user.isActive = true;
-          user.inactiveReason = undefined;
-          user.deactivatedAt = null;
-          user.reactivationDate = null;
-          user.endDate = null;
-          user.isSet = false;
-          user.finalEmailThreeWeeksSent = false;
+          user.set(activeFields());
           break;
         }
 
@@ -2078,15 +2076,7 @@ const createControllerMethods = function (UserProfile, Project, cache) {
           if (!reactivationDate) {
             return res.status(400).send({ error: 'Reactivation date is required for pause' });
           }
-          user.isActive = false;
-          user.inactiveReason = InactiveReason.PAUSED;
-          user.deactivatedAt = moment().tz(COMPANY_TZ).toISOString();
-          user.reactivationDate = moment(reactivationDate)
-            .tz(COMPANY_TZ)
-            .startOf('day')
-            .toISOString();
-          user.endDate = null;
-          user.isSet = false;
+          user.set(pauseFields(reactivationDate));
           break;
         }
 
@@ -2166,18 +2156,31 @@ const createControllerMethods = function (UserProfile, Project, cache) {
       return res.status(403).send('You are not authorized to change user status');
     }
 
+    if (!status && !activationDate) {
+      return res.status(400).send({ error: 'Reactivation date is required for pause' });
+    }
+
     cache.removeCache(`user-${userId}`);
 
     try {
-      const user = await UserProfile.findById(userId, 'isActive email firstName lastName');
+      const user = await UserProfile.findById(
+        userId,
+        `email firstName lastName ${LIFECYCLE_PROJECTION}`,
+      );
       if (!user) {
         return res.status(404).send({ error: 'User not found' });
       }
 
-      user.set({
-        isActive: status,
-        reactivationDate: activationDate,
-      });
+      // Read before the update, because the resume email reports the date the
+      // user was paused on and the update clears it.
+      const pausedOn = user.deactivatedAt;
+      const recipients = await userHelper.getEmailRecipientsForStatusChange(userId);
+
+      // The same fields the lifecycle endpoint writes. These two are the only
+      // ways to pause or resume from the UI and they have to agree about what
+      // paused and active mean.
+      const appliedFields = status ? activeFields() : pauseFields(activationDate);
+      user.set(appliedFields);
 
       await user.save();
 
@@ -2186,13 +2189,28 @@ const createControllerMethods = function (UserProfile, Project, cache) {
         const allUserData = JSON.parse(cache.getCache('allusers'));
         const userIdx = allUserData.findIndex((u) => u._id === userId);
         if (userIdx !== -1) {
-          const userData = allUserData[userIdx];
-          userData.isActive = user.isActive;
-          userData.reactivationDate = null;
-          userData.endDate = null;
+          const userData = { ...allUserData[userIdx], ...appliedFields };
           allUserData.splice(userIdx, 1, userData);
           cache.setCache('allusers', JSON.stringify(allUserData));
         }
+      }
+
+      if (status) {
+        userHelper.sendUserResumedEmail({
+          firstName: user.firstName,
+          lastName: user.lastName,
+          email: user.email,
+          recipients,
+          pausedOn,
+        });
+      } else {
+        userHelper.sendUserPausedEmail({
+          firstName: user.firstName,
+          lastName: user.lastName,
+          email: user.email,
+          reactivationDate: user.reactivationDate,
+          recipients,
+        });
       }
 
       auditIfProtectedAccountUpdated({

--- a/src/cronjobs/userProfileJobs.js
+++ b/src/cronjobs/userProfileJobs.js
@@ -67,8 +67,23 @@ const userProfileJobs = () => {
     // '* * * * *', // Comment out for testing. Run Every minute.
     '1 0 * * *', // Every day, 1 minute past midnight
     async () => {
-      await userhelper.reactivateUser();
-      await userhelper.finalizeUserEndDates();
+      // Each step is isolated. These two are unrelated, and previously a throw
+      // in the first one silently took the second one with it: this called
+      // reactivateUser while the helper exported reActivateUser, so the call
+      // was undefined and threw every night. Nobody was reactivated, and
+      // finalizeUserEndDates never ran either. Nothing surfaced because the
+      // rejection was unhandled.
+      try {
+        await userhelper.reactivateUser();
+      } catch (error) {
+        console.error('Error during reactivateUser:', error);
+      }
+
+      try {
+        await userhelper.finalizeUserEndDates();
+      } catch (error) {
+        console.error('Error during finalizeUserEndDates:', error);
+      }
     },
     null,
     false,

--- a/src/helpers/__tests__/reactivateUser.spec.js
+++ b/src/helpers/__tests__/reactivateUser.spec.js
@@ -1,0 +1,208 @@
+/**
+ * Tests for the daily paused-user reactivation job.
+ *
+ * The bug this covers: the cron called `userhelper.reactivateUser()` while the
+ * helper exported `reActivateUser`, so it threw a TypeError every night, nobody
+ * was ever reactivated, and the unhandled rejection also stopped
+ * `finalizeUserEndDates()` on the following line from running.
+ */
+
+jest.mock('../../models/userProfile', () => ({
+  find: jest.fn(),
+  findById: jest.fn(),
+  findByIdAndUpdate: jest.fn().mockResolvedValue({}),
+  aggregate: jest.fn(),
+  updateOne: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../../models/badge', () => ({ find: jest.fn(), findOne: jest.fn() }));
+jest.mock('../../models/team', () => ({ aggregate: jest.fn(), find: jest.fn() }));
+jest.mock('../dashboardhelper', () => jest.fn(() => ({ laborthisweek: jest.fn() })));
+jest.mock('../../utilities/emailSender', () => jest.fn());
+jest.mock('../../startup/logger', () => ({
+  logInfo: jest.fn(),
+  logException: jest.fn(),
+}));
+
+const moment = require('moment-timezone');
+const userProfile = require('../../models/userProfile');
+const emailSender = require('../../utilities/emailSender');
+const logger = require('../../startup/logger');
+const userHelperFactory = require('../userHelper');
+const { COMPANY_TZ } = require('../../constants/company');
+
+const helper = userHelperFactory();
+const { reactivateUser } = helper;
+
+const USER_ID = '637af0c0fb9bbc1e308cff01';
+
+/** A paused user, due back on the given date. */
+const pausedUser = (reactivationDate, overrides = {}) => ({
+  _id: USER_ID,
+  firstName: 'Ann',
+  lastName: 'Adams',
+  email: 'ann@example.com',
+  deactivatedAt: new Date('2026-08-01T12:00:00Z'),
+  reactivationDate,
+  ...overrides,
+});
+
+const setUpdate = () => userProfile.findByIdAndUpdate.mock.calls[0][1].$set;
+const unsetUpdate = () => userProfile.findByIdAndUpdate.mock.calls[0][1].$unset;
+
+describe('reactivateUser', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    userProfile.find.mockResolvedValue([]);
+    userProfile.findByIdAndUpdate.mockResolvedValue({});
+    // getEmailRecipientsForStatusChange reads teams off the profile.
+    userProfile.findById.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  const freezeAt = (iso) => {
+    jest.useFakeTimers({ doNotFake: ['nextTick', 'setImmediate'] });
+    jest.setSystemTime(new Date(iso));
+  };
+
+  it('is exported under the name the cron job actually calls', () => {
+    // The whole bug in one assertion. The helper used to export
+    // `reActivateUser` while userProfileJobs.js called `reactivateUser`.
+    expect(typeof helper.reactivateUser).toBe('function');
+    expect(helper.reActivateUser).toBeUndefined();
+  });
+
+  it('only looks at inactive users who have a reactivation date', async () => {
+    await reactivateUser();
+
+    const [query] = userProfile.find.mock.calls[0];
+    expect(query.isActive).toBe(false);
+    // Not `$exists`, which also matches an explicit null.
+    expect(query.reactivationDate).toEqual({ $ne: null });
+  });
+
+  it('reactivates somebody whose date is today', async () => {
+    // Stored as the start of the day in company time; the job runs 00:01.
+    const today = moment.tz('2026-08-20', COMPANY_TZ).startOf('day').toDate();
+    freezeAt('2026-08-20T07:01:00Z'); // 00:01 Pacific on the 20th
+    userProfile.find.mockResolvedValue([pausedUser(today)]);
+
+    await reactivateUser();
+
+    expect(userProfile.findByIdAndUpdate).toHaveBeenCalledTimes(1);
+    expect(setUpdate().isActive).toBe(true);
+  });
+
+  it('reactivates somebody whose date has already passed', async () => {
+    freezeAt('2026-08-25T07:01:00Z');
+    userProfile.find.mockResolvedValue([
+      pausedUser(moment.tz('2026-08-20', COMPANY_TZ).startOf('day').toDate()),
+    ]);
+
+    await reactivateUser();
+
+    expect(userProfile.findByIdAndUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves somebody whose date is still in the future alone', async () => {
+    freezeAt('2026-08-20T07:01:00Z');
+    userProfile.find.mockResolvedValue([
+      pausedUser(moment.tz('2026-08-25', COMPANY_TZ).startOf('day').toDate()),
+    ]);
+
+    await reactivateUser();
+
+    expect(userProfile.findByIdAndUpdate).not.toHaveBeenCalled();
+    expect(emailSender).not.toHaveBeenCalled();
+  });
+
+  it('clears every field the manual Resume button clears', async () => {
+    // These must agree. In particular a leftover reactivationDate would
+    // permanently exclude the user from finalizeUserEndDates, which skips
+    // anyone who still looks paused.
+    freezeAt('2026-08-20T07:01:00Z');
+    userProfile.find.mockResolvedValue([
+      pausedUser(moment.tz('2026-08-20', COMPANY_TZ).startOf('day').toDate()),
+    ]);
+
+    await reactivateUser();
+
+    expect(setUpdate()).toMatchObject({
+      isActive: true,
+      deactivatedAt: null,
+      reactivationDate: null,
+      endDate: null,
+      isSet: false,
+      finalEmailThreeWeeksSent: false,
+    });
+    expect(unsetUpdate()).toHaveProperty('inactiveReason');
+  });
+
+  it('sends the resumed email with the date they were paused on', async () => {
+    freezeAt('2026-08-20T07:01:00Z');
+    const pausedAt = new Date('2026-08-01T12:00:00Z');
+    userProfile.find.mockResolvedValue([
+      pausedUser(moment.tz('2026-08-20', COMPANY_TZ).startOf('day').toDate(), {
+        deactivatedAt: pausedAt,
+      }),
+    ]);
+
+    await reactivateUser();
+
+    expect(emailSender).toHaveBeenCalledTimes(1);
+    const body = emailSender.mock.calls[0][2];
+    // The old implementation read endDate *after* wiping it, so the date in
+    // this email was always wrong.
+    expect(body).toContain(moment(pausedAt).tz(COMPANY_TZ).format('M-D-YYYY'));
+    expect(body).toContain('RESUMED');
+  });
+
+  it('skips a record with an unreadable reactivation date instead of activating it', async () => {
+    freezeAt('2026-08-20T07:01:00Z');
+    userProfile.find.mockResolvedValue([pausedUser('not a date')]);
+
+    await reactivateUser();
+
+    expect(userProfile.findByIdAndUpdate).not.toHaveBeenCalled();
+    expect(logger.logInfo).toHaveBeenCalledWith(expect.stringContaining('unreadable'));
+  });
+
+  it('keeps going when one user fails, so one bad record cannot block the rest', async () => {
+    freezeAt('2026-08-20T07:01:00Z');
+    const due = moment.tz('2026-08-20', COMPANY_TZ).startOf('day').toDate();
+    userProfile.find.mockResolvedValue([
+      pausedUser(due, { _id: 'first' }),
+      pausedUser(due, { _id: 'second' }),
+    ]);
+    userProfile.findByIdAndUpdate
+      .mockRejectedValueOnce(new Error('write failed'))
+      .mockResolvedValueOnce({});
+
+    await reactivateUser();
+
+    expect(userProfile.findByIdAndUpdate).toHaveBeenCalledTimes(2);
+    expect(logger.logException).toHaveBeenCalled();
+  });
+
+  it('reports a failure to load users rather than throwing at the cron', async () => {
+    // The cron now isolates each call, but this must not throw regardless.
+    userProfile.find.mockRejectedValue(new Error('db down'));
+
+    await expect(reactivateUser()).resolves.toBeUndefined();
+    expect(logger.logException).toHaveBeenCalled();
+    expect(userProfile.findByIdAndUpdate).not.toHaveBeenCalled();
+  });
+
+  it('does nothing quietly when nobody is due', async () => {
+    userProfile.find.mockResolvedValue([]);
+
+    await reactivateUser();
+
+    expect(userProfile.findByIdAndUpdate).not.toHaveBeenCalled();
+    expect(emailSender).not.toHaveBeenCalled();
+    expect(logger.logException).not.toHaveBeenCalled();
+  });
+});

--- a/src/helpers/__tests__/userStatusEmails.spec.js
+++ b/src/helpers/__tests__/userStatusEmails.spec.js
@@ -1,0 +1,47 @@
+/**
+ * Tests for the emails sent when a user is paused.
+ *
+ * The pause email reported a return date one day after the reactivation date,
+ * compensating for a date that was itself being stored a day early. With the
+ * date stored correctly, the email has to name the reactivation date itself,
+ * which is also what the bug report asks for: the person comes back on the day
+ * they were paused to.
+ */
+
+jest.mock('../../models/userProfile', () => ({
+  find: jest.fn(),
+  findById: jest.fn(),
+  findByIdAndUpdate: jest.fn().mockResolvedValue({}),
+  aggregate: jest.fn(),
+  updateOne: jest.fn().mockResolvedValue({}),
+}));
+jest.mock('../../models/badge', () => ({ find: jest.fn(), findOne: jest.fn() }));
+jest.mock('../../models/team', () => ({ aggregate: jest.fn(), find: jest.fn() }));
+jest.mock('../dashboardhelper', () => jest.fn(() => ({ laborthisweek: jest.fn() })));
+jest.mock('../../utilities/emailSender', () => jest.fn());
+jest.mock('../../startup/logger', () => ({ logInfo: jest.fn(), logException: jest.fn() }));
+
+const emailSender = require('../../utilities/emailSender');
+const userHelperFactory = require('../userHelper');
+
+const { sendUserPausedEmail } = userHelperFactory();
+
+const emailBody = () => emailSender.mock.calls[0][2];
+
+describe('sendUserPausedEmail', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  test('names the day the user is due back, not the day after', () => {
+    // Start of 2026-09-20 in company time.
+    sendUserPausedEmail({
+      firstName: 'Ann',
+      lastName: 'Adams',
+      email: 'ann@example.com',
+      reactivationDate: new Date('2026-09-20T07:00:00.000Z'),
+      recipients: ['admin@example.com'],
+    });
+
+    expect(emailBody()).toContain('9-20-2026');
+    expect(emailBody()).not.toContain('9-21-2026');
+  });
+});

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -1651,61 +1651,88 @@ const userHelper = function () {
     return null;
   };
 
-  const reActivateUser = async () => {
-    const currentFormattedDate = moment().tz(COMPANY_TZ).format();
-
+  /**
+   * Daily job: bring paused users back on the date they were paused until.
+   *
+   * The manual Resume button and this job have to agree about what "active"
+   * means, so the fields written here mirror the ACTIVATE branch of
+   * userProfileController exactly. Leaving any of them behind has real
+   * consequences: a stale `reactivationDate` permanently excludes the user
+   * from finalizeUserEndDates, which deliberately skips anyone who still looks
+   * paused, so they could never be separated afterwards.
+   */
+  const reactivateUser = async () => {
     logger.logInfo(
-      `Job for activating users based on scheduled re-activation date starting at ${currentFormattedDate}`,
+      `Job for activating users based on scheduled re-activation date starting at ${moment()
+        .tz(COMPANY_TZ)
+        .format()}`,
     );
 
+    let users;
     try {
-      const users = await userProfile.find(
-        { isActive: false, reactivationDate: { $exists: true } },
-        '_id isActive reactivationDate',
+      users = await userProfile.find(
+        { isActive: false, reactivationDate: { $ne: null } },
+        '_id firstName lastName email deactivatedAt reactivationDate',
       );
-      for (let i = 0; i < users.length; i += 1) {
-        const user = users[i];
-        const canActivate = moment().isSameOrAfter(moment(user.reactivationDate));
-        if (canActivate) {
-          // Use '!' to invert the boolean value for testing
-          await userProfile.findByIdAndUpdate(
-            user._id,
-            {
-              $set: {
-                isActive: true,
-              },
-              $unset: {
-                endDate: user.endDate,
-              },
-            },
-            { new: true },
-          );
-          logger.logInfo(
-            `User with id: ${user._id} was re-acticated at ${moment().tz(COMPANY_TZ).format()}.`,
-          );
-          const id = user._id;
-          const person = await userProfile.findById(id);
-
-          const endDate = moment(person.endDate).format('YYYY-MM-DD');
-          logger.logInfo(`User with id: ${user._id} was re-acticated at ${moment().format()}.`);
-
-          const subject = `IMPORTANT:${person.firstName} ${person.lastName} has been RE-activated in the Highest Good Network`;
-
-          const emailBody = `<p> Hi Admin! </p>
-
-          <p>This email is to let you know that ${person.firstName} ${person.lastName} has been made active again in the Highest Good Network application after being paused on ${endDate}.</p>
-
-          <p>If you need to communicate anything with them, this is their email from the system: ${person.email}.</p>
-
-          <p> Thanks! </p>
-
-          <p>The HGN A.I. (and One Community)</p>`;
-
-          emailSender('onecommunityglobal@gmail.com', subject, emailBody, null, null, person.email);
-        }
-      }
     } catch (err) {
-      logger.logException(err);
+      logger.logException(err, 'reactivateUser: could not load paused users');
+      return;
+    }
+
+    const now = moment().tz(COMPANY_TZ);
+
+    for (let i = 0; i < users.length; i += 1) {
+      const user = users[i];
+
+      // Per user, so one unreadable record cannot stop everybody else from
+      // being reactivated.
+      try {
+        const reactivateOn = moment(user.reactivationDate).tz(COMPANY_TZ);
+        if (!reactivateOn.isValid()) {
+          logger.logInfo(`reactivateUser: skipping user ${user._id}, unreadable reactivationDate.`);
+          continue;
+        }
+
+        // The date is stored as the start of the day in company time and this
+        // job runs just after midnight, so "on that day" is an inclusive
+        // comparison rather than a strict one.
+        if (now.isBefore(reactivateOn)) continue;
+
+        // Read before the update, because the email reports the date they were
+        // paused on and the update clears it.
+        const pausedOn = user.deactivatedAt;
+        const recipients = await getEmailRecipientsForStatusChange(user._id);
+
+        await userProfile.findByIdAndUpdate(
+          user._id,
+          {
+            $set: {
+              isActive: true,
+              deactivatedAt: null,
+              reactivationDate: null,
+              endDate: null,
+              isSet: false,
+              finalEmailThreeWeeksSent: false,
+            },
+            $unset: { inactiveReason: '' },
+          },
+          { new: true },
+        );
+
+        logger.logInfo(
+          `User with id: ${user._id} was reactivated at ${moment().tz(COMPANY_TZ).format()}.`,
+        );
+
+        sendUserResumedEmail({
+          firstName: user.firstName,
+          lastName: user.lastName,
+          email: user.email,
+          recipients,
+          pausedOn,
+        });
+      } catch (err) {
+        logger.logException(err, `reactivateUser: failed for user ${user._id}`);
+      }
     }
   };
 
@@ -3482,7 +3509,7 @@ const userHelper = function () {
     // inCompleteHoursEmailFunction,
     // weeklyBlueSquareReminderFunction,
     weeklyAutoReplyEmailFunction,
-    reActivateUser,
+    reactivateUser,
     sendDeactivateEmailBody,
     deActivateUser,
     notifyInfringements,

--- a/src/helpers/userHelper.js
+++ b/src/helpers/userHelper.js
@@ -28,6 +28,7 @@ const logger = require('../startup/logger');
 const token = require('../models/profileInitialSetupToken');
 const BlueSquareEmailAssignment = require('../models/BlueSquareEmailAssignment');
 const cache = require('../utilities/nodeCache')();
+const { activeFields } = require('./userStatusFields');
 const timeOffRequest = require('../models/timeOffRequest');
 const notificationService = require('../services/notificationService');
 const { NEW_USER_BLUE_SQUARE_NOTIFICATION_MESSAGE } = require('../constants/message');
@@ -1703,17 +1704,15 @@ const userHelper = function () {
         const pausedOn = user.deactivatedAt;
         const recipients = await getEmailRecipientsForStatusChange(user._id);
 
+        // The same fields the Resume button and the lifecycle Activate action
+        // write, as an update document: everything except inactiveReason, which
+        // is removed rather than set.
+        const { inactiveReason, ...activate } = activeFields();
+
         await userProfile.findByIdAndUpdate(
           user._id,
           {
-            $set: {
-              isActive: true,
-              deactivatedAt: null,
-              reactivationDate: null,
-              endDate: null,
-              isSet: false,
-              finalEmailThreeWeeksSent: false,
-            },
+            $set: activate,
             $unset: { inactiveReason: '' },
           },
           { new: true },
@@ -3192,10 +3191,10 @@ const userHelper = function () {
   };
 
   const sendUserPausedEmail = ({ firstName, lastName, email, reactivationDate, recipients }) => {
-    const returnDate = moment(reactivationDate)
-      .tz(COMPANY_TZ)
-      .add(1, 'day') // adding a day to make it clear they return on the day of reactivation
-      .format('M-D-YYYY');
+    // The reactivation date is the day they are back, so it is the date to
+    // name here. It used to carry a day added on top, which compensated for the
+    // date being stored a day early.
+    const returnDate = moment(reactivationDate).tz(COMPANY_TZ).format('M-D-YYYY');
     const subject = `IMPORTANT: ${firstName} ${lastName} has been PAUSED in the Highest Good Network`;
 
     const emailBody = `

--- a/src/helpers/userStatusFields.js
+++ b/src/helpers/userStatusFields.js
@@ -1,0 +1,61 @@
+const moment = require('moment-timezone');
+const { COMPANY_TZ } = require('../constants/company');
+const { InactiveReason } = require('../constants/userProfile');
+
+/**
+ * One source of truth for the fields that say where a user is in their
+ * lifecycle.
+ *
+ * Pause and resume are reachable from two endpoints, `pauseResumeUser` (the
+ * Pause and Resume buttons) and `changeUserStatus` (the lifecycle actions), and
+ * the nightly job reactivates paused users on a third path. They have to write
+ * the same fields, because everything downstream reads them: `deactivatedAt` is
+ * the paused-on date in the resume email, a leftover `endDate` shows as a final
+ * day on a paused profile, and a leftover `reactivationDate` makes
+ * `finalizeUserEndDates` skip the user forever as still-paused.
+ */
+
+/**
+ * The start of a calendar day in company time.
+ *
+ * The date picker sends 'YYYY-MM-DD' with no zone. Parsing that and converting
+ * afterwards reads it in the server's zone first, which is UTC in production,
+ * so the result lands on the previous Pacific day and the user comes back a day
+ * early. Anchoring the parse in company time keeps the day the admin picked.
+ */
+const startOfCompanyDay = (date) => moment.tz(date, COMPANY_TZ).startOf('day').toISOString();
+
+/** Fields written when a user is paused until `reactivationDate`. */
+const pauseFields = (reactivationDate) => ({
+  isActive: false,
+  inactiveReason: InactiveReason.PAUSED,
+  deactivatedAt: moment().tz(COMPANY_TZ).toISOString(),
+  reactivationDate: startOfCompanyDay(reactivationDate),
+  endDate: null,
+  isSet: false,
+});
+
+/**
+ * Fields written when a user is made active, whether by the Resume button, the
+ * lifecycle Activate action, or the nightly reactivation job.
+ */
+const activeFields = () => ({
+  isActive: true,
+  inactiveReason: undefined,
+  deactivatedAt: null,
+  reactivationDate: null,
+  endDate: null,
+  isSet: false,
+  finalEmailThreeWeeksSent: false,
+});
+
+/** The fields above, listed for a `findById` projection. */
+const LIFECYCLE_PROJECTION =
+  'isActive inactiveReason deactivatedAt reactivationDate endDate isSet finalEmailThreeWeeksSent';
+
+module.exports = {
+  startOfCompanyDay,
+  pauseFields,
+  activeFields,
+  LIFECYCLE_PROJECTION,
+};


### PR DESCRIPTION
# Description

Fixes the Phase 1 bugs doc item **"Fix pause-reactivation-day not reactivating person on that day"**, and the three other lines filed with it: the pause notification email showing the wrong date, an End Date still showing on a paused profile, and the Resume button not fully working.

**The headline bug is one character, and it has been live for about seven months.** The nightly cron job calls `userhelper.reactivateUser()`, but `userHelper.js` exported the function as `reActivateUser` with a capital A. The call was therefore `undefined`, and `await undefined()` threw a TypeError at 00:01 every night. Nobody has ever been reactivated on their reactivation date. It failed silently because the rejection was unhandled inside a cron callback, so nothing reached the logs.

Traced to commit `d82f3754` (2026-01-28, "fix(userStatus): Modified UserStatus Flow"). That commit touched eight files and rewrote much of the user status flow, and its entire change to `src/cronjobs/userProfileJobs.js` was renaming the call without renaming the export. In a diff that size it reads as a harmless casing tidy-up, which is why it went unnoticed. Verified against `development`: `userhelper.reactivateUser` is undefined there, and running that cron callback verbatim throws.

**It was taking two other things down with it.**

- The throw happened before `finalizeUserEndDates()` on the very next line, so that job never ran either. Two unrelated features were dead from one typo. Confirmed by running the callback, not inferred.
- Latent third bug: the old reactivation code set only `isActive: true` and unset `endDate`, leaving `reactivationDate` populated. `finalizeUserEndDates` filters on `reactivationDate: { $in: [null, undefined] }` as a deliberate "skip anyone who still looks paused" guard, so any user this job reactivated would have been permanently excluded from ever being separated afterwards. It never bit because the job never ran, but fixing the rename on its own would have activated it.

**The other three lines of the report all came from one cause: there are two implementations of pause and resume in the backend, and the UI uses the thinner one.** Both Pause buttons in the frontend, `UserManagement.jsx:506` and `PauseAndResumeButton.jsx:40`, call `PATCH /api/userProfile/:userId/pause`, which lands in `pauseResumeUser` and wrote only `isActive` and `reactivationDate`. The `changeUserStatus` PAUSE branch writes the whole lifecycle field set. The frontend action that would reach it, `pauseUserAction` in `userLifecycleActions.js`, is defined but imported by no component, so in practice every pause done from the UI left the record half filled in. That is why a final day set before a pause still showed as an End Date, why the resume email had no paused-on date to report (`deactivatedAt` was never written), and why the Resume button and the lifecycle Activate action disagreed about what "active" means.

**A timezone bug found along the way.** The pause modal sends a plain `YYYY-MM-DD` string, and `changeUserStatus` parsed it as `moment(date).tz(COMPANY_TZ).startOf('day')`, which reads the calendar date in the **server's** timezone before converting. Production runs on UTC, which is ahead of Pacific, so the result lands on the previous Pacific day and the nightly job would have brought the person back a day early. `moment.tz(date, COMPANY_TZ)` keeps the day that was actually picked. That is also what the "+1 day" in the pause email was compensating for, so it is removed and the email now names the reactivation date itself, which is what the bug report asks for.

**"Delete Final Day" turned out to be fine already** and needed no change: it is now the Cancel branch of `SetUpFinalDayButton` and goes through `activateUserAction`.

## Related PRS (if any):

None. This is backend only and needs no frontend change. The existing frontend Pause and Resume buttons and the pause modal already send everything these endpoints need, so the fix is visible in the current UI without checking anything else out.

## Main changes explained:

- **Create `src/helpers/userStatusFields.js`** as the single source of truth for the lifecycle fields. Pause and resume are reachable from three code paths (`pauseResumeUser`, `changeUserStatus`, and the nightly job) and all three now write the same field set from this one definition. It also owns `startOfCompanyDay`, which anchors the date parse in company time, and `LIFECYCLE_PROJECTION`, the field list the `findById` calls need.
- **Update `src/helpers/userHelper.js`**:
  - Rename the export `reActivateUser` to `reactivateUser` to match the call site, after confirming no other caller exists anywhere in the repo.
  - Rewrite the job to write `activeFields()`, so it agrees with the manual Resume button about what "active" means, with `inactiveReason` removed via `$unset` rather than set.
  - Process each user in its own try/catch, so one unreadable record cannot stop everybody else from being reactivated, and skip rather than activate on an unreadable `reactivationDate`.
  - Log instead of throwing when the initial query fails.
  - Change the query from `reactivationDate: { $exists: true }` to `{ $ne: null }`, because a paused-then-deactivated user has the field present but null and was being matched.
  - Replace the job's hand-rolled email with `sendUserResumedEmail`, reading `deactivatedAt` before the update clears it, so the paused-on date in it is right. It previously read the date out of `endDate`, a field the same function had already wiped.
  - Remove the `.add(1, 'day')` from `sendUserPausedEmail`. It was compensating for the date being stored a day early, which is fixed at the source now.
- **Update `src/controllers/userProfileController.js`**:
  - `changeUserStatus` ACTIVATE and PAUSE branches now call `activeFields()` and `pauseFields()` instead of assigning fields inline, so the timezone-safe parse applies here too.
  - `pauseResumeUser` writes the same full field set, sends the pause and resume notification emails (it was sending neither), reads `deactivatedAt` before the update for the resume email, refuses a pause with no date with a 400 instead of pausing somebody indefinitely, and updates the `allusers` cache entry from the same field map rather than from a hardcoded partial list.
  - Both `findById` projections widened to `LIFECYCLE_PROJECTION`. A field left out of a projection reads as undefined, which was a second and independent reason the paused-on date was missing on the lifecycle path.
- **Update `src/cronjobs/userProfileJobs.js`** to put `reactivateUser` and `finalizeUserEndDates` in separate try/catch blocks, matching the pattern the Sunday job in the same file already uses, so neither can take the other down again.
- **Create `src/helpers/__tests__/reactivateUser.spec.js`** (11 tests), **`src/controllers/__tests__/userStatusPauseResume.spec.js`** (8 tests) and **`src/helpers/__tests__/userStatusEmails.spec.js`** (3 tests). Two of the controller tests pin both endpoints to the same field set, so the two paths cannot silently drift apart again.

**No API surface changes.** No new routes, no changed request or response shapes, no schema changes. The only behaviour change a caller can see is the new 400 on `PATCH /api/userProfile/:userId/pause` when a pause is sent with no `reactivationDate`.

## How to test:

1. Check out this branch, `sitaram/fix/pause-reactivation-day`
2. `npm install`, then run the backend (Redis must be running locally)
3. **Unit tests, and this is the quickest proof the fix is real.** Run `npx jest src/helpers/__tests__/reactivateUser.spec.js src/controllers/__tests__/userStatusPauseResume.spec.js src/helpers/__tests__/userStatusEmails.spec.js`. Expect 3 suites, 22 tests, all passing. Then stash the source changes and run `reactivateUser.spec.js` against `development`: all 11 fail, so the tests cover the bug rather than merely passing alongside it.
4. **See the original bug directly.** On `development`, open a node REPL in the repo and evaluate `require('./src/helpers/userHelper')().reactivateUser`. It is `undefined`. On this branch it is a function. That single expression is the whole seven-month outage.
5. **The nightly job, end to end.** Log in and pause a test user with `PATCH /api/userProfile/:userId/pause`, body `{"status":"Paused","reactivationDate":"<today, as YYYY-MM-DD>"}`. Then invoke the job by hand: `require('./src/helpers/userHelper')().reactivateUser()`. The user must come back **on** that date, not the day after, because the date is stored as the start of the day in company time and the job runs at 00:01. There is a test frozen at 00:01 Pacific on the boundary day covering exactly this. Re-read the profile and confirm `isActive` is true and that `reactivationDate`, `deactivatedAt`, `endDate` and `inactiveReason` are all cleared.
6. **Set the reactivation date to tomorrow instead** and run the job again. The user must stay paused.
7. **The End Date line of the report.** Set a final day on a user, then pause them from the UI. On `development` the paused profile and User Management still show that End Date. On this branch `endDate` and `isSet` are cleared by the pause, so it is gone.
8. **The paused-on date in the email.** Pause a user, then resume them with `PATCH /api/userProfile/:userId/pause`, body `{"status":"Active"}`. The resume email must name the date they were actually paused on. On `development` this endpoint sends no email at all, and the lifecycle path's version of it falls back to "an earlier date".
9. **The Resume button.** Resume as in step 8 and compare the resulting document against a user activated through `PATCH /api/userProfile/:userId` with body `{"action":"ACTIVATE"}`. Every lifecycle field must match. This is what the two pinning tests assert.
10. **The timezone fix.** Run the backend with `TZ=UTC`, then pause a user with a `reactivationDate` of a specific day. Read back the stored value: it must land on the start of that day in Pacific time, not the day before. This is the case that would have brought people back a day early on the production server.
11. **Guards.** `PATCH /api/userProfile/:userId/pause` with `{"status":"Paused"}` and no `reactivationDate` must return 400. On `development` it pauses the user with no date, indefinitely.
12. **Regression check.** `npx jest src/helpers/userHelper.spec.js` (76 tests) must pass, confirming the rename broke nothing. Everything under `src/controllers` and `src/helpers` is 1658 passing; the one failing suite there, `reasonSchedulingController`, needs a live MongoDB and fails identically on the committed code.

## Screenshots or videos of changes:



<img width="2560" height="1600" alt="Screenshot (185)" src="https://github.com/user-attachments/assets/d81c3047-3fc0-4df8-a8e7-4f604c2e9f2f" />
<img width="2560" height="1600" alt="Screenshot (186)" src="https://github.com/user-attachments/assets/9b314f1e-b4b0-476b-a328-5c6bd2af79cb" />
<img width="2560" height="1600" alt="Screenshot (187)" src="https://github.com/user-attachments/assets/7d8fee84-1524-4d24-ae71-58fc70256813" />
<img width="2560" height="1600" alt="Screenshot (188)" src="https://github.com/user-attachments/assets/67b50200-66a3-42dd-a139-8bad49c2b885" />

## Note:

- **Dark mode: not applicable.** This PR is backend only. It touches no frontend file, no component and no CSS, and it adds no UI surface. The Pause and Resume buttons it fixes are existing components that render unchanged, so there is nothing here for dark mode to affect. Noting it explicitly because dark mode is part of every PR review.
- **This is a silent production bug, not a feature request.** Until this merges, no paused volunteer is being brought back automatically on their date, and `finalizeUserEndDates` has not run since 2026-01-28 either. Both have been failing every night with nothing in the logs.
- **Why the field set matters as much as the rename.** Fixing only the export name would have activated the latent `finalizeUserEndDates` exclusion described above, so reactivated users could never be separated afterwards. The rename and the field set need to land together.
- **One behaviour change to be aware of:** `pauseResumeUser` now sends notification emails. It sent none before. If anyone was relying on pausing from the UI being silent, this is the change that alters that.
- **Deliberately not fixed here, same class of defect but a different bug:** `DEACTIVATE` and `SCHEDULE_DEACTIVATION` in `changeUserStatus` parse `endDate` the same unsafe way, so a scheduled final day also lands a day early on a UTC server. It is outside this bug report, it is noted at the end of the second commit message, and it is going into the bugs doc as its own entry.
- The full write-up, including the trace back to `d82f3754` and the reasoning behind each decision, is in the two commit messages on this branch.
