### PR TITLE
Ruthwik fix the share availability bug for events

### DIFF
--- a/src/startup/routes.js
+++ b/src/startup/routes.js
@@ -452,6 +452,7 @@ const educatorRoutes = require('../routes/educatorRoutes');
 // Class Aggregation Reports
 const classAggregationRouter = require('../routes/classAgreegraterRouter');
 const activityLogRouter = require('../routes/activityLogRouter')();
+const eventRouter = require('../routes/eventRouter');
 
 const educationTaskRouter = require('../routes/educationTaskRouter')();
 
@@ -643,6 +644,7 @@ module.exports = function (app) {
   app.use('/api/communityportal/reports/participation', cpNoShowRouter);
   app.use('/api/communityportal/activities/', cpEventFeedbackRouter);
   app.use('/api/communityportal', NoShowFollowUpRouter);
+  app.use('/api', eventRouter);
 
   // lb dashboard
   app.use('/api/lbdashboard', lbRegisterRouter);


### PR DESCRIPTION
# Description
This fixes the errors in loading events for the frontend PR [#4730](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4730). 

## Related PRS (if any):
This backend PR is related to the frontend PR [#4730](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4730). Test this together with that.
…

## Main changes explained:
Wires in the events router properly to ensure the endpoint is accesible
…

## How to test:
1. check into current branch
2. do `npm install` and `...` to run this PR locally
3. Clear site data/cache
4. use this as the backend for frontend PR [#4730](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4730)
5. Test all the functionality fixed in the frontend PR [#4730](https://github.com/OneCommunityGlobal/HighestGoodNetworkApp/pull/4730)


## Screenshots or videos of changes:

https://github.com/user-attachments/assets/801c2ffd-a502-4e97-baac-8c9da1bd1681


