### PR TITLE
Amaresh: Fix N+1 query and new member threshold in Promotion Eligibility endpoint

### DIFF
--- a/src/controllers/promotionEligibilityController.js
+++ b/src/controllers/promotionEligibilityController.js
@@ -10,21 +10,56 @@ const promotionEligibilityController = function (
   Task,
   PromotionEligibility,
 ) {
-  const calculateWeeksMetRequirement = async (userId, pledgedHours) => {
-    const weeklyTasks = await TimeEntry.aggregate([
-      { $match: { personId: mongoose.Types.ObjectId(userId), isTangible: true } },
+  // Batched across all users: one aggregate returns, per user, the list of weekly
+  // hour totals for review/PR-tagged tangible time entries. The per-user pledged-hours
+  // threshold varies, so filtering weeks against it happens in JS after this query returns.
+  const getWeeklyHoursByUser = async (userIds) => {
+    const rows = await TimeEntry.aggregate([
+      { $match: { personId: { $in: userIds }, isTangible: true } },
       { $lookup: { from: 'tasks', localField: 'taskId', foreignField: '_id', as: 'taskInfo' } },
       { $unwind: '$taskInfo' },
       { $match: { 'taskInfo.taskName': { $regex: /review|pr/i } } },
       {
         $group: {
-          _id: { $week: { $toDate: '$dateOfWork' } },
+          _id: { personId: '$personId', week: { $week: { $toDate: '$dateOfWork' } } },
           totalHours: { $sum: { $divide: ['$totalSeconds', 3600] } },
         },
       },
-      { $match: { totalHours: { $gte: pledgedHours / 2 } } },
     ]);
-    return weeklyTasks.length;
+
+    const weeklyHoursByUser = new Map();
+    rows.forEach(({ _id, totalHours }) => {
+      const key = _id.personId.toString();
+      if (!weeklyHoursByUser.has(key)) weeklyHoursByUser.set(key, []);
+      weeklyHoursByUser.get(key).push(totalHours);
+    });
+    return weeklyHoursByUser;
+  };
+
+  // Batched across all users: counts, per user, the number of distinct review/PR-tagged
+  // tasks where that user appears in `resources` with completedTask true — matching the
+  // semantics of the original per-user Task.countDocuments call exactly.
+  const getReviewCountsByUser = async (userIds) => {
+    const rows = await Task.aggregate([
+      {
+        $match: {
+          taskName: { $regex: /review|pr/i },
+          resources: { $elemMatch: { userID: { $in: userIds }, completedTask: true } },
+        },
+      },
+      { $unwind: '$resources' },
+      {
+        $match: {
+          'resources.userID': { $in: userIds },
+          'resources.completedTask': true,
+        },
+      },
+      // Dedupe so a task counts at most once per user, matching countDocuments semantics.
+      { $group: { _id: { userID: '$resources.userID', taskId: '$_id' } } },
+      { $group: { _id: '$_id.userID', totalReviews: { $sum: 1 } } },
+    ]);
+
+    return new Map(rows.map(({ _id, totalReviews }) => [_id.toString(), totalReviews]));
   };
 
   const getPromotionEligibilityData = async (req, res) => {
@@ -41,24 +76,28 @@ const promotionEligibilityController = function (
         '_id firstName lastName weeklycommittedHours createdDate',
       ).lean();
 
-      // Refactor: Use map and Promise.all for concurrent processing
-      const eligibilityPromises = users.map(async (user) => {
+      const userIds = users.map((user) => user._id);
+
+      const [weeklyHoursByUser, reviewCountsByUser] = await Promise.all([
+        getWeeklyHoursByUser(userIds),
+        getReviewCountsByUser(userIds),
+      ]);
+
+      const eligibilityData = users.map((user) => {
         const pledgedHours = user.weeklycommittedHours || 0;
         const requiredPRs = pledgedHours / 2;
 
-        const totalReviews = await Task.countDocuments({
-          resources: { $elemMatch: { userID: user._id, completedTask: true } },
-          taskName: { $regex: /review|pr/i },
-        });
+        const totalReviews = reviewCountsByUser.get(user._id.toString()) || 0;
 
-        const successfulWeeks = await calculateWeeksMetRequirement(user._id, pledgedHours);
+        const weeklyHours = weeklyHoursByUser.get(user._id.toString()) || [];
+        const successfulWeeks = weeklyHours.filter((hours) => hours >= pledgedHours / 2).length;
 
         const remainingWeeks = Math.max(0, 2 - successfulWeeks);
         const isNewMember =
           (new Date() - new Date(user.createdDate)) / (1000 * 60 * 60 * 24 * 30.44) < 6;
         const weeklyRequirementsMet = successfulWeeks >= 2;
 
-        const dataEntry = {
+        return {
           reviewerId: user._id,
           reviewerName: `${user.firstName} ${user.lastName}`,
           pledgedHours,
@@ -69,18 +108,24 @@ const promotionEligibilityController = function (
           weeklyRequirementsMet,
           calculatedAt: new Date(),
         };
-
-        // Save/update the calculated data in the new collection concurrently
-        // This will still have await, but it's within a map callback, not a sequential loop that blocks subsequent iterations.
-        await PromotionEligibility.findOneAndUpdate({ reviewerId: user._id }, dataEntry, {
-          upsert: true,
-          new: true,
-        });
-
-        return dataEntry; // Return the data entry to be collected by Promise.all
       });
 
-      const eligibilityData = await Promise.all(eligibilityPromises); // Await all promises to resolve
+      // Persist the computed snapshot for promoteMembers to read/update later. The response
+      // below already reflects the freshly computed data, so this write does not need to
+      // block the request — it just needs to happen.
+      if (eligibilityData.length > 0) {
+        PromotionEligibility.bulkWrite(
+          eligibilityData.map((dataEntry) => ({
+            updateOne: {
+              filter: { reviewerId: dataEntry.reviewerId },
+              update: { $set: dataEntry },
+              upsert: true,
+            },
+          })),
+        ).catch((error) => {
+          logger.logException(error, { endpoint: 'getPromotionEligibilityData:bulkWrite' });
+        });
+      }
 
       res.status(200).json(eligibilityData);
     } catch (error) {

--- a/src/controllers/promotionEligibilityController.js
+++ b/src/controllers/promotionEligibilityController.js
@@ -93,7 +93,7 @@ const promotionEligibilityController = function (
         const successfulWeeks = weeklyHours.filter((hours) => hours >= pledgedHours / 2).length;
 
         const remainingWeeks = Math.max(0, 2 - successfulWeeks);
-        const daysSinceCreated = (new Date() - new Date(user.createdDate)) / (1000 * 60 * 60 * 24);
+        const daysSinceCreated = (Date.now() - new Date(user.createdDate)) / (1000 * 60 * 60 * 24);
         const isNewMember = daysSinceCreated <= 7;
         const weeklyRequirementsMet = successfulWeeks >= 2;
 

--- a/src/controllers/promotionEligibilityController.js
+++ b/src/controllers/promotionEligibilityController.js
@@ -93,8 +93,8 @@ const promotionEligibilityController = function (
         const successfulWeeks = weeklyHours.filter((hours) => hours >= pledgedHours / 2).length;
 
         const remainingWeeks = Math.max(0, 2 - successfulWeeks);
-        const isNewMember =
-          (new Date() - new Date(user.createdDate)) / (1000 * 60 * 60 * 24 * 30.44) < 6;
+        const daysSinceCreated = (new Date() - new Date(user.createdDate)) / (1000 * 60 * 60 * 24);
+        const isNewMember = daysSinceCreated <= 7;
         const weeklyRequirementsMet = successfulWeeks >= 2;
 
         return {

--- a/src/controllers/promotionEligibilityController.test.js
+++ b/src/controllers/promotionEligibilityController.test.js
@@ -1,0 +1,286 @@
+jest.mock('../utilities/permissions');
+jest.mock('../startup/logger');
+
+const mongoose = require('mongoose');
+const { hasPermission } = require('../utilities/permissions');
+const logger = require('../startup/logger');
+const promotionEligibilityControllerFactory = require('./promotionEligibilityController');
+
+describe('promotionEligibilityController', () => {
+  let UserProfile;
+  let TimeEntry;
+  let Task;
+  let PromotionEligibility;
+  let controller;
+  let mockReq;
+  let mockRes;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    UserProfile = {
+      find: jest.fn(),
+      findById: jest.fn(),
+    };
+    TimeEntry = { aggregate: jest.fn() };
+    Task = { aggregate: jest.fn() };
+    PromotionEligibility = {
+      bulkWrite: jest.fn(),
+      findOneAndUpdate: jest.fn(),
+    };
+
+    controller = promotionEligibilityControllerFactory(
+      UserProfile,
+      TimeEntry,
+      Task,
+      PromotionEligibility,
+    );
+
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    };
+    mockReq = { body: { requestor: { requestorId: 'requestor1' } } };
+
+    hasPermission.mockResolvedValue(true);
+  });
+
+  describe('getPromotionEligibilityData', () => {
+    it('returns 403 when the requestor lacks permission', async () => {
+      hasPermission.mockResolvedValue(false);
+
+      await controller.getPromotionEligibilityData(mockReq, mockRes);
+
+      expect(hasPermission).toHaveBeenCalledWith(mockReq.body.requestor, 'getReports');
+      expect(mockRes.status).toHaveBeenCalledWith(403);
+      expect(mockRes.send).toHaveBeenCalledWith(
+        'You are not authorized to view promotion eligibility data.',
+      );
+      expect(UserProfile.find).not.toHaveBeenCalled();
+    });
+
+    it('computes eligibility data per user from the batched aggregates and persists a snapshot', async () => {
+      const oldDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000); // 30 days ago
+      const recentDate = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000); // 2 days ago
+
+      const users = [
+        {
+          _id: 'user1',
+          firstName: 'Alice',
+          lastName: 'Smith',
+          weeklycommittedHours: 20,
+          createdDate: oldDate,
+        },
+        {
+          _id: 'user2',
+          firstName: 'Bob',
+          lastName: 'Jones',
+          weeklycommittedHours: 10,
+          createdDate: recentDate,
+        },
+      ];
+
+      UserProfile.find.mockReturnValue({ lean: jest.fn().mockResolvedValue(users) });
+
+      // Alice: one week meets her 10hr/week threshold (pledgedHours/2), one week doesn't.
+      TimeEntry.aggregate.mockResolvedValue([
+        { _id: { personId: 'user1', week: 1 }, totalHours: 12 },
+        { _id: { personId: 'user1', week: 2 }, totalHours: 3 },
+      ]);
+
+      Task.aggregate.mockResolvedValue([{ _id: 'user1', totalReviews: 5 }]);
+      PromotionEligibility.bulkWrite.mockResolvedValue({});
+
+      await controller.getPromotionEligibilityData(mockReq, mockRes);
+
+      expect(UserProfile.find).toHaveBeenCalledWith(
+        { isActive: true, role: { $nin: ['Owner', 'Administrator', 'Promoted Reviewer'] } },
+        '_id firstName lastName weeklycommittedHours createdDate',
+      );
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+
+      const responseData = mockRes.json.mock.calls[0][0];
+      expect(responseData).toHaveLength(2);
+
+      const alice = responseData.find((r) => r.reviewerId === 'user1');
+      expect(alice.reviewerName).toBe('Alice Smith');
+      expect(alice.pledgedHours).toBe(20);
+      expect(alice.requiredPRs).toBe(10);
+      expect(alice.totalReviews).toBe(5);
+      expect(alice.remainingWeeks).toBe(1);
+      expect(alice.weeklyRequirementsMet).toBe(false);
+      expect(alice.isNewMember).toBe(false);
+
+      const bob = responseData.find((r) => r.reviewerId === 'user2');
+      expect(bob.totalReviews).toBe(0);
+      expect(bob.remainingWeeks).toBe(2);
+      expect(bob.weeklyRequirementsMet).toBe(false);
+      expect(bob.isNewMember).toBe(true);
+
+      // bulkWrite is fire-and-forget, so flush microtasks before asserting on it.
+      await new Promise(setImmediate);
+      expect(PromotionEligibility.bulkWrite).toHaveBeenCalledTimes(1);
+      const bulkOps = PromotionEligibility.bulkWrite.mock.calls[0][0];
+      expect(bulkOps).toHaveLength(2);
+      expect(bulkOps[0].updateOne.upsert).toBe(true);
+    });
+
+    it('responds with an empty array and skips bulkWrite when there are no eligible users', async () => {
+      UserProfile.find.mockReturnValue({ lean: jest.fn().mockResolvedValue([]) });
+      TimeEntry.aggregate.mockResolvedValue([]);
+      Task.aggregate.mockResolvedValue([]);
+
+      await controller.getPromotionEligibilityData(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith([]);
+      expect(PromotionEligibility.bulkWrite).not.toHaveBeenCalled();
+    });
+
+    it('logs but does not fail the response when the snapshot bulkWrite rejects', async () => {
+      const users = [
+        {
+          _id: 'user1',
+          firstName: 'A',
+          lastName: 'B',
+          weeklycommittedHours: 10,
+          createdDate: new Date(),
+        },
+      ];
+      UserProfile.find.mockReturnValue({ lean: jest.fn().mockResolvedValue(users) });
+      TimeEntry.aggregate.mockResolvedValue([]);
+      Task.aggregate.mockResolvedValue([]);
+      const bulkWriteError = new Error('bulk write failed');
+      PromotionEligibility.bulkWrite.mockRejectedValue(bulkWriteError);
+
+      await controller.getPromotionEligibilityData(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+
+      await new Promise(setImmediate);
+      expect(logger.logException).toHaveBeenCalledWith(bulkWriteError, {
+        endpoint: 'getPromotionEligibilityData:bulkWrite',
+      });
+    });
+
+    it('returns 500 when an unexpected error is thrown', async () => {
+      const dbError = new Error('db down');
+      UserProfile.find.mockImplementation(() => {
+        throw dbError;
+      });
+
+      await controller.getPromotionEligibilityData(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.send).toHaveBeenCalledWith('Error fetching promotion eligibility data.');
+      expect(logger.logException).toHaveBeenCalledWith(dbError, {
+        endpoint: 'getPromotionEligibilityData',
+      });
+    });
+  });
+
+  describe('promoteMembers', () => {
+    let mockSession;
+
+    beforeEach(() => {
+      mockSession = {
+        startTransaction: jest.fn(),
+        commitTransaction: jest.fn().mockResolvedValue(undefined),
+        abortTransaction: jest.fn().mockResolvedValue(undefined),
+        endSession: jest.fn(),
+      };
+      jest.spyOn(mongoose, 'startSession').mockResolvedValue(mockSession);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('returns 403 when the requestor lacks permission', async () => {
+      hasPermission.mockResolvedValue(false);
+      mockReq.body.memberIds = ['507f1f77bcf86cd799439011'];
+
+      await controller.promoteMembers(mockReq, mockRes);
+
+      expect(hasPermission).toHaveBeenCalledWith(mockReq.body.requestor, 'putUserProfile');
+      expect(mockRes.status).toHaveBeenCalledWith(403);
+    });
+
+    it('returns 400 when memberIds is missing or empty', async () => {
+      mockReq.body.memberIds = [];
+
+      await controller.promoteMembers(mockReq, mockRes);
+
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.send).toHaveBeenCalledWith('No member IDs provided for promotion.');
+    });
+
+    it('promotes a valid member and commits the transaction', async () => {
+      const memberId = '507f1f77bcf86cd799439011';
+      mockReq.body.memberIds = [memberId];
+
+      const mockUser = {
+        firstName: 'Alice',
+        lastName: 'Smith',
+        role: 'Volunteer',
+        save: jest.fn().mockResolvedValue(undefined),
+      };
+      UserProfile.findById.mockReturnValue({ session: jest.fn().mockResolvedValue(mockUser) });
+      PromotionEligibility.findOneAndUpdate.mockResolvedValue({});
+
+      await controller.promoteMembers(mockReq, mockRes);
+
+      expect(mockUser.role).toBe('Promoted Reviewer');
+      expect(mockUser.save).toHaveBeenCalledWith({ session: mockSession });
+      expect(PromotionEligibility.findOneAndUpdate).toHaveBeenCalledWith(
+        { reviewerId: memberId },
+        { $set: { isPromoted: true, promotionDate: expect.any(Date) } },
+        { new: true, session: mockSession },
+      );
+      expect(mockSession.commitTransaction).toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.send).toHaveBeenCalledWith({
+        message: 'Members promoted successfully.',
+        promotedMembers: [{ id: memberId, name: 'Alice Smith' }],
+      });
+    });
+
+    it('skips a non-existent member without failing the transaction', async () => {
+      const memberId = '507f1f77bcf86cd799439011';
+      mockReq.body.memberIds = [memberId];
+      UserProfile.findById.mockReturnValue({ session: jest.fn().mockResolvedValue(null) });
+
+      await controller.promoteMembers(mockReq, mockRes);
+
+      expect(logger.logInfo).toHaveBeenCalledWith(
+        `Attempted to promote non-existent user with ID: ${memberId}`,
+      );
+      expect(mockSession.commitTransaction).toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+    });
+
+    it('returns 400 and aborts the transaction for an invalid member id', async () => {
+      mockReq.body.memberIds = ['not-a-valid-id'];
+
+      await controller.promoteMembers(mockReq, mockRes);
+
+      expect(mockSession.abortTransaction).toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.send).toHaveBeenCalledWith({ error: 'Invalid member ID: not-a-valid-id' });
+    });
+
+    it('returns 500 and aborts the transaction on an unexpected error', async () => {
+      const memberId = '507f1f77bcf86cd799439011';
+      mockReq.body.memberIds = [memberId];
+      const dbError = new Error('db failure');
+      UserProfile.findById.mockReturnValue({ session: jest.fn().mockRejectedValue(dbError) });
+
+      await controller.promoteMembers(mockReq, mockRes);
+
+      expect(mockSession.abortTransaction).toHaveBeenCalled();
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.send).toHaveBeenCalledWith('Error promoting members.');
+    });
+  });
+});


### PR DESCRIPTION
## Description
Fixes two issues in the Promotion Eligibility endpoint (`POST /api/promotion-eligibility`), found while manually E2E-testing:

1. **Catastrophic slowness (20-60+ seconds per load).** `getPromotionEligibilityData` ran a per-user loop (`users.map(async user => ...)` + `Promise.all`) issuing 3 DB round trips per user: a review-count query, a weekly-hours aggregate, and a `findOneAndUpdate` upsert against ~1,655 seeded users. Classic N+1: hundreds of concurrent aggregation pipelines and upserts queued against a single Mongo instance.
2. **"New Member" threshold didn't match spec.** The doc specifies New Members as "joined ≤ 1 week ago," but the code computed `isNewMember` as `< 6 months` old, which is about 24x more permissive than intended, so the New/Existing Member dropdown was showing the wrong members in each group.

<img width="756" height="691" alt="Screenshot 2026-09-12 at 1 21 47 PM" src="https://github.com/user-attachments/assets/2f84d1a0-4bf7-4a11-a919-3e43aee67623" />
<img width="778" height="694" alt="Screenshot 2026-09-12 at 1 21 59 PM" src="https://github.com/user-attachments/assets/40f7cfe7-7a12-4ecc-b42c-ae67ca0443b9" />
<img width="759" height="368" alt="Screenshot 2026-09-12 at 1 22 12 PM" src="https://github.com/user-attachments/assets/0cf64ec0-202a-47c0-ac5e-c0b455676a32" />


## Related PRS (if any):
This backend PR is related to frontend PR [#5546](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/5546).

## Main changes explained:
- Update `src/controllers/promotionEligibilityController.js` for replacing the per-user N+1 loop with two batched aggregations run once across all users: `getWeeklyHoursByUser` (grouped by `personId` + week) and `getReviewCountsByUser` (grouped by `resources.userID`, deduped to match the original `countDocuments` semantics exactly).
- Update `src/controllers/promotionEligibilityController.js` for replacing N individual `PromotionEligibility.findOneAndUpdate` calls with a single `bulkWrite`, fired without blocking the response (the response body is already fully computed in memory before the write starts).
- Update `src/controllers/promotionEligibilityController.js` for correcting the `isNewMember` threshold from `< 6 months` to `daysSinceCreated <= 7` (1 week), matching the doc spec.

## How to test:
1. Check out the current branch
2. Run `npm install` and `npm run dev` to run this PR locally
4. Clear site data/cache
5. Log in as an admin user (Dev Admin account)
6. Go to PR Dashboard → Promotion Eligibility (`/pr-dashboard/promotion-eligibility`)
7. Open DevTools → Network tab, reload, confirm `POST /api/promotion-eligibility` completes in ~1-2s (not 20-60s) and the table populates correctly
8. Toggle the New Member / Existing Member dropdown; only accounts created in the last 7 days should appear under "New Member"

## Screenshots or videos of changes:
<img width="1470" height="880" alt="Screenshot 2026-09-12 at 1 12 23 PM" src="https://github.com/user-attachments/assets/6582c22c-036a-4f27-8c33-d1bb5409b908" />
<img width="1470" height="881" alt="Screenshot 2026-09-12 at 1 17 31 PM" src="https://github.com/user-attachments/assets/2ad16cdf-701a-43e1-9d52-49b1a076740e" />

## Note: