### PR TITLE
Aditya - Job descriptions: sanitize HTML before saving

### DIFF
--- a/src/controllers/jobsController.js
+++ b/src/controllers/jobsController.js
@@ -1,5 +1,6 @@
 const Job = require('../models/jobs');
 const JobPositionCategory = require('../models/jobPositionCategory');
+const { stripHtml } = require('../utilities/htmlContentSanitizer');
 
 /* ============================================================
    UTILS
@@ -231,7 +232,7 @@ const createJob = async (req, res) => {
     const newJob = new Job({
       title,
       category,
-      description,
+      description: typeof description === 'string' ? stripHtml(description) : description,
       imageUrl,
       location,
       applyLink,
@@ -253,7 +254,12 @@ const updateJob = async (req, res) => {
   const { id } = req.params;
 
   try {
-    const updatedJob = await Job.findByIdAndUpdate(id, req.body, { new: true });
+    const updates = { ...req.body };
+    if (typeof updates.description === 'string') {
+      updates.description = stripHtml(updates.description);
+    }
+
+    const updatedJob = await Job.findByIdAndUpdate(id, updates, { new: true });
     if (!updatedJob) return res.status(404).json({ error: 'Job not found' });
 
     res.json(updatedJob);

--- a/src/controllers/jobsController.test.js
+++ b/src/controllers/jobsController.test.js
@@ -157,6 +157,24 @@ describe('jobsController', () => {
       expect(res.json).toHaveBeenCalledWith(expect.objectContaining(updateData));
     });
 
+    it('updateJob: should store the description as plain text', async () => {
+      Job.findByIdAndUpdate.mockResolvedValue({ _id: jobId });
+
+      await updateJob(
+        {
+          params: { id: jobId },
+          body: { description: '<p>Build <strong>useful</strong> tools</p>' },
+        },
+        res,
+      );
+
+      expect(Job.findByIdAndUpdate).toHaveBeenCalledWith(
+        jobId,
+        { description: 'Build useful tools' },
+        { new: true },
+      );
+    });
+
     it('deleteJob: should delete successfully', async () => {
       Job.findByIdAndDelete.mockResolvedValue({ _id: jobId });
       await deleteJob({ params: { id: jobId } }, res);
@@ -253,6 +271,24 @@ describe('jobsController', () => {
 
       expect(res.status).toHaveBeenCalledWith(201);
       expect(res.json).toHaveBeenCalledWith(savedJob);
+    });
+
+    it('stores a new job description as plain text', async () => {
+      Job.findOne.mockReturnValue({ sort: jest.fn().mockResolvedValue(null) });
+      const saveSpy = jest.spyOn(Job.prototype, 'save').mockResolvedValue({ _id: 'job1' });
+
+      await createJob(
+        {
+          body: {
+            ...newJobBody,
+            description: '<p>Build <strong>useful</strong> tools</p><script>bad()</script>',
+          },
+        },
+        res,
+      );
+
+      const savedInstance = saveSpy.mock.instances.at(-1);
+      expect(savedInstance.description).toBe('Build useful tools');
     });
 
     it('defaults displayOrder to 0 when no jobs exist yet', async () => {

--- a/src/utilities/__tests__/htmlContentSanitizer.test.js
+++ b/src/utilities/__tests__/htmlContentSanitizer.test.js
@@ -1,4 +1,4 @@
-const { cleanHtml } = require('../htmlContentSanitizer');
+const { cleanHtml, stripHtml } = require('../htmlContentSanitizer');
 
 describe('htmlContentSanitizer', () => {
   it('should sanitize HTML content', () => {
@@ -54,5 +54,26 @@ describe('htmlContentSanitizer', () => {
     const dirtyHtml = '<p style="color:red;" onclick="alert(\'xss\')">Test</p>';
     const clean = cleanHtml(dirtyHtml);
     expect(clean).toBe('<p>Test</p>');
+  });
+});
+
+describe('stripHtml', () => {
+  it('removes markup while preserving readable block boundaries', () => {
+    const dirty = '<p>Hello <strong>world</strong></p><ul><li>One</li><li>Two</li></ul>';
+
+    expect(stripHtml(dirty)).toBe('Hello world\nOne\nTwo');
+  });
+
+  it('removes script content and decodes HTML entities', () => {
+    const dirty = '<script>alert("xss")</script><p>Safe &amp; sound; 2 &lt; 3</p>';
+
+    expect(stripHtml(dirty)).toBe('Safe & sound; 2 < 3');
+  });
+
+  it('handles plain, empty, and missing values', () => {
+    expect(stripHtml('Just plain text')).toBe('Just plain text');
+    expect(stripHtml('')).toBe('');
+    expect(stripHtml(null)).toBe('');
+    expect(stripHtml(undefined)).toBe('');
   });
 });

--- a/src/utilities/htmlContentSanitizer.js
+++ b/src/utilities/htmlContentSanitizer.js
@@ -1,4 +1,5 @@
 const sanitizeHtml = require('sanitize-html');
+const cheerio = require('cheerio');
 
 // Please refer to https://www.npmjs.com/package/sanitize-html?activeTab=readme for more information.
 // eslint-disable-next-line import/prefer-default-export
@@ -8,6 +9,26 @@ const cleanHtml = (dirty) =>
     allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img']),
   });
 
+const stripHtml = (dirty) => {
+  if (dirty === null || dirty === undefined) return '';
+
+  const textWithLineBreaks = String(dirty)
+    .replace(/<br\b[^>]*>/gi, '\n')
+    .replace(/<\/(?:p|div|li|h[1-6]|tr|blockquote)\s*>/gi, '\n');
+  const sanitizedText = sanitizeHtml(textWithLineBreaks, {
+    allowedTags: [],
+    allowedAttributes: {},
+  });
+  const decodedText = cheerio.load(`<body>${sanitizedText}</body>`)('body').text();
+
+  return decodedText
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join('\n');
+};
+
 module.exports = {
   cleanHtml,
+  stripHtml,
 };


### PR DESCRIPTION
# Description

Existing job descriptions were cleaned in the database, but `createJob` and `updateJob` still accepted unsanitized HTML. New or edited postings could therefore reintroduce raw tags or unsafe markup into summaries. This stores descriptions as readable plain text at both write paths.

This issue concerns [Item 40](https://docs.google.com/document/d/1zifX1otZPl-VJLQk0sZqZbQFginRytlQ2vKHeQAh_Lo/edit?tab=t.0#bookmark=id.4strgdvevbe6).

## Original task

Job descriptions — sanitize HTML before saving through both the job-creation and job-update APIs.

[Open master Google Doc Item 40](https://docs.google.com/document/d/1zifX1otZPl-VJLQk0sZqZbQFginRytlQ2vKHeQAh_Lo/edit?tab=t.0#bookmark=id.4strgdvevbe6)

### Master Google Doc task entry

<img width="1050" height="820" alt="Master Google Doc - Item 40 job description sanitization" src="https://github.com/user-attachments/assets/17ffaab3-9093-4633-b818-2308d1a124a9" />

## Related PRS (if any):

No frontend changes. The existing Collaboration summary cleanup remains unchanged.

## Main changes explained:

1. Adds a reusable `stripHtml` utility built on the repository’s existing `sanitize-html` and `cheerio` dependencies.
2. Removes markup and script content while preserving readable block and list boundaries.
3. Decodes safe HTML entities back to readable text.
4. Applies the utility to string descriptions in both `createJob` and `updateJob`.
5. Preserves non-string values so the existing controller validation behavior is not broadened.
6. Adds focused create, update, block-boundary, script-removal, entity, plain-text, and empty-value tests.

## How to test:

1. Check out this branch and install dependencies.
2. Create a job whose description contains paragraphs, emphasis, list items, entities, and a script tag.
3. Confirm the stored description contains readable plain text, preserves sensible line breaks, decodes entities, and contains no tag or script content.
4. Update an existing job with the same cases and confirm identical sanitization.
5. Confirm a plain-text description remains unchanged.
6. Run `jest src/controllers/jobsController.test.js src/utilities/__tests__/htmlContentSanitizer.test.js --runInBand`.
7. Run `npm run build`.

## Automated verification evidence:

This is a backend data-sanitization change with no standalone visual state. The live PR checks passed:

- [Lint Check](https://github.com/OneCommunityGlobal/HGNRest/actions/runs/34684639914/job/103529388543)
- [Tests with 10% Coverage Enforcement](https://github.com/OneCommunityGlobal/HGNRest/actions/runs/34684639914/job/103529505547)
- [SonarCloud Scan](https://github.com/OneCommunityGlobal/HGNRest/actions/runs/34684639914/job/103529927357)
- [SonarCloud Code Analysis](https://sonarcloud.io/dashboard?id=OneCommunityGlobal_HGNRest&pullRequest=2344)

## Note:

The focused controller and sanitizer suites pass 45 tests on current `development`.
